### PR TITLE
local.conf.in: Document shorter KVERSION

### DIFF
--- a/conf/local.conf.in
+++ b/conf/local.conf.in
@@ -242,6 +242,6 @@ CONF_VERSION = "1"
 
 # To build The linux-imx kernel from a different github repository,
 # uncomment the appropriate lines below and adjust as needed.
-#KVERSION="3.5.7.12"
+#KVERSION="3.5"
 #SRC_URI_pn-linux-imx = "git://github.com/MentorEmbedded/linux-meibp.git;branch=staging-35;protocol=ssh;user=git"
 #SRCREV_pn-linux-imx = "${AUTOREV}"


### PR DESCRIPTION
This is no longer needed to synchronize the kernel header versions.
It is currently only used in the package naming so use just the
major and minor kernel version numbers to avoid having to constantly
update it.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
