### PR TITLE
systemtap: Add -lpthread option in LDFLAGS.

### DIFF
--- a/recipes/systemtap/systemtap_git.bbappend
+++ b/recipes/systemtap/systemtap_git.bbappend
@@ -5,3 +5,5 @@ SRC_URI += " file://include_linux_binfmts_h.patch"
 FILESPATH = "${@base_set_filespath([ "${FILE_DIRNAME}/${PF}", "${FILE_DIRNAME}/${P}", "${FILE_DIRNAME}/${PN}", "${FILE_DIRNAME}/${BP}", "${FILE_DIRNAME}/${BPN}", "${FILE_DIRNAME}/files", "${FILE_DIRNAME}" ], d)}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/systemtap:"
+
+LDFLAGS += "-lpthread"


### PR DESCRIPTION
- CodeSourcery toolchain 2013.05-27 gives an error about
  pthread_cacel symbol. Toolchain was not able to load
  libpthread.so automatically so we have to link it manually.
- CB-2122

Signed-off-by: Noor Ahsan noor_ahsan@mentor.com

Backported from master branch.
Original commit is 296b92963f40fdd17b904f5ff3f6f780054ccd8f

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
