### PR TITLE
Kergoth bb det layers

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 
 glob_default = './*/:./*/*/:{scriptdir}/../../*/:{scriptdir}/../../*/*/'
-layers_default = 'sourcery mentor toolchain-layer openembedded-layer core yocto networking'
+layers_default = 'core yocto mentor'
 priority_overrides = {
     'openembedded-layer': 1,
 }

--- a/scripts/setup-builddir
+++ b/scripts/setup-builddir
@@ -157,7 +157,7 @@ sed -i -n '/^BBLAYERS/{ :start; /\\$/{n; b start}; d; }; p' $BUILDDIR/conf/bblay
 
 echo 'BBLAYERS = "\' >> $BUILDDIR/conf/bblayers.conf
 layersfile=$(mktemp setup-builddir.XXXXXX)
-$(dirname $0)/bb-determine-layers -g "*:*/*:$MELDIR/*:$MELDIR/*/*" -o "$OPTIONALLAYERS" $MACHINE >$layersfile
+$(dirname $0)/bb-determine-layers -g "*:*/*:$MELDIR/*:$MELDIR/*/*" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" $MACHINE >$layersfile
 if [ $? -ne 0 ]; then
     rm -f $layersfile
     echo >&2 "Error in execution of bb-determine-layers, aborting"

--- a/setup-environment
+++ b/setup-environment
@@ -194,10 +194,11 @@ else
     fi
     layerdir=$(mel_abspath $layerdir)
     export OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
+    export EXTRAMELLAYERS="${EXTRAMELLAYERS:-openembedded-layer networking toolchain-layer sourcery}"
     mel_setup "$@"
     sed -i -e "s/^DISTRO.*/DISTRO = 'mel'/" conf/local.conf
 
-    unset OPTIONALLAYERS
+    unset OPTIONALLAYERS EXTRAMELLAYERS
     unset MACHINE BUILDDIR MELDIR force_overwrite layerdir
     unset -f mel_setup mel_usage mel_prompt_machine mel_list_all_machines mel_abspath
     unset -f run_builddir


### PR DESCRIPTION
Pull in changes from ATP 2013.10 by kergoth.

<kergoth> fyi, altered the setup scripts so the layer requirements match the readme. now meta-mentor can be used with just oe-core and meta-yocto, but all our stuff will be pulled in if available, which of course it is for mel
<kergoth> that way any open source folk cloning the layer don't need to go grab meta-networking and crap
<kergoth> this was jsut a small step in the right direction, correcting behavior for upstream, and also fixing bugs in layer dependenecy handling
<kergoth> previously, having an optional layer with deps would result in not including that layer if its deps weren't already configured/included, rather than including them if they're available
