### PR TITLE
libmusicbrainz: Add -lpthread option in LDFLAGS.

### DIFF
--- a/recipes/musicbrainz/libmusicbrainz_3.0.3.bbappend
+++ b/recipes/musicbrainz/libmusicbrainz_3.0.3.bbappend
@@ -1,0 +1,3 @@
+PRINC := "${@int(PRINC) + 1}"
+
+LDFLAGS += "-lpthread"


### PR DESCRIPTION
- CodeSourcery toolchain 2013.05-29 gives errors about
  pthread symbols. The toolchain is not able to load
  libpthread.so automatically so we have to link it manually.

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
