### PR TITLE
separate debug symbols support

### DIFF
--- a/conf/distro/include/gdbserver-gplv3.inc
+++ b/conf/distro/include/gdbserver-gplv3.inc
@@ -3,7 +3,7 @@
 # but don't allow it to be installed into an image in that case unless the
 # user explicitly allows it via ALLOW_GPLV3_GDBSERVER.
 
-ALLOW_GPLV3_GDBSERVER ?= ""
+ALLOW_GPLV3_DEBUG_TOOLS ?= ""
 INCOMPATIBLE_LICENSE_pn-external-sourcery-toolchain = ""
 ROOTFS_POSTPROCESS_COMMAND_append = "check_for_gdbserver;"
 
@@ -13,21 +13,24 @@ python adjust_packagegroup_gdbserver () {
     d = e.data
 
     if 'GPLv3' in (d.getVar('INCOMPATIBLE_LICENSE', True) or ''):
-        if not d.getVar('ALLOW_GPLV3_GDBSERVER', True):
+        if not d.getVar('ALLOW_GPLV3_DEBUG_TOOLS', True):
             # Remove installation of gdbserver from codebench-debug
             pkggroup = d.getVar('PACKAGE_GROUP_codebench-debug', True).split()
             if 'gdbserver' in pkggroup:
                 pkggroup.remove('gdbserver')
                 d.setVar('PACKAGE_GROUP_codebench-debug', ' '.join(pkggroup))
+        else:
+            # Also allow installation of gdb
+            d.setVar('INCOMPATIBLE_LICENSE_pn-gdb', '')
 }
 addhandler adjust_packagegroup_gdbserver
 
 check_for_gdbserver () {
     if echo '${INCOMPATIBLE_LICENSE}' | grep -q 'GPLv3' && \
-       [ -z "${ALLOW_GPLV3_GDBSERVER}" ]; then
+       [ -z "${ALLOW_GPLV3_DEBUG_TOOLS}" ]; then
         gdb_gplv3="$(sed -n '/^PACKAGE NAME: gdbserver$/{ n; n; n; /LICENSE: GPLv3/p }')"
         if [ -n "$gdb_gplv3" ]; then
-            bbfatal "Detected GPLv3 gdbserver package in license manifest, aborting. To allow this to be included, define ALLOW_GPLv3_GDBSERVER=1"
+            bbfatal "Detected GPLv3 gdbserver package in license manifest, aborting. To allow this to be included, define ALLOW_GPLv3_DEBUG_TOOLS=1"
         fi
     fi
 }

--- a/conf/local.conf.in
+++ b/conf/local.conf.in
@@ -26,7 +26,7 @@ MACHINE ??= "qemux86"
 # The CORE_IMAGE_EXTRA_INSTALL variable allows extra individual packages to be
 # added to any of the "core" images (e.g. core-image-base,
 # core-image-minimal).
-#CORE_IMAGE_EXTRA_INSTALL = "nano psplash"
+#CORE_IMAGE_EXTRA_INSTALL = "nano psplash gdb"
 
 # The EXTRA_IMAGE_FEATURES variable allows groups of packages to be added to
 # the generated images. Some of these options are added to certain image types
@@ -71,7 +71,10 @@ EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-openssh codebench-debug tools-lt
 # Uncomment this to enable inclusion of gdbserver in the codebench-debug
 # packagegroup / image feature even when GPLv3 is in INCOMPATIBLE_LICENSE, or
 # using a distro which sets it that way (atp).
-#ALLOW_GPLV3_GDBSERVER = "1"
+#ALLOW_GPLV3_DEBUG_TOOLS = "1"
+
+# Uncomment this to enable separate archive containing debug symbols and tools
+#SEPARATE_ARCHIVE_DEBUG = "1"
 
 # User features lets you manipulate the distro features. To add a distro
 # feature, simply add it to USER_FEATURES. To remove, prefix it with ~.


### PR DESCRIPTION
Final part of debug-file-directory style support and separate debug symbols archive.
- Rename ALLOW_GPLV3_GDBSERVER to ALLOW_GPLV3_DEBUG_TOOLS;
- Clean INCOMPATIBLE_LICENSE for gdb if ALLOW_GPLV3_DEBUG_TOOLS enabled;
- Add SEPARATE_ARCHIVE_DEBUG to local.conf template.
