### PR TITLE
busybox: Allow empty busybox-hwclock and busybox-httpd

### DIFF
--- a/recipes/busybox/busybox_1.21.1.bbappend
+++ b/recipes/busybox/busybox_1.21.1.bbappend
@@ -1,2 +1,5 @@
-PR .= ".1"
+PR .= ".2"
 FILESEXTRAPATHS_prepend := "${THISDIR}/busybox:"
+
+ALLOW_EMPTY_${PN}-hwclock = "1"
+ALLOW_EMPTY_${PN}-httpd = "1"


### PR DESCRIPTION
busybox-hwclock is empty when systemd.bbclass is inherited

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
