### PR TITLE
Add lttng 2.2.0 bbappend with ARM syscalls instrumentation patch

### DIFF
--- a/recipes/lttng-2.0/lttng-modules/0001-Update-ARM-32-bit-syscall-tracepoints-to-3.4.patch
+++ b/recipes/lttng-2.0/lttng-modules/0001-Update-ARM-32-bit-syscall-tracepoints-to-3.4.patch
@@ -1,0 +1,7725 @@
+From c974cc6e86378a838440feceac5c5e743dcaa1c6 Mon Sep 17 00:00:00 2001
+From: Jan Glauber <jan.glauber@gmail.com>
+Date: Fri, 10 May 2013 11:52:07 -0400
+Subject: [PATCH] Update ARM (32 bit) syscall tracepoints to 3.4
+
+Update from 2.6.38 to 3.4. Added syscalls:
+sys_acct
+sys_swapon
+sys_swapoff
+sys_quotactl
+sys_perf_event_open
+sys_fanotify_init
+sys_name_to_handle_at
+sys_open_by_handle_at
+sys_clock_adjtime
+sys_syncfs
+sys_sendmmsg
+sys_setns
+sys_process_vm_readv
+sys_process_vm_writev
+
+Signed-off-by: Jan Glauber <jan.glauber@gmail.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ .../syscalls/2.6.38/arm-32-syscalls-2.6.38         |  285 ---
+ .../syscalls/3.4.25/arm-32-syscalls-3.4.25         |  299 +++
+ .../headers/arm-32-syscalls-2.6.38_integers.h      | 1145 ----------
+ .../arm-32-syscalls-2.6.38_integers_override.h     |   52 -
+ .../headers/arm-32-syscalls-2.6.38_pointers.h      | 2184 ------------------
+ .../arm-32-syscalls-2.6.38_pointers_override.h     |   39 -
+ .../headers/arm-32-syscalls-3.4.25_integers.h      | 1181 ++++++++++
+ .../arm-32-syscalls-3.4.25_integers_override.h     |   52 +
+ .../headers/arm-32-syscalls-3.4.25_pointers.h      | 2316 ++++++++++++++++++++
+ .../arm-32-syscalls-3.4.25_pointers_override.h     |   39 +
+ .../syscalls/headers/syscalls_integers.h           |    2 +-
+ .../syscalls/headers/syscalls_pointers.h           |    2 +-
+ 12 files changed, 3889 insertions(+), 3707 deletions(-)
+ delete mode 100644 instrumentation/syscalls/2.6.38/arm-32-syscalls-2.6.38
+ create mode 100644 instrumentation/syscalls/3.4.25/arm-32-syscalls-3.4.25
+ delete mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers.h
+ delete mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers_override.h
+ delete mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers.h
+ delete mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers_override.h
+ create mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers.h
+ create mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers_override.h
+ create mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers.h
+ create mode 100644 instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers_override.h
+
+diff --git a/instrumentation/syscalls/2.6.38/arm-32-syscalls-2.6.38 b/instrumentation/syscalls/2.6.38/arm-32-syscalls-2.6.38
+deleted file mode 100644
+index 89194e2..0000000
+--- a/instrumentation/syscalls/2.6.38/arm-32-syscalls-2.6.38
++++ /dev/null
+@@ -1,285 +0,0 @@
+-syscall sys_restart_syscall nr 0 nbargs 0 types: () args: ()
+-syscall sys_exit nr 1 nbargs 1 types: (int) args: (error_code)
+-syscall sys_read nr 3 nbargs 3 types: (unsigned int, char *, size_t) args: (fd, buf, count)
+-syscall sys_write nr 4 nbargs 3 types: (unsigned int, const char *, size_t) args: (fd, buf, count)
+-syscall sys_open nr 5 nbargs 3 types: (const char *, int, int) args: (filename, flags, mode)
+-syscall sys_close nr 6 nbargs 1 types: (unsigned int) args: (fd)
+-syscall sys_creat nr 8 nbargs 2 types: (const char *, int) args: (pathname, mode)
+-syscall sys_link nr 9 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
+-syscall sys_unlink nr 10 nbargs 1 types: (const char *) args: (pathname)
+-syscall sys_chdir nr 12 nbargs 1 types: (const char *) args: (filename)
+-syscall sys_mknod nr 14 nbargs 3 types: (const char *, int, unsigned) args: (filename, mode, dev)
+-syscall sys_chmod nr 15 nbargs 2 types: (const char *, mode_t) args: (filename, mode)
+-syscall sys_lchown16 nr 16 nbargs 3 types: (const char *, old_uid_t, old_gid_t) args: (filename, user, group)
+-syscall sys_lseek nr 19 nbargs 3 types: (unsigned int, off_t, unsigned int) args: (fd, offset, origin)
+-syscall sys_getpid nr 20 nbargs 0 types: () args: ()
+-syscall sys_mount nr 21 nbargs 5 types: (char *, char *, char *, unsigned long, void *) args: (dev_name, dir_name, type, flags, data)
+-syscall sys_setuid16 nr 23 nbargs 1 types: (old_uid_t) args: (uid)
+-syscall sys_getuid16 nr 24 nbargs 0 types: () args: ()
+-syscall sys_ptrace nr 26 nbargs 4 types: (long, long, unsigned long, unsigned long) args: (request, pid, addr, data)
+-syscall sys_pause nr 29 nbargs 0 types: () args: ()
+-syscall sys_access nr 33 nbargs 2 types: (const char *, int) args: (filename, mode)
+-syscall sys_nice nr 34 nbargs 1 types: (int) args: (increment)
+-syscall sys_sync nr 36 nbargs 0 types: () args: ()
+-syscall sys_kill nr 37 nbargs 2 types: (pid_t, int) args: (pid, sig)
+-syscall sys_rename nr 38 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
+-syscall sys_mkdir nr 39 nbargs 2 types: (const char *, int) args: (pathname, mode)
+-syscall sys_rmdir nr 40 nbargs 1 types: (const char *) args: (pathname)
+-syscall sys_dup nr 41 nbargs 1 types: (unsigned int) args: (fildes)
+-syscall sys_pipe nr 42 nbargs 1 types: (int *) args: (fildes)
+-syscall sys_times nr 43 nbargs 1 types: (struct tms *) args: (tbuf)
+-syscall sys_brk nr 45 nbargs 1 types: (unsigned long) args: (brk)
+-syscall sys_setgid16 nr 46 nbargs 1 types: (old_gid_t) args: (gid)
+-syscall sys_getgid16 nr 47 nbargs 0 types: () args: ()
+-syscall sys_geteuid16 nr 49 nbargs 0 types: () args: ()
+-syscall sys_getegid16 nr 50 nbargs 0 types: () args: ()
+-syscall sys_umount nr 52 nbargs 2 types: (char *, int) args: (name, flags)
+-syscall sys_ioctl nr 54 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
+-syscall sys_fcntl nr 55 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
+-syscall sys_setpgid nr 57 nbargs 2 types: (pid_t, pid_t) args: (pid, pgid)
+-syscall sys_umask nr 60 nbargs 1 types: (int) args: (mask)
+-syscall sys_chroot nr 61 nbargs 1 types: (const char *) args: (filename)
+-syscall sys_ustat nr 62 nbargs 2 types: (unsigned, struct ustat *) args: (dev, ubuf)
+-syscall sys_dup2 nr 63 nbargs 2 types: (unsigned int, unsigned int) args: (oldfd, newfd)
+-syscall sys_getppid nr 64 nbargs 0 types: () args: ()
+-syscall sys_getpgrp nr 65 nbargs 0 types: () args: ()
+-syscall sys_setsid nr 66 nbargs 0 types: () args: ()
+-syscall sys_setreuid16 nr 70 nbargs 2 types: (old_uid_t, old_uid_t) args: (ruid, euid)
+-syscall sys_setregid16 nr 71 nbargs 2 types: (old_gid_t, old_gid_t) args: (rgid, egid)
+-syscall sys_sigpending nr 73 nbargs 1 types: (old_sigset_t *) args: (set)
+-syscall sys_sethostname nr 74 nbargs 2 types: (char *, int) args: (name, len)
+-syscall sys_setrlimit nr 75 nbargs 2 types: (unsigned int, struct rlimit *) args: (resource, rlim)
+-syscall sys_getrusage nr 77 nbargs 2 types: (int, struct rusage *) args: (who, ru)
+-syscall sys_gettimeofday nr 78 nbargs 2 types: (struct timeval *, struct timezone *) args: (tv, tz)
+-syscall sys_settimeofday nr 79 nbargs 2 types: (struct timeval *, struct timezone *) args: (tv, tz)
+-syscall sys_getgroups16 nr 80 nbargs 2 types: (int, old_gid_t *) args: (gidsetsize, grouplist)
+-syscall sys_setgroups16 nr 81 nbargs 2 types: (int, old_gid_t *) args: (gidsetsize, grouplist)
+-syscall sys_symlink nr 83 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
+-syscall sys_readlink nr 85 nbargs 3 types: (const char *, char *, int) args: (path, buf, bufsiz)
+-syscall sys_uselib nr 86 nbargs 1 types: (const char *) args: (library)
+-syscall sys_reboot nr 88 nbargs 4 types: (int, int, unsigned int, void *) args: (magic1, magic2, cmd, arg)
+-syscall sys_munmap nr 91 nbargs 2 types: (unsigned long, size_t) args: (addr, len)
+-syscall sys_truncate nr 92 nbargs 2 types: (const char *, long) args: (path, length)
+-syscall sys_ftruncate nr 93 nbargs 2 types: (unsigned int, unsigned long) args: (fd, length)
+-syscall sys_fchmod nr 94 nbargs 2 types: (unsigned int, mode_t) args: (fd, mode)
+-syscall sys_fchown16 nr 95 nbargs 3 types: (unsigned int, old_uid_t, old_gid_t) args: (fd, user, group)
+-syscall sys_getpriority nr 96 nbargs 2 types: (int, int) args: (which, who)
+-syscall sys_setpriority nr 97 nbargs 3 types: (int, int, int) args: (which, who, niceval)
+-syscall sys_statfs nr 99 nbargs 2 types: (const char *, struct statfs *) args: (pathname, buf)
+-syscall sys_fstatfs nr 100 nbargs 2 types: (unsigned int, struct statfs *) args: (fd, buf)
+-syscall sys_syslog nr 103 nbargs 3 types: (int, char *, int) args: (type, buf, len)
+-syscall sys_setitimer nr 104 nbargs 3 types: (int, struct itimerval *, struct itimerval *) args: (which, value, ovalue)
+-syscall sys_getitimer nr 105 nbargs 2 types: (int, struct itimerval *) args: (which, value)
+-syscall sys_newstat nr 106 nbargs 2 types: (const char *, struct stat *) args: (filename, statbuf)
+-syscall sys_newlstat nr 107 nbargs 2 types: (const char *, struct stat *) args: (filename, statbuf)
+-syscall sys_newfstat nr 108 nbargs 2 types: (unsigned int, struct stat *) args: (fd, statbuf)
+-syscall sys_vhangup nr 111 nbargs 0 types: () args: ()
+-syscall sys_wait4 nr 114 nbargs 4 types: (pid_t, int *, int, struct rusage *) args: (upid, stat_addr, options, ru)
+-syscall sys_sysinfo nr 116 nbargs 1 types: (struct sysinfo *) args: (info)
+-syscall sys_fsync nr 118 nbargs 1 types: (unsigned int) args: (fd)
+-syscall sys_setdomainname nr 121 nbargs 2 types: (char *, int) args: (name, len)
+-syscall sys_newuname nr 122 nbargs 1 types: (struct new_utsname *) args: (name)
+-syscall sys_adjtimex nr 124 nbargs 1 types: (struct timex *) args: (txc_p)
+-syscall sys_mprotect nr 125 nbargs 3 types: (unsigned long, size_t, unsigned long) args: (start, len, prot)
+-syscall sys_sigprocmask nr 126 nbargs 3 types: (int, old_sigset_t *, old_sigset_t *) args: (how, set, oset)
+-syscall sys_init_module nr 128 nbargs 3 types: (void *, unsigned long, const char *) args: (umod, len, uargs)
+-syscall sys_delete_module nr 129 nbargs 2 types: (const char *, unsigned int) args: (name_user, flags)
+-syscall sys_getpgid nr 132 nbargs 1 types: (pid_t) args: (pid)
+-syscall sys_fchdir nr 133 nbargs 1 types: (unsigned int) args: (fd)
+-syscall sys_bdflush nr 134 nbargs 2 types: (int, long) args: (func, data)
+-syscall sys_sysfs nr 135 nbargs 3 types: (int, unsigned long, unsigned long) args: (option, arg1, arg2)
+-syscall sys_personality nr 136 nbargs 1 types: (unsigned int) args: (personality)
+-syscall sys_setfsuid16 nr 138 nbargs 1 types: (old_uid_t) args: (uid)
+-syscall sys_setfsgid16 nr 139 nbargs 1 types: (old_gid_t) args: (gid)
+-syscall sys_llseek nr 140 nbargs 5 types: (unsigned int, unsigned long, unsigned long, loff_t *, unsigned int) args: (fd, offset_high, offset_low, result, origin)
+-syscall sys_getdents nr 141 nbargs 3 types: (unsigned int, struct linux_dirent *, unsigned int) args: (fd, dirent, count)
+-syscall sys_select nr 142 nbargs 5 types: (int, fd_set *, fd_set *, fd_set *, struct timeval *) args: (n, inp, outp, exp, tvp)
+-syscall sys_flock nr 143 nbargs 2 types: (unsigned int, unsigned int) args: (fd, cmd)
+-syscall sys_msync nr 144 nbargs 3 types: (unsigned long, size_t, int) args: (start, len, flags)
+-syscall sys_readv nr 145 nbargs 3 types: (unsigned long, const struct iovec *, unsigned long) args: (fd, vec, vlen)
+-syscall sys_writev nr 146 nbargs 3 types: (unsigned long, const struct iovec *, unsigned long) args: (fd, vec, vlen)
+-syscall sys_getsid nr 147 nbargs 1 types: (pid_t) args: (pid)
+-syscall sys_fdatasync nr 148 nbargs 1 types: (unsigned int) args: (fd)
+-syscall sys_sysctl nr 149 nbargs 1 types: (struct __sysctl_args *) args: (args)
+-syscall sys_mlock nr 150 nbargs 2 types: (unsigned long, size_t) args: (start, len)
+-syscall sys_munlock nr 151 nbargs 2 types: (unsigned long, size_t) args: (start, len)
+-syscall sys_mlockall nr 152 nbargs 1 types: (int) args: (flags)
+-syscall sys_munlockall nr 153 nbargs 0 types: () args: ()
+-syscall sys_sched_setparam nr 154 nbargs 2 types: (pid_t, struct sched_param *) args: (pid, param)
+-syscall sys_sched_getparam nr 155 nbargs 2 types: (pid_t, struct sched_param *) args: (pid, param)
+-syscall sys_sched_setscheduler nr 156 nbargs 3 types: (pid_t, int, struct sched_param *) args: (pid, policy, param)
+-syscall sys_sched_getscheduler nr 157 nbargs 1 types: (pid_t) args: (pid)
+-syscall sys_sched_yield nr 158 nbargs 0 types: () args: ()
+-syscall sys_sched_get_priority_max nr 159 nbargs 1 types: (int) args: (policy)
+-syscall sys_sched_get_priority_min nr 160 nbargs 1 types: (int) args: (policy)
+-syscall sys_sched_rr_get_interval nr 161 nbargs 2 types: (pid_t, struct timespec *) args: (pid, interval)
+-syscall sys_nanosleep nr 162 nbargs 2 types: (struct timespec *, struct timespec *) args: (rqtp, rmtp)
+-syscall sys_mremap nr 163 nbargs 5 types: (unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) args: (addr, old_len, new_len, flags, new_addr)
+-syscall sys_setresuid16 nr 164 nbargs 3 types: (old_uid_t, old_uid_t, old_uid_t) args: (ruid, euid, suid)
+-syscall sys_getresuid16 nr 165 nbargs 3 types: (old_uid_t *, old_uid_t *, old_uid_t *) args: (ruid, euid, suid)
+-syscall sys_poll nr 168 nbargs 3 types: (struct pollfd *, unsigned int, long) args: (ufds, nfds, timeout_msecs)
+-syscall sys_setresgid16 nr 170 nbargs 3 types: (old_gid_t, old_gid_t, old_gid_t) args: (rgid, egid, sgid)
+-syscall sys_getresgid16 nr 171 nbargs 3 types: (old_gid_t *, old_gid_t *, old_gid_t *) args: (rgid, egid, sgid)
+-syscall sys_prctl nr 172 nbargs 5 types: (int, unsigned long, unsigned long, unsigned long, unsigned long) args: (option, arg2, arg3, arg4, arg5)
+-syscall sys_rt_sigaction nr 174 nbargs 4 types: (int, const struct sigaction *, struct sigaction *, size_t) args: (sig, act, oact, sigsetsize)
+-syscall sys_rt_sigprocmask nr 175 nbargs 4 types: (int, sigset_t *, sigset_t *, size_t) args: (how, set, oset, sigsetsize)
+-syscall sys_rt_sigpending nr 176 nbargs 2 types: (sigset_t *, size_t) args: (set, sigsetsize)
+-syscall sys_rt_sigtimedwait nr 177 nbargs 4 types: (const sigset_t *, siginfo_t *, const struct timespec *, size_t) args: (uthese, uinfo, uts, sigsetsize)
+-syscall sys_rt_sigqueueinfo nr 178 nbargs 3 types: (pid_t, int, siginfo_t *) args: (pid, sig, uinfo)
+-syscall sys_rt_sigsuspend nr 179 nbargs 2 types: (sigset_t *, size_t) args: (unewset, sigsetsize)
+-syscall sys_chown16 nr 182 nbargs 3 types: (const char *, old_uid_t, old_gid_t) args: (filename, user, group)
+-syscall sys_getcwd nr 183 nbargs 2 types: (char *, unsigned long) args: (buf, size)
+-syscall sys_capget nr 184 nbargs 2 types: (cap_user_header_t, cap_user_data_t) args: (header, dataptr)
+-syscall sys_capset nr 185 nbargs 2 types: (cap_user_header_t, const cap_user_data_t) args: (header, data)
+-syscall sys_sendfile nr 187 nbargs 4 types: (int, int, off_t *, size_t) args: (out_fd, in_fd, offset, count)
+-syscall sys_getrlimit nr 191 nbargs 2 types: (unsigned int, struct rlimit *) args: (resource, rlim)
+-syscall sys_stat64 nr 195 nbargs 2 types: (const char *, struct stat64 *) args: (filename, statbuf)
+-syscall sys_lstat64 nr 196 nbargs 2 types: (const char *, struct stat64 *) args: (filename, statbuf)
+-syscall sys_fstat64 nr 197 nbargs 2 types: (unsigned long, struct stat64 *) args: (fd, statbuf)
+-syscall sys_lchown nr 198 nbargs 3 types: (const char *, uid_t, gid_t) args: (filename, user, group)
+-syscall sys_getuid nr 199 nbargs 0 types: () args: ()
+-syscall sys_getgid nr 200 nbargs 0 types: () args: ()
+-syscall sys_geteuid nr 201 nbargs 0 types: () args: ()
+-syscall sys_getegid nr 202 nbargs 0 types: () args: ()
+-syscall sys_setreuid nr 203 nbargs 2 types: (uid_t, uid_t) args: (ruid, euid)
+-syscall sys_setregid nr 204 nbargs 2 types: (gid_t, gid_t) args: (rgid, egid)
+-syscall sys_getgroups nr 205 nbargs 2 types: (int, gid_t *) args: (gidsetsize, grouplist)
+-syscall sys_setgroups nr 206 nbargs 2 types: (int, gid_t *) args: (gidsetsize, grouplist)
+-syscall sys_fchown nr 207 nbargs 3 types: (unsigned int, uid_t, gid_t) args: (fd, user, group)
+-syscall sys_setresuid nr 208 nbargs 3 types: (uid_t, uid_t, uid_t) args: (ruid, euid, suid)
+-syscall sys_getresuid nr 209 nbargs 3 types: (uid_t *, uid_t *, uid_t *) args: (ruid, euid, suid)
+-syscall sys_setresgid nr 210 nbargs 3 types: (gid_t, gid_t, gid_t) args: (rgid, egid, sgid)
+-syscall sys_getresgid nr 211 nbargs 3 types: (gid_t *, gid_t *, gid_t *) args: (rgid, egid, sgid)
+-syscall sys_chown nr 212 nbargs 3 types: (const char *, uid_t, gid_t) args: (filename, user, group)
+-syscall sys_setuid nr 213 nbargs 1 types: (uid_t) args: (uid)
+-syscall sys_setgid nr 214 nbargs 1 types: (gid_t) args: (gid)
+-syscall sys_setfsuid nr 215 nbargs 1 types: (uid_t) args: (uid)
+-syscall sys_setfsgid nr 216 nbargs 1 types: (gid_t) args: (gid)
+-syscall sys_getdents64 nr 217 nbargs 3 types: (unsigned int, struct linux_dirent64 *, unsigned int) args: (fd, dirent, count)
+-syscall sys_pivot_root nr 218 nbargs 2 types: (const char *, const char *) args: (new_root, put_old)
+-syscall sys_mincore nr 219 nbargs 3 types: (unsigned long, size_t, unsigned char *) args: (start, len, vec)
+-syscall sys_madvise nr 220 nbargs 3 types: (unsigned long, size_t, int) args: (start, len_in, behavior)
+-syscall sys_fcntl64 nr 221 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
+-syscall sys_gettid nr 224 nbargs 0 types: () args: ()
+-syscall sys_setxattr nr 226 nbargs 5 types: (const char *, const char *, const void *, size_t, int) args: (pathname, name, value, size, flags)
+-syscall sys_lsetxattr nr 227 nbargs 5 types: (const char *, const char *, const void *, size_t, int) args: (pathname, name, value, size, flags)
+-syscall sys_fsetxattr nr 228 nbargs 5 types: (int, const char *, const void *, size_t, int) args: (fd, name, value, size, flags)
+-syscall sys_getxattr nr 229 nbargs 4 types: (const char *, const char *, void *, size_t) args: (pathname, name, value, size)
+-syscall sys_lgetxattr nr 230 nbargs 4 types: (const char *, const char *, void *, size_t) args: (pathname, name, value, size)
+-syscall sys_fgetxattr nr 231 nbargs 4 types: (int, const char *, void *, size_t) args: (fd, name, value, size)
+-syscall sys_listxattr nr 232 nbargs 3 types: (const char *, char *, size_t) args: (pathname, list, size)
+-syscall sys_llistxattr nr 233 nbargs 3 types: (const char *, char *, size_t) args: (pathname, list, size)
+-syscall sys_flistxattr nr 234 nbargs 3 types: (int, char *, size_t) args: (fd, list, size)
+-syscall sys_removexattr nr 235 nbargs 2 types: (const char *, const char *) args: (pathname, name)
+-syscall sys_lremovexattr nr 236 nbargs 2 types: (const char *, const char *) args: (pathname, name)
+-syscall sys_fremovexattr nr 237 nbargs 2 types: (int, const char *) args: (fd, name)
+-syscall sys_tkill nr 238 nbargs 2 types: (pid_t, int) args: (pid, sig)
+-syscall sys_sendfile64 nr 239 nbargs 4 types: (int, int, loff_t *, size_t) args: (out_fd, in_fd, offset, count)
+-syscall sys_futex nr 240 nbargs 6 types: (u32 *, int, u32, struct timespec *, u32 *, u32) args: (uaddr, op, val, utime, uaddr2, val3)
+-syscall sys_sched_setaffinity nr 241 nbargs 3 types: (pid_t, unsigned int, unsigned long *) args: (pid, len, user_mask_ptr)
+-syscall sys_sched_getaffinity nr 242 nbargs 3 types: (pid_t, unsigned int, unsigned long *) args: (pid, len, user_mask_ptr)
+-syscall sys_io_setup nr 243 nbargs 2 types: (unsigned, aio_context_t *) args: (nr_events, ctxp)
+-syscall sys_io_destroy nr 244 nbargs 1 types: (aio_context_t) args: (ctx)
+-syscall sys_io_getevents nr 245 nbargs 5 types: (aio_context_t, long, long, struct io_event *, struct timespec *) args: (ctx_id, min_nr, nr, events, timeout)
+-syscall sys_io_submit nr 246 nbargs 3 types: (aio_context_t, long, struct iocb * *) args: (ctx_id, nr, iocbpp)
+-syscall sys_io_cancel nr 247 nbargs 3 types: (aio_context_t, struct iocb *, struct io_event *) args: (ctx_id, iocb, result)
+-syscall sys_exit_group nr 248 nbargs 1 types: (int) args: (error_code)
+-syscall sys_epoll_create nr 250 nbargs 1 types: (int) args: (size)
+-syscall sys_epoll_ctl nr 251 nbargs 4 types: (int, int, int, struct epoll_event *) args: (epfd, op, fd, event)
+-syscall sys_epoll_wait nr 252 nbargs 4 types: (int, struct epoll_event *, int, int) args: (epfd, events, maxevents, timeout)
+-syscall sys_remap_file_pages nr 253 nbargs 5 types: (unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) args: (start, size, prot, pgoff, flags)
+-syscall sys_set_tid_address nr 256 nbargs 1 types: (int *) args: (tidptr)
+-syscall sys_timer_create nr 257 nbargs 3 types: (const clockid_t, struct sigevent *, timer_t *) args: (which_clock, timer_event_spec, created_timer_id)
+-syscall sys_timer_settime nr 258 nbargs 4 types: (timer_t, int, const struct itimerspec *, struct itimerspec *) args: (timer_id, flags, new_setting, old_setting)
+-syscall sys_timer_gettime nr 259 nbargs 2 types: (timer_t, struct itimerspec *) args: (timer_id, setting)
+-syscall sys_timer_getoverrun nr 260 nbargs 1 types: (timer_t) args: (timer_id)
+-syscall sys_timer_delete nr 261 nbargs 1 types: (timer_t) args: (timer_id)
+-syscall sys_clock_settime nr 262 nbargs 2 types: (const clockid_t, const struct timespec *) args: (which_clock, tp)
+-syscall sys_clock_gettime nr 263 nbargs 2 types: (const clockid_t, struct timespec *) args: (which_clock, tp)
+-syscall sys_clock_getres nr 264 nbargs 2 types: (const clockid_t, struct timespec *) args: (which_clock, tp)
+-syscall sys_clock_nanosleep nr 265 nbargs 4 types: (const clockid_t, int, const struct timespec *, struct timespec *) args: (which_clock, flags, rqtp, rmtp)
+-syscall sys_tgkill nr 268 nbargs 3 types: (pid_t, pid_t, int) args: (tgid, pid, sig)
+-syscall sys_utimes nr 269 nbargs 2 types: (char *, struct timeval *) args: (filename, utimes)
+-syscall sys_mq_open nr 274 nbargs 4 types: (const char *, int, mode_t, struct mq_attr *) args: (u_name, oflag, mode, u_attr)
+-syscall sys_mq_unlink nr 275 nbargs 1 types: (const char *) args: (u_name)
+-syscall sys_mq_timedsend nr 276 nbargs 5 types: (mqd_t, const char *, size_t, unsigned int, const struct timespec *) args: (mqdes, u_msg_ptr, msg_len, msg_prio, u_abs_timeout)
+-syscall sys_mq_timedreceive nr 277 nbargs 5 types: (mqd_t, char *, size_t, unsigned int *, const struct timespec *) args: (mqdes, u_msg_ptr, msg_len, u_msg_prio, u_abs_timeout)
+-syscall sys_mq_notify nr 278 nbargs 2 types: (mqd_t, const struct sigevent *) args: (mqdes, u_notification)
+-syscall sys_mq_getsetattr nr 279 nbargs 3 types: (mqd_t, const struct mq_attr *, struct mq_attr *) args: (mqdes, u_mqstat, u_omqstat)
+-syscall sys_waitid nr 280 nbargs 5 types: (int, pid_t, struct siginfo *, int, struct rusage *) args: (which, upid, infop, options, ru)
+-syscall sys_socket nr 281 nbargs 3 types: (int, int, int) args: (family, type, protocol)
+-syscall sys_bind nr 282 nbargs 3 types: (int, struct sockaddr *, int) args: (fd, umyaddr, addrlen)
+-syscall sys_connect nr 283 nbargs 3 types: (int, struct sockaddr *, int) args: (fd, uservaddr, addrlen)
+-syscall sys_listen nr 284 nbargs 2 types: (int, int) args: (fd, backlog)
+-syscall sys_accept nr 285 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, upeer_sockaddr, upeer_addrlen)
+-syscall sys_getsockname nr 286 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, usockaddr, usockaddr_len)
+-syscall sys_getpeername nr 287 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, usockaddr, usockaddr_len)
+-syscall sys_socketpair nr 288 nbargs 4 types: (int, int, int, int *) args: (family, type, protocol, usockvec)
+-syscall sys_send nr 289 nbargs 4 types: (int, void *, size_t, unsigned) args: (fd, buff, len, flags)
+-syscall sys_sendto nr 290 nbargs 6 types: (int, void *, size_t, unsigned, struct sockaddr *, int) args: (fd, buff, len, flags, addr, addr_len)
+-syscall sys_recvfrom nr 292 nbargs 6 types: (int, void *, size_t, unsigned, struct sockaddr *, int *) args: (fd, ubuf, size, flags, addr, addr_len)
+-syscall sys_shutdown nr 293 nbargs 2 types: (int, int) args: (fd, how)
+-syscall sys_setsockopt nr 294 nbargs 5 types: (int, int, int, char *, int) args: (fd, level, optname, optval, optlen)
+-syscall sys_getsockopt nr 295 nbargs 5 types: (int, int, int, char *, int *) args: (fd, level, optname, optval, optlen)
+-syscall sys_sendmsg nr 296 nbargs 3 types: (int, struct msghdr *, unsigned) args: (fd, msg, flags)
+-syscall sys_recvmsg nr 297 nbargs 3 types: (int, struct msghdr *, unsigned int) args: (fd, msg, flags)
+-syscall sys_semop nr 298 nbargs 3 types: (int, struct sembuf *, unsigned) args: (semid, tsops, nsops)
+-syscall sys_semget nr 299 nbargs 3 types: (key_t, int, int) args: (key, nsems, semflg)
+-syscall sys_msgsnd nr 301 nbargs 4 types: (int, struct msgbuf *, size_t, int) args: (msqid, msgp, msgsz, msgflg)
+-syscall sys_msgrcv nr 302 nbargs 5 types: (int, struct msgbuf *, size_t, long, int) args: (msqid, msgp, msgsz, msgtyp, msgflg)
+-syscall sys_msgget nr 303 nbargs 2 types: (key_t, int) args: (key, msgflg)
+-syscall sys_msgctl nr 304 nbargs 3 types: (int, int, struct msqid_ds *) args: (msqid, cmd, buf)
+-syscall sys_shmat nr 305 nbargs 3 types: (int, char *, int) args: (shmid, shmaddr, shmflg)
+-syscall sys_shmdt nr 306 nbargs 1 types: (char *) args: (shmaddr)
+-syscall sys_shmget nr 307 nbargs 3 types: (key_t, size_t, int) args: (key, size, shmflg)
+-syscall sys_shmctl nr 308 nbargs 3 types: (int, int, struct shmid_ds *) args: (shmid, cmd, buf)
+-syscall sys_add_key nr 309 nbargs 5 types: (const char *, const char *, const void *, size_t, key_serial_t) args: (_type, _description, _payload, plen, ringid)
+-syscall sys_request_key nr 310 nbargs 4 types: (const char *, const char *, const char *, key_serial_t) args: (_type, _description, _callout_info, destringid)
+-syscall sys_keyctl nr 311 nbargs 5 types: (int, unsigned long, unsigned long, unsigned long, unsigned long) args: (option, arg2, arg3, arg4, arg5)
+-syscall sys_semtimedop nr 312 nbargs 4 types: (int, struct sembuf *, unsigned, const struct timespec *) args: (semid, tsops, nsops, timeout)
+-syscall sys_ioprio_set nr 314 nbargs 3 types: (int, int, int) args: (which, who, ioprio)
+-syscall sys_ioprio_get nr 315 nbargs 2 types: (int, int) args: (which, who)
+-syscall sys_inotify_init nr 316 nbargs 0 types: () args: ()
+-syscall sys_inotify_add_watch nr 317 nbargs 3 types: (int, const char *, u32) args: (fd, pathname, mask)
+-syscall sys_inotify_rm_watch nr 318 nbargs 2 types: (int, __s32) args: (fd, wd)
+-syscall sys_openat nr 322 nbargs 4 types: (int, const char *, int, int) args: (dfd, filename, flags, mode)
+-syscall sys_mkdirat nr 323 nbargs 3 types: (int, const char *, int) args: (dfd, pathname, mode)
+-syscall sys_mknodat nr 324 nbargs 4 types: (int, const char *, int, unsigned) args: (dfd, filename, mode, dev)
+-syscall sys_fchownat nr 325 nbargs 5 types: (int, const char *, uid_t, gid_t, int) args: (dfd, filename, user, group, flag)
+-syscall sys_futimesat nr 326 nbargs 3 types: (int, const char *, struct timeval *) args: (dfd, filename, utimes)
+-syscall sys_fstatat64 nr 327 nbargs 4 types: (int, const char *, struct stat64 *, int) args: (dfd, filename, statbuf, flag)
+-syscall sys_unlinkat nr 328 nbargs 3 types: (int, const char *, int) args: (dfd, pathname, flag)
+-syscall sys_renameat nr 329 nbargs 4 types: (int, const char *, int, const char *) args: (olddfd, oldname, newdfd, newname)
+-syscall sys_linkat nr 330 nbargs 5 types: (int, const char *, int, const char *, int) args: (olddfd, oldname, newdfd, newname, flags)
+-syscall sys_symlinkat nr 331 nbargs 3 types: (const char *, int, const char *) args: (oldname, newdfd, newname)
+-syscall sys_readlinkat nr 332 nbargs 4 types: (int, const char *, char *, int) args: (dfd, pathname, buf, bufsiz)
+-syscall sys_fchmodat nr 333 nbargs 3 types: (int, const char *, mode_t) args: (dfd, filename, mode)
+-syscall sys_faccessat nr 334 nbargs 3 types: (int, const char *, int) args: (dfd, filename, mode)
+-syscall sys_pselect6 nr 335 nbargs 6 types: (int, fd_set *, fd_set *, fd_set *, struct timespec *, void *) args: (n, inp, outp, exp, tsp, sig)
+-syscall sys_ppoll nr 336 nbargs 5 types: (struct pollfd *, unsigned int, struct timespec *, const sigset_t *, size_t) args: (ufds, nfds, tsp, sigmask, sigsetsize)
+-syscall sys_unshare nr 337 nbargs 1 types: (unsigned long) args: (unshare_flags)
+-syscall sys_set_robust_list nr 338 nbargs 2 types: (struct robust_list_head *, size_t) args: (head, len)
+-syscall sys_get_robust_list nr 339 nbargs 3 types: (int, struct robust_list_head * *, size_t *) args: (pid, head_ptr, len_ptr)
+-syscall sys_splice nr 340 nbargs 6 types: (int, loff_t *, int, loff_t *, size_t, unsigned int) args: (fd_in, off_in, fd_out, off_out, len, flags)
+-syscall sys_tee nr 342 nbargs 4 types: (int, int, size_t, unsigned int) args: (fdin, fdout, len, flags)
+-syscall sys_vmsplice nr 343 nbargs 4 types: (int, const struct iovec *, unsigned long, unsigned int) args: (fd, iov, nr_segs, flags)
+-syscall sys_getcpu nr 345 nbargs 3 types: (unsigned *, unsigned *, struct getcpu_cache *) args: (cpup, nodep, unused)
+-syscall sys_epoll_pwait nr 346 nbargs 6 types: (int, struct epoll_event *, int, int, const sigset_t *, size_t) args: (epfd, events, maxevents, timeout, sigmask, sigsetsize)
+-syscall sys_utimensat nr 348 nbargs 4 types: (int, const char *, struct timespec *, int) args: (dfd, filename, utimes, flags)
+-syscall sys_signalfd nr 349 nbargs 3 types: (int, sigset_t *, size_t) args: (ufd, user_mask, sizemask)
+-syscall sys_timerfd_create nr 350 nbargs 2 types: (int, int) args: (clockid, flags)
+-syscall sys_eventfd nr 351 nbargs 1 types: (unsigned int) args: (count)
+-syscall sys_timerfd_settime nr 353 nbargs 4 types: (int, int, const struct itimerspec *, struct itimerspec *) args: (ufd, flags, utmr, otmr)
+-syscall sys_timerfd_gettime nr 354 nbargs 2 types: (int, struct itimerspec *) args: (ufd, otmr)
+-syscall sys_signalfd4 nr 355 nbargs 4 types: (int, sigset_t *, size_t, int) args: (ufd, user_mask, sizemask, flags)
+-syscall sys_eventfd2 nr 356 nbargs 2 types: (unsigned int, int) args: (count, flags)
+-syscall sys_epoll_create1 nr 357 nbargs 1 types: (int) args: (flags)
+-syscall sys_dup3 nr 358 nbargs 3 types: (unsigned int, unsigned int, int) args: (oldfd, newfd, flags)
+-syscall sys_pipe2 nr 359 nbargs 2 types: (int *, int) args: (fildes, flags)
+-syscall sys_inotify_init1 nr 360 nbargs 1 types: (int) args: (flags)
+-syscall sys_preadv nr 361 nbargs 5 types: (unsigned long, const struct iovec *, unsigned long, unsigned long, unsigned long) args: (fd, vec, vlen, pos_l, pos_h)
+-syscall sys_pwritev nr 362 nbargs 5 types: (unsigned long, const struct iovec *, unsigned long, unsigned long, unsigned long) args: (fd, vec, vlen, pos_l, pos_h)
+-syscall sys_rt_tgsigqueueinfo nr 363 nbargs 4 types: (pid_t, pid_t, int, siginfo_t *) args: (tgid, pid, sig, uinfo)
+-syscall sys_recvmmsg nr 365 nbargs 5 types: (int, struct mmsghdr *, unsigned int, unsigned int, struct timespec *) args: (fd, mmsg, vlen, flags, timeout)
+-syscall sys_accept4 nr 366 nbargs 4 types: (int, struct sockaddr *, int *, int) args: (fd, upeer_sockaddr, upeer_addrlen, flags)
+-syscall sys_prlimit64 nr 369 nbargs 4 types: (pid_t, unsigned int, const struct rlimit64 *, struct rlimit64 *) args: (pid, resource, new_rlim, old_rlim)
+diff --git a/instrumentation/syscalls/3.4.25/arm-32-syscalls-3.4.25 b/instrumentation/syscalls/3.4.25/arm-32-syscalls-3.4.25
+new file mode 100644
+index 0000000..65c3973
+--- /dev/null
++++ b/instrumentation/syscalls/3.4.25/arm-32-syscalls-3.4.25
+@@ -0,0 +1,299 @@
++syscall sys_restart_syscall nr 0 nbargs 0 types: () args: ()
++syscall sys_exit nr 1 nbargs 1 types: (int) args: (error_code)
++syscall sys_read nr 3 nbargs 3 types: (unsigned int, char *, size_t) args: (fd, buf, count)
++syscall sys_write nr 4 nbargs 3 types: (unsigned int, const char *, size_t) args: (fd, buf, count)
++syscall sys_open nr 5 nbargs 3 types: (const char *, int, umode_t) args: (filename, flags, mode)
++syscall sys_close nr 6 nbargs 1 types: (unsigned int) args: (fd)
++syscall sys_creat nr 8 nbargs 2 types: (const char *, umode_t) args: (pathname, mode)
++syscall sys_link nr 9 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
++syscall sys_unlink nr 10 nbargs 1 types: (const char *) args: (pathname)
++syscall sys_chdir nr 12 nbargs 1 types: (const char *) args: (filename)
++syscall sys_mknod nr 14 nbargs 3 types: (const char *, umode_t, unsigned) args: (filename, mode, dev)
++syscall sys_chmod nr 15 nbargs 2 types: (const char *, umode_t) args: (filename, mode)
++syscall sys_lchown16 nr 16 nbargs 3 types: (const char *, old_uid_t, old_gid_t) args: (filename, user, group)
++syscall sys_lseek nr 19 nbargs 3 types: (unsigned int, off_t, unsigned int) args: (fd, offset, origin)
++syscall sys_getpid nr 20 nbargs 0 types: () args: ()
++syscall sys_mount nr 21 nbargs 5 types: (char *, char *, char *, unsigned long, void *) args: (dev_name, dir_name, type, flags, data)
++syscall sys_setuid16 nr 23 nbargs 1 types: (old_uid_t) args: (uid)
++syscall sys_getuid16 nr 24 nbargs 0 types: () args: ()
++syscall sys_ptrace nr 26 nbargs 4 types: (long, long, unsigned long, unsigned long) args: (request, pid, addr, data)
++syscall sys_pause nr 29 nbargs 0 types: () args: ()
++syscall sys_access nr 33 nbargs 2 types: (const char *, int) args: (filename, mode)
++syscall sys_nice nr 34 nbargs 1 types: (int) args: (increment)
++syscall sys_sync nr 36 nbargs 0 types: () args: ()
++syscall sys_kill nr 37 nbargs 2 types: (pid_t, int) args: (pid, sig)
++syscall sys_rename nr 38 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
++syscall sys_mkdir nr 39 nbargs 2 types: (const char *, umode_t) args: (pathname, mode)
++syscall sys_rmdir nr 40 nbargs 1 types: (const char *) args: (pathname)
++syscall sys_dup nr 41 nbargs 1 types: (unsigned int) args: (fildes)
++syscall sys_pipe nr 42 nbargs 1 types: (int *) args: (fildes)
++syscall sys_times nr 43 nbargs 1 types: (struct tms *) args: (tbuf)
++syscall sys_brk nr 45 nbargs 1 types: (unsigned long) args: (brk)
++syscall sys_setgid16 nr 46 nbargs 1 types: (old_gid_t) args: (gid)
++syscall sys_getgid16 nr 47 nbargs 0 types: () args: ()
++syscall sys_geteuid16 nr 49 nbargs 0 types: () args: ()
++syscall sys_getegid16 nr 50 nbargs 0 types: () args: ()
++syscall sys_acct nr 51 nbargs 1 types: (const char *) args: (name)
++syscall sys_umount nr 52 nbargs 2 types: (char *, int) args: (name, flags)
++syscall sys_ioctl nr 54 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
++syscall sys_fcntl nr 55 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
++syscall sys_setpgid nr 57 nbargs 2 types: (pid_t, pid_t) args: (pid, pgid)
++syscall sys_umask nr 60 nbargs 1 types: (int) args: (mask)
++syscall sys_chroot nr 61 nbargs 1 types: (const char *) args: (filename)
++syscall sys_ustat nr 62 nbargs 2 types: (unsigned, struct ustat *) args: (dev, ubuf)
++syscall sys_dup2 nr 63 nbargs 2 types: (unsigned int, unsigned int) args: (oldfd, newfd)
++syscall sys_getppid nr 64 nbargs 0 types: () args: ()
++syscall sys_getpgrp nr 65 nbargs 0 types: () args: ()
++syscall sys_setsid nr 66 nbargs 0 types: () args: ()
++syscall sys_setreuid16 nr 70 nbargs 2 types: (old_uid_t, old_uid_t) args: (ruid, euid)
++syscall sys_setregid16 nr 71 nbargs 2 types: (old_gid_t, old_gid_t) args: (rgid, egid)
++syscall sys_sigpending nr 73 nbargs 1 types: (old_sigset_t *) args: (set)
++syscall sys_sethostname nr 74 nbargs 2 types: (char *, int) args: (name, len)
++syscall sys_setrlimit nr 75 nbargs 2 types: (unsigned int, struct rlimit *) args: (resource, rlim)
++syscall sys_getrusage nr 77 nbargs 2 types: (int, struct rusage *) args: (who, ru)
++syscall sys_gettimeofday nr 78 nbargs 2 types: (struct timeval *, struct timezone *) args: (tv, tz)
++syscall sys_settimeofday nr 79 nbargs 2 types: (struct timeval *, struct timezone *) args: (tv, tz)
++syscall sys_getgroups16 nr 80 nbargs 2 types: (int, old_gid_t *) args: (gidsetsize, grouplist)
++syscall sys_setgroups16 nr 81 nbargs 2 types: (int, old_gid_t *) args: (gidsetsize, grouplist)
++syscall sys_symlink nr 83 nbargs 2 types: (const char *, const char *) args: (oldname, newname)
++syscall sys_readlink nr 85 nbargs 3 types: (const char *, char *, int) args: (path, buf, bufsiz)
++syscall sys_uselib nr 86 nbargs 1 types: (const char *) args: (library)
++syscall sys_swapon nr 87 nbargs 2 types: (const char *, int) args: (specialfile, swap_flags)
++syscall sys_reboot nr 88 nbargs 4 types: (int, int, unsigned int, void *) args: (magic1, magic2, cmd, arg)
++syscall sys_munmap nr 91 nbargs 2 types: (unsigned long, size_t) args: (addr, len)
++syscall sys_truncate nr 92 nbargs 2 types: (const char *, long) args: (path, length)
++syscall sys_ftruncate nr 93 nbargs 2 types: (unsigned int, unsigned long) args: (fd, length)
++syscall sys_fchmod nr 94 nbargs 2 types: (unsigned int, umode_t) args: (fd, mode)
++syscall sys_fchown16 nr 95 nbargs 3 types: (unsigned int, old_uid_t, old_gid_t) args: (fd, user, group)
++syscall sys_getpriority nr 96 nbargs 2 types: (int, int) args: (which, who)
++syscall sys_setpriority nr 97 nbargs 3 types: (int, int, int) args: (which, who, niceval)
++syscall sys_statfs nr 99 nbargs 2 types: (const char *, struct statfs *) args: (pathname, buf)
++syscall sys_fstatfs nr 100 nbargs 2 types: (unsigned int, struct statfs *) args: (fd, buf)
++syscall sys_syslog nr 103 nbargs 3 types: (int, char *, int) args: (type, buf, len)
++syscall sys_setitimer nr 104 nbargs 3 types: (int, struct itimerval *, struct itimerval *) args: (which, value, ovalue)
++syscall sys_getitimer nr 105 nbargs 2 types: (int, struct itimerval *) args: (which, value)
++syscall sys_newstat nr 106 nbargs 2 types: (const char *, struct stat *) args: (filename, statbuf)
++syscall sys_newlstat nr 107 nbargs 2 types: (const char *, struct stat *) args: (filename, statbuf)
++syscall sys_newfstat nr 108 nbargs 2 types: (unsigned int, struct stat *) args: (fd, statbuf)
++syscall sys_vhangup nr 111 nbargs 0 types: () args: ()
++syscall sys_wait4 nr 114 nbargs 4 types: (pid_t, int *, int, struct rusage *) args: (upid, stat_addr, options, ru)
++syscall sys_swapoff nr 115 nbargs 1 types: (const char *) args: (specialfile)
++syscall sys_sysinfo nr 116 nbargs 1 types: (struct sysinfo *) args: (info)
++syscall sys_fsync nr 118 nbargs 1 types: (unsigned int) args: (fd)
++syscall sys_setdomainname nr 121 nbargs 2 types: (char *, int) args: (name, len)
++syscall sys_newuname nr 122 nbargs 1 types: (struct new_utsname *) args: (name)
++syscall sys_adjtimex nr 124 nbargs 1 types: (struct timex *) args: (txc_p)
++syscall sys_mprotect nr 125 nbargs 3 types: (unsigned long, size_t, unsigned long) args: (start, len, prot)
++syscall sys_sigprocmask nr 126 nbargs 3 types: (int, old_sigset_t *, old_sigset_t *) args: (how, nset, oset)
++syscall sys_init_module nr 128 nbargs 3 types: (void *, unsigned long, const char *) args: (umod, len, uargs)
++syscall sys_delete_module nr 129 nbargs 2 types: (const char *, unsigned int) args: (name_user, flags)
++syscall sys_quotactl nr 131 nbargs 4 types: (unsigned int, const char *, qid_t, void *) args: (cmd, special, id, addr)
++syscall sys_getpgid nr 132 nbargs 1 types: (pid_t) args: (pid)
++syscall sys_fchdir nr 133 nbargs 1 types: (unsigned int) args: (fd)
++syscall sys_bdflush nr 134 nbargs 2 types: (int, long) args: (func, data)
++syscall sys_sysfs nr 135 nbargs 3 types: (int, unsigned long, unsigned long) args: (option, arg1, arg2)
++syscall sys_personality nr 136 nbargs 1 types: (unsigned int) args: (personality)
++syscall sys_setfsuid16 nr 138 nbargs 1 types: (old_uid_t) args: (uid)
++syscall sys_setfsgid16 nr 139 nbargs 1 types: (old_gid_t) args: (gid)
++syscall sys_llseek nr 140 nbargs 5 types: (unsigned int, unsigned long, unsigned long, loff_t *, unsigned int) args: (fd, offset_high, offset_low, result, origin)
++syscall sys_getdents nr 141 nbargs 3 types: (unsigned int, struct linux_dirent *, unsigned int) args: (fd, dirent, count)
++syscall sys_select nr 142 nbargs 5 types: (int, fd_set *, fd_set *, fd_set *, struct timeval *) args: (n, inp, outp, exp, tvp)
++syscall sys_flock nr 143 nbargs 2 types: (unsigned int, unsigned int) args: (fd, cmd)
++syscall sys_msync nr 144 nbargs 3 types: (unsigned long, size_t, int) args: (start, len, flags)
++syscall sys_readv nr 145 nbargs 3 types: (unsigned long, const struct iovec *, unsigned long) args: (fd, vec, vlen)
++syscall sys_writev nr 146 nbargs 3 types: (unsigned long, const struct iovec *, unsigned long) args: (fd, vec, vlen)
++syscall sys_getsid nr 147 nbargs 1 types: (pid_t) args: (pid)
++syscall sys_fdatasync nr 148 nbargs 1 types: (unsigned int) args: (fd)
++syscall sys_sysctl nr 149 nbargs 1 types: (struct __sysctl_args *) args: (args)
++syscall sys_mlock nr 150 nbargs 2 types: (unsigned long, size_t) args: (start, len)
++syscall sys_munlock nr 151 nbargs 2 types: (unsigned long, size_t) args: (start, len)
++syscall sys_mlockall nr 152 nbargs 1 types: (int) args: (flags)
++syscall sys_munlockall nr 153 nbargs 0 types: () args: ()
++syscall sys_sched_setparam nr 154 nbargs 2 types: (pid_t, struct sched_param *) args: (pid, param)
++syscall sys_sched_getparam nr 155 nbargs 2 types: (pid_t, struct sched_param *) args: (pid, param)
++syscall sys_sched_setscheduler nr 156 nbargs 3 types: (pid_t, int, struct sched_param *) args: (pid, policy, param)
++syscall sys_sched_getscheduler nr 157 nbargs 1 types: (pid_t) args: (pid)
++syscall sys_sched_yield nr 158 nbargs 0 types: () args: ()
++syscall sys_sched_get_priority_max nr 159 nbargs 1 types: (int) args: (policy)
++syscall sys_sched_get_priority_min nr 160 nbargs 1 types: (int) args: (policy)
++syscall sys_sched_rr_get_interval nr 161 nbargs 2 types: (pid_t, struct timespec *) args: (pid, interval)
++syscall sys_nanosleep nr 162 nbargs 2 types: (struct timespec *, struct timespec *) args: (rqtp, rmtp)
++syscall sys_mremap nr 163 nbargs 5 types: (unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) args: (addr, old_len, new_len, flags, new_addr)
++syscall sys_setresuid16 nr 164 nbargs 3 types: (old_uid_t, old_uid_t, old_uid_t) args: (ruid, euid, suid)
++syscall sys_getresuid16 nr 165 nbargs 3 types: (old_uid_t *, old_uid_t *, old_uid_t *) args: (ruid, euid, suid)
++syscall sys_poll nr 168 nbargs 3 types: (struct pollfd *, unsigned int, int) args: (ufds, nfds, timeout_msecs)
++syscall sys_setresgid16 nr 170 nbargs 3 types: (old_gid_t, old_gid_t, old_gid_t) args: (rgid, egid, sgid)
++syscall sys_getresgid16 nr 171 nbargs 3 types: (old_gid_t *, old_gid_t *, old_gid_t *) args: (rgid, egid, sgid)
++syscall sys_prctl nr 172 nbargs 5 types: (int, unsigned long, unsigned long, unsigned long, unsigned long) args: (option, arg2, arg3, arg4, arg5)
++syscall sys_rt_sigaction nr 174 nbargs 4 types: (int, const struct sigaction *, struct sigaction *, size_t) args: (sig, act, oact, sigsetsize)
++syscall sys_rt_sigprocmask nr 175 nbargs 4 types: (int, sigset_t *, sigset_t *, size_t) args: (how, nset, oset, sigsetsize)
++syscall sys_rt_sigpending nr 176 nbargs 2 types: (sigset_t *, size_t) args: (set, sigsetsize)
++syscall sys_rt_sigtimedwait nr 177 nbargs 4 types: (const sigset_t *, siginfo_t *, const struct timespec *, size_t) args: (uthese, uinfo, uts, sigsetsize)
++syscall sys_rt_sigqueueinfo nr 178 nbargs 3 types: (pid_t, int, siginfo_t *) args: (pid, sig, uinfo)
++syscall sys_rt_sigsuspend nr 179 nbargs 2 types: (sigset_t *, size_t) args: (unewset, sigsetsize)
++syscall sys_chown16 nr 182 nbargs 3 types: (const char *, old_uid_t, old_gid_t) args: (filename, user, group)
++syscall sys_getcwd nr 183 nbargs 2 types: (char *, unsigned long) args: (buf, size)
++syscall sys_capget nr 184 nbargs 2 types: (cap_user_header_t, cap_user_data_t) args: (header, dataptr)
++syscall sys_capset nr 185 nbargs 2 types: (cap_user_header_t, const cap_user_data_t) args: (header, data)
++syscall sys_sendfile nr 187 nbargs 4 types: (int, int, off_t *, size_t) args: (out_fd, in_fd, offset, count)
++syscall sys_getrlimit nr 191 nbargs 2 types: (unsigned int, struct rlimit *) args: (resource, rlim)
++syscall sys_stat64 nr 195 nbargs 2 types: (const char *, struct stat64 *) args: (filename, statbuf)
++syscall sys_lstat64 nr 196 nbargs 2 types: (const char *, struct stat64 *) args: (filename, statbuf)
++syscall sys_fstat64 nr 197 nbargs 2 types: (unsigned long, struct stat64 *) args: (fd, statbuf)
++syscall sys_lchown nr 198 nbargs 3 types: (const char *, uid_t, gid_t) args: (filename, user, group)
++syscall sys_getuid nr 199 nbargs 0 types: () args: ()
++syscall sys_getgid nr 200 nbargs 0 types: () args: ()
++syscall sys_geteuid nr 201 nbargs 0 types: () args: ()
++syscall sys_getegid nr 202 nbargs 0 types: () args: ()
++syscall sys_setreuid nr 203 nbargs 2 types: (uid_t, uid_t) args: (ruid, euid)
++syscall sys_setregid nr 204 nbargs 2 types: (gid_t, gid_t) args: (rgid, egid)
++syscall sys_getgroups nr 205 nbargs 2 types: (int, gid_t *) args: (gidsetsize, grouplist)
++syscall sys_setgroups nr 206 nbargs 2 types: (int, gid_t *) args: (gidsetsize, grouplist)
++syscall sys_fchown nr 207 nbargs 3 types: (unsigned int, uid_t, gid_t) args: (fd, user, group)
++syscall sys_setresuid nr 208 nbargs 3 types: (uid_t, uid_t, uid_t) args: (ruid, euid, suid)
++syscall sys_getresuid nr 209 nbargs 3 types: (uid_t *, uid_t *, uid_t *) args: (ruid, euid, suid)
++syscall sys_setresgid nr 210 nbargs 3 types: (gid_t, gid_t, gid_t) args: (rgid, egid, sgid)
++syscall sys_getresgid nr 211 nbargs 3 types: (gid_t *, gid_t *, gid_t *) args: (rgid, egid, sgid)
++syscall sys_chown nr 212 nbargs 3 types: (const char *, uid_t, gid_t) args: (filename, user, group)
++syscall sys_setuid nr 213 nbargs 1 types: (uid_t) args: (uid)
++syscall sys_setgid nr 214 nbargs 1 types: (gid_t) args: (gid)
++syscall sys_setfsuid nr 215 nbargs 1 types: (uid_t) args: (uid)
++syscall sys_setfsgid nr 216 nbargs 1 types: (gid_t) args: (gid)
++syscall sys_getdents64 nr 217 nbargs 3 types: (unsigned int, struct linux_dirent64 *, unsigned int) args: (fd, dirent, count)
++syscall sys_pivot_root nr 218 nbargs 2 types: (const char *, const char *) args: (new_root, put_old)
++syscall sys_mincore nr 219 nbargs 3 types: (unsigned long, size_t, unsigned char *) args: (start, len, vec)
++syscall sys_madvise nr 220 nbargs 3 types: (unsigned long, size_t, int) args: (start, len_in, behavior)
++syscall sys_fcntl64 nr 221 nbargs 3 types: (unsigned int, unsigned int, unsigned long) args: (fd, cmd, arg)
++syscall sys_gettid nr 224 nbargs 0 types: () args: ()
++syscall sys_setxattr nr 226 nbargs 5 types: (const char *, const char *, const void *, size_t, int) args: (pathname, name, value, size, flags)
++syscall sys_lsetxattr nr 227 nbargs 5 types: (const char *, const char *, const void *, size_t, int) args: (pathname, name, value, size, flags)
++syscall sys_fsetxattr nr 228 nbargs 5 types: (int, const char *, const void *, size_t, int) args: (fd, name, value, size, flags)
++syscall sys_getxattr nr 229 nbargs 4 types: (const char *, const char *, void *, size_t) args: (pathname, name, value, size)
++syscall sys_lgetxattr nr 230 nbargs 4 types: (const char *, const char *, void *, size_t) args: (pathname, name, value, size)
++syscall sys_fgetxattr nr 231 nbargs 4 types: (int, const char *, void *, size_t) args: (fd, name, value, size)
++syscall sys_listxattr nr 232 nbargs 3 types: (const char *, char *, size_t) args: (pathname, list, size)
++syscall sys_llistxattr nr 233 nbargs 3 types: (const char *, char *, size_t) args: (pathname, list, size)
++syscall sys_flistxattr nr 234 nbargs 3 types: (int, char *, size_t) args: (fd, list, size)
++syscall sys_removexattr nr 235 nbargs 2 types: (const char *, const char *) args: (pathname, name)
++syscall sys_lremovexattr nr 236 nbargs 2 types: (const char *, const char *) args: (pathname, name)
++syscall sys_fremovexattr nr 237 nbargs 2 types: (int, const char *) args: (fd, name)
++syscall sys_tkill nr 238 nbargs 2 types: (pid_t, int) args: (pid, sig)
++syscall sys_sendfile64 nr 239 nbargs 4 types: (int, int, loff_t *, size_t) args: (out_fd, in_fd, offset, count)
++syscall sys_futex nr 240 nbargs 6 types: (u32 *, int, u32, struct timespec *, u32 *, u32) args: (uaddr, op, val, utime, uaddr2, val3)
++syscall sys_sched_setaffinity nr 241 nbargs 3 types: (pid_t, unsigned int, unsigned long *) args: (pid, len, user_mask_ptr)
++syscall sys_sched_getaffinity nr 242 nbargs 3 types: (pid_t, unsigned int, unsigned long *) args: (pid, len, user_mask_ptr)
++syscall sys_io_setup nr 243 nbargs 2 types: (unsigned, aio_context_t *) args: (nr_events, ctxp)
++syscall sys_io_destroy nr 244 nbargs 1 types: (aio_context_t) args: (ctx)
++syscall sys_io_getevents nr 245 nbargs 5 types: (aio_context_t, long, long, struct io_event *, struct timespec *) args: (ctx_id, min_nr, nr, events, timeout)
++syscall sys_io_submit nr 246 nbargs 3 types: (aio_context_t, long, struct iocb * *) args: (ctx_id, nr, iocbpp)
++syscall sys_io_cancel nr 247 nbargs 3 types: (aio_context_t, struct iocb *, struct io_event *) args: (ctx_id, iocb, result)
++syscall sys_exit_group nr 248 nbargs 1 types: (int) args: (error_code)
++syscall sys_epoll_create nr 250 nbargs 1 types: (int) args: (size)
++syscall sys_epoll_ctl nr 251 nbargs 4 types: (int, int, int, struct epoll_event *) args: (epfd, op, fd, event)
++syscall sys_epoll_wait nr 252 nbargs 4 types: (int, struct epoll_event *, int, int) args: (epfd, events, maxevents, timeout)
++syscall sys_remap_file_pages nr 253 nbargs 5 types: (unsigned long, unsigned long, unsigned long, unsigned long, unsigned long) args: (start, size, prot, pgoff, flags)
++syscall sys_set_tid_address nr 256 nbargs 1 types: (int *) args: (tidptr)
++syscall sys_timer_create nr 257 nbargs 3 types: (const clockid_t, struct sigevent *, timer_t *) args: (which_clock, timer_event_spec, created_timer_id)
++syscall sys_timer_settime nr 258 nbargs 4 types: (timer_t, int, const struct itimerspec *, struct itimerspec *) args: (timer_id, flags, new_setting, old_setting)
++syscall sys_timer_gettime nr 259 nbargs 2 types: (timer_t, struct itimerspec *) args: (timer_id, setting)
++syscall sys_timer_getoverrun nr 260 nbargs 1 types: (timer_t) args: (timer_id)
++syscall sys_timer_delete nr 261 nbargs 1 types: (timer_t) args: (timer_id)
++syscall sys_clock_settime nr 262 nbargs 2 types: (const clockid_t, const struct timespec *) args: (which_clock, tp)
++syscall sys_clock_gettime nr 263 nbargs 2 types: (const clockid_t, struct timespec *) args: (which_clock, tp)
++syscall sys_clock_getres nr 264 nbargs 2 types: (const clockid_t, struct timespec *) args: (which_clock, tp)
++syscall sys_clock_nanosleep nr 265 nbargs 4 types: (const clockid_t, int, const struct timespec *, struct timespec *) args: (which_clock, flags, rqtp, rmtp)
++syscall sys_tgkill nr 268 nbargs 3 types: (pid_t, pid_t, int) args: (tgid, pid, sig)
++syscall sys_utimes nr 269 nbargs 2 types: (char *, struct timeval *) args: (filename, utimes)
++syscall sys_mq_open nr 274 nbargs 4 types: (const char *, int, umode_t, struct mq_attr *) args: (u_name, oflag, mode, u_attr)
++syscall sys_mq_unlink nr 275 nbargs 1 types: (const char *) args: (u_name)
++syscall sys_mq_timedsend nr 276 nbargs 5 types: (mqd_t, const char *, size_t, unsigned int, const struct timespec *) args: (mqdes, u_msg_ptr, msg_len, msg_prio, u_abs_timeout)
++syscall sys_mq_timedreceive nr 277 nbargs 5 types: (mqd_t, char *, size_t, unsigned int *, const struct timespec *) args: (mqdes, u_msg_ptr, msg_len, u_msg_prio, u_abs_timeout)
++syscall sys_mq_notify nr 278 nbargs 2 types: (mqd_t, const struct sigevent *) args: (mqdes, u_notification)
++syscall sys_mq_getsetattr nr 279 nbargs 3 types: (mqd_t, const struct mq_attr *, struct mq_attr *) args: (mqdes, u_mqstat, u_omqstat)
++syscall sys_waitid nr 280 nbargs 5 types: (int, pid_t, struct siginfo *, int, struct rusage *) args: (which, upid, infop, options, ru)
++syscall sys_socket nr 281 nbargs 3 types: (int, int, int) args: (family, type, protocol)
++syscall sys_bind nr 282 nbargs 3 types: (int, struct sockaddr *, int) args: (fd, umyaddr, addrlen)
++syscall sys_connect nr 283 nbargs 3 types: (int, struct sockaddr *, int) args: (fd, uservaddr, addrlen)
++syscall sys_listen nr 284 nbargs 2 types: (int, int) args: (fd, backlog)
++syscall sys_accept nr 285 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, upeer_sockaddr, upeer_addrlen)
++syscall sys_getsockname nr 286 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, usockaddr, usockaddr_len)
++syscall sys_getpeername nr 287 nbargs 3 types: (int, struct sockaddr *, int *) args: (fd, usockaddr, usockaddr_len)
++syscall sys_socketpair nr 288 nbargs 4 types: (int, int, int, int *) args: (family, type, protocol, usockvec)
++syscall sys_send nr 289 nbargs 4 types: (int, void *, size_t, unsigned) args: (fd, buff, len, flags)
++syscall sys_sendto nr 290 nbargs 6 types: (int, void *, size_t, unsigned, struct sockaddr *, int) args: (fd, buff, len, flags, addr, addr_len)
++syscall sys_recvfrom nr 292 nbargs 6 types: (int, void *, size_t, unsigned, struct sockaddr *, int *) args: (fd, ubuf, size, flags, addr, addr_len)
++syscall sys_shutdown nr 293 nbargs 2 types: (int, int) args: (fd, how)
++syscall sys_setsockopt nr 294 nbargs 5 types: (int, int, int, char *, int) args: (fd, level, optname, optval, optlen)
++syscall sys_getsockopt nr 295 nbargs 5 types: (int, int, int, char *, int *) args: (fd, level, optname, optval, optlen)
++syscall sys_sendmsg nr 296 nbargs 3 types: (int, struct msghdr *, unsigned) args: (fd, msg, flags)
++syscall sys_recvmsg nr 297 nbargs 3 types: (int, struct msghdr *, unsigned int) args: (fd, msg, flags)
++syscall sys_semop nr 298 nbargs 3 types: (int, struct sembuf *, unsigned) args: (semid, tsops, nsops)
++syscall sys_semget nr 299 nbargs 3 types: (key_t, int, int) args: (key, nsems, semflg)
++syscall sys_msgsnd nr 301 nbargs 4 types: (int, struct msgbuf *, size_t, int) args: (msqid, msgp, msgsz, msgflg)
++syscall sys_msgrcv nr 302 nbargs 5 types: (int, struct msgbuf *, size_t, long, int) args: (msqid, msgp, msgsz, msgtyp, msgflg)
++syscall sys_msgget nr 303 nbargs 2 types: (key_t, int) args: (key, msgflg)
++syscall sys_msgctl nr 304 nbargs 3 types: (int, int, struct msqid_ds *) args: (msqid, cmd, buf)
++syscall sys_shmat nr 305 nbargs 3 types: (int, char *, int) args: (shmid, shmaddr, shmflg)
++syscall sys_shmdt nr 306 nbargs 1 types: (char *) args: (shmaddr)
++syscall sys_shmget nr 307 nbargs 3 types: (key_t, size_t, int) args: (key, size, shmflg)
++syscall sys_shmctl nr 308 nbargs 3 types: (int, int, struct shmid_ds *) args: (shmid, cmd, buf)
++syscall sys_add_key nr 309 nbargs 5 types: (const char *, const char *, const void *, size_t, key_serial_t) args: (_type, _description, _payload, plen, ringid)
++syscall sys_request_key nr 310 nbargs 4 types: (const char *, const char *, const char *, key_serial_t) args: (_type, _description, _callout_info, destringid)
++syscall sys_keyctl nr 311 nbargs 5 types: (int, unsigned long, unsigned long, unsigned long, unsigned long) args: (option, arg2, arg3, arg4, arg5)
++syscall sys_semtimedop nr 312 nbargs 4 types: (int, struct sembuf *, unsigned, const struct timespec *) args: (semid, tsops, nsops, timeout)
++syscall sys_ioprio_set nr 314 nbargs 3 types: (int, int, int) args: (which, who, ioprio)
++syscall sys_ioprio_get nr 315 nbargs 2 types: (int, int) args: (which, who)
++syscall sys_inotify_init nr 316 nbargs 0 types: () args: ()
++syscall sys_inotify_add_watch nr 317 nbargs 3 types: (int, const char *, u32) args: (fd, pathname, mask)
++syscall sys_inotify_rm_watch nr 318 nbargs 2 types: (int, __s32) args: (fd, wd)
++syscall sys_openat nr 322 nbargs 4 types: (int, const char *, int, umode_t) args: (dfd, filename, flags, mode)
++syscall sys_mkdirat nr 323 nbargs 3 types: (int, const char *, umode_t) args: (dfd, pathname, mode)
++syscall sys_mknodat nr 324 nbargs 4 types: (int, const char *, umode_t, unsigned) args: (dfd, filename, mode, dev)
++syscall sys_fchownat nr 325 nbargs 5 types: (int, const char *, uid_t, gid_t, int) args: (dfd, filename, user, group, flag)
++syscall sys_futimesat nr 326 nbargs 3 types: (int, const char *, struct timeval *) args: (dfd, filename, utimes)
++syscall sys_fstatat64 nr 327 nbargs 4 types: (int, const char *, struct stat64 *, int) args: (dfd, filename, statbuf, flag)
++syscall sys_unlinkat nr 328 nbargs 3 types: (int, const char *, int) args: (dfd, pathname, flag)
++syscall sys_renameat nr 329 nbargs 4 types: (int, const char *, int, const char *) args: (olddfd, oldname, newdfd, newname)
++syscall sys_linkat nr 330 nbargs 5 types: (int, const char *, int, const char *, int) args: (olddfd, oldname, newdfd, newname, flags)
++syscall sys_symlinkat nr 331 nbargs 3 types: (const char *, int, const char *) args: (oldname, newdfd, newname)
++syscall sys_readlinkat nr 332 nbargs 4 types: (int, const char *, char *, int) args: (dfd, pathname, buf, bufsiz)
++syscall sys_fchmodat nr 333 nbargs 3 types: (int, const char *, umode_t) args: (dfd, filename, mode)
++syscall sys_faccessat nr 334 nbargs 3 types: (int, const char *, int) args: (dfd, filename, mode)
++syscall sys_pselect6 nr 335 nbargs 6 types: (int, fd_set *, fd_set *, fd_set *, struct timespec *, void *) args: (n, inp, outp, exp, tsp, sig)
++syscall sys_ppoll nr 336 nbargs 5 types: (struct pollfd *, unsigned int, struct timespec *, const sigset_t *, size_t) args: (ufds, nfds, tsp, sigmask, sigsetsize)
++syscall sys_unshare nr 337 nbargs 1 types: (unsigned long) args: (unshare_flags)
++syscall sys_set_robust_list nr 338 nbargs 2 types: (struct robust_list_head *, size_t) args: (head, len)
++syscall sys_get_robust_list nr 339 nbargs 3 types: (int, struct robust_list_head * *, size_t *) args: (pid, head_ptr, len_ptr)
++syscall sys_splice nr 340 nbargs 6 types: (int, loff_t *, int, loff_t *, size_t, unsigned int) args: (fd_in, off_in, fd_out, off_out, len, flags)
++syscall sys_tee nr 342 nbargs 4 types: (int, int, size_t, unsigned int) args: (fdin, fdout, len, flags)
++syscall sys_vmsplice nr 343 nbargs 4 types: (int, const struct iovec *, unsigned long, unsigned int) args: (fd, iov, nr_segs, flags)
++syscall sys_getcpu nr 345 nbargs 3 types: (unsigned *, unsigned *, struct getcpu_cache *) args: (cpup, nodep, unused)
++syscall sys_epoll_pwait nr 346 nbargs 6 types: (int, struct epoll_event *, int, int, const sigset_t *, size_t) args: (epfd, events, maxevents, timeout, sigmask, sigsetsize)
++syscall sys_utimensat nr 348 nbargs 4 types: (int, const char *, struct timespec *, int) args: (dfd, filename, utimes, flags)
++syscall sys_signalfd nr 349 nbargs 3 types: (int, sigset_t *, size_t) args: (ufd, user_mask, sizemask)
++syscall sys_timerfd_create nr 350 nbargs 2 types: (int, int) args: (clockid, flags)
++syscall sys_eventfd nr 351 nbargs 1 types: (unsigned int) args: (count)
++syscall sys_timerfd_settime nr 353 nbargs 4 types: (int, int, const struct itimerspec *, struct itimerspec *) args: (ufd, flags, utmr, otmr)
++syscall sys_timerfd_gettime nr 354 nbargs 2 types: (int, struct itimerspec *) args: (ufd, otmr)
++syscall sys_signalfd4 nr 355 nbargs 4 types: (int, sigset_t *, size_t, int) args: (ufd, user_mask, sizemask, flags)
++syscall sys_eventfd2 nr 356 nbargs 2 types: (unsigned int, int) args: (count, flags)
++syscall sys_epoll_create1 nr 357 nbargs 1 types: (int) args: (flags)
++syscall sys_dup3 nr 358 nbargs 3 types: (unsigned int, unsigned int, int) args: (oldfd, newfd, flags)
++syscall sys_pipe2 nr 359 nbargs 2 types: (int *, int) args: (fildes, flags)
++syscall sys_inotify_init1 nr 360 nbargs 1 types: (int) args: (flags)
++syscall sys_preadv nr 361 nbargs 5 types: (unsigned long, const struct iovec *, unsigned long, unsigned long, unsigned long) args: (fd, vec, vlen, pos_l, pos_h)
++syscall sys_pwritev nr 362 nbargs 5 types: (unsigned long, const struct iovec *, unsigned long, unsigned long, unsigned long) args: (fd, vec, vlen, pos_l, pos_h)
++syscall sys_rt_tgsigqueueinfo nr 363 nbargs 4 types: (pid_t, pid_t, int, siginfo_t *) args: (tgid, pid, sig, uinfo)
++syscall sys_perf_event_open nr 364 nbargs 5 types: (struct perf_event_attr *, pid_t, int, int, unsigned long) args: (attr_uptr, pid, cpu, group_fd, flags)
++syscall sys_recvmmsg nr 365 nbargs 5 types: (int, struct mmsghdr *, unsigned int, unsigned int, struct timespec *) args: (fd, mmsg, vlen, flags, timeout)
++syscall sys_accept4 nr 366 nbargs 4 types: (int, struct sockaddr *, int *, int) args: (fd, upeer_sockaddr, upeer_addrlen, flags)
++syscall sys_fanotify_init nr 367 nbargs 2 types: (unsigned int, unsigned int) args: (flags, event_f_flags)
++syscall sys_prlimit64 nr 369 nbargs 4 types: (pid_t, unsigned int, const struct rlimit64 *, struct rlimit64 *) args: (pid, resource, new_rlim, old_rlim)
++syscall sys_name_to_handle_at nr 370 nbargs 5 types: (int, const char *, struct file_handle *, int *, int) args: (dfd, name, handle, mnt_id, flag)
++syscall sys_open_by_handle_at nr 371 nbargs 3 types: (int, struct file_handle *, int) args: (mountdirfd, handle, flags)
++syscall sys_clock_adjtime nr 372 nbargs 2 types: (const clockid_t, struct timex *) args: (which_clock, utx)
++syscall sys_syncfs nr 373 nbargs 1 types: (int) args: (fd)
++syscall sys_sendmmsg nr 374 nbargs 4 types: (int, struct mmsghdr *, unsigned int, unsigned int) args: (fd, mmsg, vlen, flags)
++syscall sys_setns nr 375 nbargs 2 types: (int, int) args: (fd, nstype)
++syscall sys_process_vm_readv nr 376 nbargs 6 types: (pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) args: (pid, lvec, liovcnt, rvec, riovcnt, flags)
++syscall sys_process_vm_writev nr 377 nbargs 6 types: (pid_t, const struct iovec *, unsigned long, const struct iovec *, unsigned long, unsigned long) args: (pid, lvec, liovcnt, rvec, riovcnt, flags)
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers.h b/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers.h
+deleted file mode 100644
+index 9419331..0000000
+--- a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers.h
++++ /dev/null
+@@ -1,1145 +0,0 @@
+-/* THIS FILE IS AUTO-GENERATED. DO NOT EDIT */
+-#ifndef CREATE_SYSCALL_TABLE
+-
+-#if !defined(_TRACE_SYSCALLS_INTEGERS_H) || defined(TRACE_HEADER_MULTI_READ)
+-#define _TRACE_SYSCALLS_INTEGERS_H
+-
+-#include <linux/tracepoint.h>
+-#include <linux/syscalls.h>
+-#include "arm-32-syscalls-2.6.38_integers_override.h"
+-#include "syscalls_integers_override.h"
+-
+-SC_DECLARE_EVENT_CLASS_NOARGS(syscalls_noargs,
+-	TP_STRUCT__entry(),
+-	TP_fast_assign(),
+-	TP_printk()
+-)
+-#ifndef OVERRIDE_32_sys_restart_syscall
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_restart_syscall)
+-#endif
+-#ifndef OVERRIDE_32_sys_getpid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getpid)
+-#endif
+-#ifndef OVERRIDE_32_sys_getuid16
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getuid16)
+-#endif
+-#ifndef OVERRIDE_32_sys_pause
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_pause)
+-#endif
+-#ifndef OVERRIDE_32_sys_sync
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_sync)
+-#endif
+-#ifndef OVERRIDE_32_sys_getgid16
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getgid16)
+-#endif
+-#ifndef OVERRIDE_32_sys_geteuid16
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_geteuid16)
+-#endif
+-#ifndef OVERRIDE_32_sys_getegid16
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getegid16)
+-#endif
+-#ifndef OVERRIDE_32_sys_getppid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getppid)
+-#endif
+-#ifndef OVERRIDE_32_sys_getpgrp
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getpgrp)
+-#endif
+-#ifndef OVERRIDE_32_sys_setsid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_setsid)
+-#endif
+-#ifndef OVERRIDE_32_sys_vhangup
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_vhangup)
+-#endif
+-#ifndef OVERRIDE_32_sys_munlockall
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_munlockall)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_yield
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_sched_yield)
+-#endif
+-#ifndef OVERRIDE_32_sys_getuid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getuid)
+-#endif
+-#ifndef OVERRIDE_32_sys_getgid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getgid)
+-#endif
+-#ifndef OVERRIDE_32_sys_geteuid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_geteuid)
+-#endif
+-#ifndef OVERRIDE_32_sys_getegid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getegid)
+-#endif
+-#ifndef OVERRIDE_32_sys_gettid
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_gettid)
+-#endif
+-#ifndef OVERRIDE_32_sys_inotify_init
+-SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_inotify_init)
+-#endif
+-#ifndef OVERRIDE_32_sys_exit
+-SC_TRACE_EVENT(sys_exit,
+-	TP_PROTO(int error_code),
+-	TP_ARGS(error_code),
+-	TP_STRUCT__entry(__field(int, error_code)),
+-	TP_fast_assign(tp_assign(error_code, error_code)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_close
+-SC_TRACE_EVENT(sys_close,
+-	TP_PROTO(unsigned int fd),
+-	TP_ARGS(fd),
+-	TP_STRUCT__entry(__field(unsigned int, fd)),
+-	TP_fast_assign(tp_assign(fd, fd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setuid16
+-SC_TRACE_EVENT(sys_setuid16,
+-	TP_PROTO(old_uid_t uid),
+-	TP_ARGS(uid),
+-	TP_STRUCT__entry(__field(old_uid_t, uid)),
+-	TP_fast_assign(tp_assign(uid, uid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_nice
+-SC_TRACE_EVENT(sys_nice,
+-	TP_PROTO(int increment),
+-	TP_ARGS(increment),
+-	TP_STRUCT__entry(__field(int, increment)),
+-	TP_fast_assign(tp_assign(increment, increment)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_dup
+-SC_TRACE_EVENT(sys_dup,
+-	TP_PROTO(unsigned int fildes),
+-	TP_ARGS(fildes),
+-	TP_STRUCT__entry(__field(unsigned int, fildes)),
+-	TP_fast_assign(tp_assign(fildes, fildes)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_brk
+-SC_TRACE_EVENT(sys_brk,
+-	TP_PROTO(unsigned long brk),
+-	TP_ARGS(brk),
+-	TP_STRUCT__entry(__field(unsigned long, brk)),
+-	TP_fast_assign(tp_assign(brk, brk)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setgid16
+-SC_TRACE_EVENT(sys_setgid16,
+-	TP_PROTO(old_gid_t gid),
+-	TP_ARGS(gid),
+-	TP_STRUCT__entry(__field(old_gid_t, gid)),
+-	TP_fast_assign(tp_assign(gid, gid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_umask
+-SC_TRACE_EVENT(sys_umask,
+-	TP_PROTO(int mask),
+-	TP_ARGS(mask),
+-	TP_STRUCT__entry(__field(int, mask)),
+-	TP_fast_assign(tp_assign(mask, mask)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fsync
+-SC_TRACE_EVENT(sys_fsync,
+-	TP_PROTO(unsigned int fd),
+-	TP_ARGS(fd),
+-	TP_STRUCT__entry(__field(unsigned int, fd)),
+-	TP_fast_assign(tp_assign(fd, fd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getpgid
+-SC_TRACE_EVENT(sys_getpgid,
+-	TP_PROTO(pid_t pid),
+-	TP_ARGS(pid),
+-	TP_STRUCT__entry(__field(pid_t, pid)),
+-	TP_fast_assign(tp_assign(pid, pid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchdir
+-SC_TRACE_EVENT(sys_fchdir,
+-	TP_PROTO(unsigned int fd),
+-	TP_ARGS(fd),
+-	TP_STRUCT__entry(__field(unsigned int, fd)),
+-	TP_fast_assign(tp_assign(fd, fd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_personality
+-SC_TRACE_EVENT(sys_personality,
+-	TP_PROTO(unsigned int personality),
+-	TP_ARGS(personality),
+-	TP_STRUCT__entry(__field(unsigned int, personality)),
+-	TP_fast_assign(tp_assign(personality, personality)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setfsuid16
+-SC_TRACE_EVENT(sys_setfsuid16,
+-	TP_PROTO(old_uid_t uid),
+-	TP_ARGS(uid),
+-	TP_STRUCT__entry(__field(old_uid_t, uid)),
+-	TP_fast_assign(tp_assign(uid, uid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setfsgid16
+-SC_TRACE_EVENT(sys_setfsgid16,
+-	TP_PROTO(old_gid_t gid),
+-	TP_ARGS(gid),
+-	TP_STRUCT__entry(__field(old_gid_t, gid)),
+-	TP_fast_assign(tp_assign(gid, gid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getsid
+-SC_TRACE_EVENT(sys_getsid,
+-	TP_PROTO(pid_t pid),
+-	TP_ARGS(pid),
+-	TP_STRUCT__entry(__field(pid_t, pid)),
+-	TP_fast_assign(tp_assign(pid, pid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fdatasync
+-SC_TRACE_EVENT(sys_fdatasync,
+-	TP_PROTO(unsigned int fd),
+-	TP_ARGS(fd),
+-	TP_STRUCT__entry(__field(unsigned int, fd)),
+-	TP_fast_assign(tp_assign(fd, fd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mlockall
+-SC_TRACE_EVENT(sys_mlockall,
+-	TP_PROTO(int flags),
+-	TP_ARGS(flags),
+-	TP_STRUCT__entry(__field(int, flags)),
+-	TP_fast_assign(tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_getscheduler
+-SC_TRACE_EVENT(sys_sched_getscheduler,
+-	TP_PROTO(pid_t pid),
+-	TP_ARGS(pid),
+-	TP_STRUCT__entry(__field(pid_t, pid)),
+-	TP_fast_assign(tp_assign(pid, pid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_get_priority_max
+-SC_TRACE_EVENT(sys_sched_get_priority_max,
+-	TP_PROTO(int policy),
+-	TP_ARGS(policy),
+-	TP_STRUCT__entry(__field(int, policy)),
+-	TP_fast_assign(tp_assign(policy, policy)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_get_priority_min
+-SC_TRACE_EVENT(sys_sched_get_priority_min,
+-	TP_PROTO(int policy),
+-	TP_ARGS(policy),
+-	TP_STRUCT__entry(__field(int, policy)),
+-	TP_fast_assign(tp_assign(policy, policy)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setuid
+-SC_TRACE_EVENT(sys_setuid,
+-	TP_PROTO(uid_t uid),
+-	TP_ARGS(uid),
+-	TP_STRUCT__entry(__field(uid_t, uid)),
+-	TP_fast_assign(tp_assign(uid, uid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setgid
+-SC_TRACE_EVENT(sys_setgid,
+-	TP_PROTO(gid_t gid),
+-	TP_ARGS(gid),
+-	TP_STRUCT__entry(__field(gid_t, gid)),
+-	TP_fast_assign(tp_assign(gid, gid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setfsuid
+-SC_TRACE_EVENT(sys_setfsuid,
+-	TP_PROTO(uid_t uid),
+-	TP_ARGS(uid),
+-	TP_STRUCT__entry(__field(uid_t, uid)),
+-	TP_fast_assign(tp_assign(uid, uid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setfsgid
+-SC_TRACE_EVENT(sys_setfsgid,
+-	TP_PROTO(gid_t gid),
+-	TP_ARGS(gid),
+-	TP_STRUCT__entry(__field(gid_t, gid)),
+-	TP_fast_assign(tp_assign(gid, gid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_io_destroy
+-SC_TRACE_EVENT(sys_io_destroy,
+-	TP_PROTO(aio_context_t ctx),
+-	TP_ARGS(ctx),
+-	TP_STRUCT__entry(__field(aio_context_t, ctx)),
+-	TP_fast_assign(tp_assign(ctx, ctx)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_exit_group
+-SC_TRACE_EVENT(sys_exit_group,
+-	TP_PROTO(int error_code),
+-	TP_ARGS(error_code),
+-	TP_STRUCT__entry(__field(int, error_code)),
+-	TP_fast_assign(tp_assign(error_code, error_code)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_epoll_create
+-SC_TRACE_EVENT(sys_epoll_create,
+-	TP_PROTO(int size),
+-	TP_ARGS(size),
+-	TP_STRUCT__entry(__field(int, size)),
+-	TP_fast_assign(tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timer_getoverrun
+-SC_TRACE_EVENT(sys_timer_getoverrun,
+-	TP_PROTO(timer_t timer_id),
+-	TP_ARGS(timer_id),
+-	TP_STRUCT__entry(__field(timer_t, timer_id)),
+-	TP_fast_assign(tp_assign(timer_id, timer_id)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timer_delete
+-SC_TRACE_EVENT(sys_timer_delete,
+-	TP_PROTO(timer_t timer_id),
+-	TP_ARGS(timer_id),
+-	TP_STRUCT__entry(__field(timer_t, timer_id)),
+-	TP_fast_assign(tp_assign(timer_id, timer_id)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_unshare
+-SC_TRACE_EVENT(sys_unshare,
+-	TP_PROTO(unsigned long unshare_flags),
+-	TP_ARGS(unshare_flags),
+-	TP_STRUCT__entry(__field(unsigned long, unshare_flags)),
+-	TP_fast_assign(tp_assign(unshare_flags, unshare_flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_eventfd
+-SC_TRACE_EVENT(sys_eventfd,
+-	TP_PROTO(unsigned int count),
+-	TP_ARGS(count),
+-	TP_STRUCT__entry(__field(unsigned int, count)),
+-	TP_fast_assign(tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_epoll_create1
+-SC_TRACE_EVENT(sys_epoll_create1,
+-	TP_PROTO(int flags),
+-	TP_ARGS(flags),
+-	TP_STRUCT__entry(__field(int, flags)),
+-	TP_fast_assign(tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_inotify_init1
+-SC_TRACE_EVENT(sys_inotify_init1,
+-	TP_PROTO(int flags),
+-	TP_ARGS(flags),
+-	TP_STRUCT__entry(__field(int, flags)),
+-	TP_fast_assign(tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_kill
+-SC_TRACE_EVENT(sys_kill,
+-	TP_PROTO(pid_t pid, int sig),
+-	TP_ARGS(pid, sig),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setpgid
+-SC_TRACE_EVENT(sys_setpgid,
+-	TP_PROTO(pid_t pid, pid_t pgid),
+-	TP_ARGS(pid, pgid),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(pid_t, pgid)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(pgid, pgid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_dup2
+-SC_TRACE_EVENT(sys_dup2,
+-	TP_PROTO(unsigned int oldfd, unsigned int newfd),
+-	TP_ARGS(oldfd, newfd),
+-	TP_STRUCT__entry(__field(unsigned int, oldfd) __field(unsigned int, newfd)),
+-	TP_fast_assign(tp_assign(oldfd, oldfd) tp_assign(newfd, newfd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setreuid16
+-SC_TRACE_EVENT(sys_setreuid16,
+-	TP_PROTO(old_uid_t ruid, old_uid_t euid),
+-	TP_ARGS(ruid, euid),
+-	TP_STRUCT__entry(__field(old_uid_t, ruid) __field(old_uid_t, euid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setregid16
+-SC_TRACE_EVENT(sys_setregid16,
+-	TP_PROTO(old_gid_t rgid, old_gid_t egid),
+-	TP_ARGS(rgid, egid),
+-	TP_STRUCT__entry(__field(old_gid_t, rgid) __field(old_gid_t, egid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_munmap
+-SC_TRACE_EVENT(sys_munmap,
+-	TP_PROTO(unsigned long addr, size_t len),
+-	TP_ARGS(addr, len),
+-	TP_STRUCT__entry(__field_hex(unsigned long, addr) __field(size_t, len)),
+-	TP_fast_assign(tp_assign(addr, addr) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ftruncate
+-SC_TRACE_EVENT(sys_ftruncate,
+-	TP_PROTO(unsigned int fd, unsigned long length),
+-	TP_ARGS(fd, length),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned long, length)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(length, length)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchmod
+-SC_TRACE_EVENT(sys_fchmod,
+-	TP_PROTO(unsigned int fd, mode_t mode),
+-	TP_ARGS(fd, mode),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(mode_t, mode)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getpriority
+-SC_TRACE_EVENT(sys_getpriority,
+-	TP_PROTO(int which, int who),
+-	TP_ARGS(which, who),
+-	TP_STRUCT__entry(__field(int, which) __field(int, who)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(who, who)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_bdflush
+-SC_TRACE_EVENT(sys_bdflush,
+-	TP_PROTO(int func, long data),
+-	TP_ARGS(func, data),
+-	TP_STRUCT__entry(__field(int, func) __field(long, data)),
+-	TP_fast_assign(tp_assign(func, func) tp_assign(data, data)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_flock
+-SC_TRACE_EVENT(sys_flock,
+-	TP_PROTO(unsigned int fd, unsigned int cmd),
+-	TP_ARGS(fd, cmd),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mlock
+-SC_TRACE_EVENT(sys_mlock,
+-	TP_PROTO(unsigned long start, size_t len),
+-	TP_ARGS(start, len),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_munlock
+-SC_TRACE_EVENT(sys_munlock,
+-	TP_PROTO(unsigned long start, size_t len),
+-	TP_ARGS(start, len),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setreuid
+-SC_TRACE_EVENT(sys_setreuid,
+-	TP_PROTO(uid_t ruid, uid_t euid),
+-	TP_ARGS(ruid, euid),
+-	TP_STRUCT__entry(__field(uid_t, ruid) __field(uid_t, euid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setregid
+-SC_TRACE_EVENT(sys_setregid,
+-	TP_PROTO(gid_t rgid, gid_t egid),
+-	TP_ARGS(rgid, egid),
+-	TP_STRUCT__entry(__field(gid_t, rgid) __field(gid_t, egid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_tkill
+-SC_TRACE_EVENT(sys_tkill,
+-	TP_PROTO(pid_t pid, int sig),
+-	TP_ARGS(pid, sig),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_listen
+-SC_TRACE_EVENT(sys_listen,
+-	TP_PROTO(int fd, int backlog),
+-	TP_ARGS(fd, backlog),
+-	TP_STRUCT__entry(__field(int, fd) __field(int, backlog)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(backlog, backlog)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_shutdown
+-SC_TRACE_EVENT(sys_shutdown,
+-	TP_PROTO(int fd, int how),
+-	TP_ARGS(fd, how),
+-	TP_STRUCT__entry(__field(int, fd) __field(int, how)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(how, how)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_msgget
+-SC_TRACE_EVENT(sys_msgget,
+-	TP_PROTO(key_t key, int msgflg),
+-	TP_ARGS(key, msgflg),
+-	TP_STRUCT__entry(__field(key_t, key) __field(int, msgflg)),
+-	TP_fast_assign(tp_assign(key, key) tp_assign(msgflg, msgflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ioprio_get
+-SC_TRACE_EVENT(sys_ioprio_get,
+-	TP_PROTO(int which, int who),
+-	TP_ARGS(which, who),
+-	TP_STRUCT__entry(__field(int, which) __field(int, who)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(who, who)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_inotify_rm_watch
+-SC_TRACE_EVENT(sys_inotify_rm_watch,
+-	TP_PROTO(int fd, __s32 wd),
+-	TP_ARGS(fd, wd),
+-	TP_STRUCT__entry(__field(int, fd) __field(__s32, wd)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(wd, wd)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timerfd_create
+-SC_TRACE_EVENT(sys_timerfd_create,
+-	TP_PROTO(int clockid, int flags),
+-	TP_ARGS(clockid, flags),
+-	TP_STRUCT__entry(__field(int, clockid) __field(int, flags)),
+-	TP_fast_assign(tp_assign(clockid, clockid) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_eventfd2
+-SC_TRACE_EVENT(sys_eventfd2,
+-	TP_PROTO(unsigned int count, int flags),
+-	TP_ARGS(count, flags),
+-	TP_STRUCT__entry(__field(unsigned int, count) __field(int, flags)),
+-	TP_fast_assign(tp_assign(count, count) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lseek
+-SC_TRACE_EVENT(sys_lseek,
+-	TP_PROTO(unsigned int fd, off_t offset, unsigned int origin),
+-	TP_ARGS(fd, offset, origin),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(off_t, offset) __field(unsigned int, origin)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(offset, offset) tp_assign(origin, origin)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ioctl
+-SC_TRACE_EVENT(sys_ioctl,
+-	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
+-	TP_ARGS(fd, cmd, arg),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fcntl
+-SC_TRACE_EVENT(sys_fcntl,
+-	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
+-	TP_ARGS(fd, cmd, arg),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchown16
+-SC_TRACE_EVENT(sys_fchown16,
+-	TP_PROTO(unsigned int fd, old_uid_t user, old_gid_t group),
+-	TP_ARGS(fd, user, group),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(old_uid_t, user) __field(old_gid_t, group)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setpriority
+-SC_TRACE_EVENT(sys_setpriority,
+-	TP_PROTO(int which, int who, int niceval),
+-	TP_ARGS(which, who, niceval),
+-	TP_STRUCT__entry(__field(int, which) __field(int, who) __field(int, niceval)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(who, who) tp_assign(niceval, niceval)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mprotect
+-SC_TRACE_EVENT(sys_mprotect,
+-	TP_PROTO(unsigned long start, size_t len, unsigned long prot),
+-	TP_ARGS(start, len, prot),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field(unsigned long, prot)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(prot, prot)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sysfs
+-SC_TRACE_EVENT(sys_sysfs,
+-	TP_PROTO(int option, unsigned long arg1, unsigned long arg2),
+-	TP_ARGS(option, arg1, arg2),
+-	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg1) __field(unsigned long, arg2)),
+-	TP_fast_assign(tp_assign(option, option) tp_assign(arg1, arg1) tp_assign(arg2, arg2)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_msync
+-SC_TRACE_EVENT(sys_msync,
+-	TP_PROTO(unsigned long start, size_t len, int flags),
+-	TP_ARGS(start, len, flags),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field(int, flags)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setresuid16
+-SC_TRACE_EVENT(sys_setresuid16,
+-	TP_PROTO(old_uid_t ruid, old_uid_t euid, old_uid_t suid),
+-	TP_ARGS(ruid, euid, suid),
+-	TP_STRUCT__entry(__field(old_uid_t, ruid) __field(old_uid_t, euid) __field(old_uid_t, suid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setresgid16
+-SC_TRACE_EVENT(sys_setresgid16,
+-	TP_PROTO(old_gid_t rgid, old_gid_t egid, old_gid_t sgid),
+-	TP_ARGS(rgid, egid, sgid),
+-	TP_STRUCT__entry(__field(old_gid_t, rgid) __field(old_gid_t, egid) __field(old_gid_t, sgid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchown
+-SC_TRACE_EVENT(sys_fchown,
+-	TP_PROTO(unsigned int fd, uid_t user, gid_t group),
+-	TP_ARGS(fd, user, group),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(uid_t, user) __field(gid_t, group)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setresuid
+-SC_TRACE_EVENT(sys_setresuid,
+-	TP_PROTO(uid_t ruid, uid_t euid, uid_t suid),
+-	TP_ARGS(ruid, euid, suid),
+-	TP_STRUCT__entry(__field(uid_t, ruid) __field(uid_t, euid) __field(uid_t, suid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setresgid
+-SC_TRACE_EVENT(sys_setresgid,
+-	TP_PROTO(gid_t rgid, gid_t egid, gid_t sgid),
+-	TP_ARGS(rgid, egid, sgid),
+-	TP_STRUCT__entry(__field(gid_t, rgid) __field(gid_t, egid) __field(gid_t, sgid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_madvise
+-SC_TRACE_EVENT(sys_madvise,
+-	TP_PROTO(unsigned long start, size_t len_in, int behavior),
+-	TP_ARGS(start, len_in, behavior),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len_in) __field(int, behavior)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len_in, len_in) tp_assign(behavior, behavior)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fcntl64
+-SC_TRACE_EVENT(sys_fcntl64,
+-	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
+-	TP_ARGS(fd, cmd, arg),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_tgkill
+-SC_TRACE_EVENT(sys_tgkill,
+-	TP_PROTO(pid_t tgid, pid_t pid, int sig),
+-	TP_ARGS(tgid, pid, sig),
+-	TP_STRUCT__entry(__field(pid_t, tgid) __field(pid_t, pid) __field(int, sig)),
+-	TP_fast_assign(tp_assign(tgid, tgid) tp_assign(pid, pid) tp_assign(sig, sig)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_socket
+-SC_TRACE_EVENT(sys_socket,
+-	TP_PROTO(int family, int type, int protocol),
+-	TP_ARGS(family, type, protocol),
+-	TP_STRUCT__entry(__field(int, family) __field(int, type) __field(int, protocol)),
+-	TP_fast_assign(tp_assign(family, family) tp_assign(type, type) tp_assign(protocol, protocol)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_semget
+-SC_TRACE_EVENT(sys_semget,
+-	TP_PROTO(key_t key, int nsems, int semflg),
+-	TP_ARGS(key, nsems, semflg),
+-	TP_STRUCT__entry(__field(key_t, key) __field(int, nsems) __field(int, semflg)),
+-	TP_fast_assign(tp_assign(key, key) tp_assign(nsems, nsems) tp_assign(semflg, semflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_shmget
+-SC_TRACE_EVENT(sys_shmget,
+-	TP_PROTO(key_t key, size_t size, int shmflg),
+-	TP_ARGS(key, size, shmflg),
+-	TP_STRUCT__entry(__field(key_t, key) __field(size_t, size) __field(int, shmflg)),
+-	TP_fast_assign(tp_assign(key, key) tp_assign(size, size) tp_assign(shmflg, shmflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ioprio_set
+-SC_TRACE_EVENT(sys_ioprio_set,
+-	TP_PROTO(int which, int who, int ioprio),
+-	TP_ARGS(which, who, ioprio),
+-	TP_STRUCT__entry(__field(int, which) __field(int, who) __field(int, ioprio)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(who, who) tp_assign(ioprio, ioprio)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_dup3
+-SC_TRACE_EVENT(sys_dup3,
+-	TP_PROTO(unsigned int oldfd, unsigned int newfd, int flags),
+-	TP_ARGS(oldfd, newfd, flags),
+-	TP_STRUCT__entry(__field(unsigned int, oldfd) __field(unsigned int, newfd) __field(int, flags)),
+-	TP_fast_assign(tp_assign(oldfd, oldfd) tp_assign(newfd, newfd) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ptrace
+-SC_TRACE_EVENT(sys_ptrace,
+-	TP_PROTO(long request, long pid, unsigned long addr, unsigned long data),
+-	TP_ARGS(request, pid, addr, data),
+-	TP_STRUCT__entry(__field(long, request) __field(long, pid) __field_hex(unsigned long, addr) __field(unsigned long, data)),
+-	TP_fast_assign(tp_assign(request, request) tp_assign(pid, pid) tp_assign(addr, addr) tp_assign(data, data)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_tee
+-SC_TRACE_EVENT(sys_tee,
+-	TP_PROTO(int fdin, int fdout, size_t len, unsigned int flags),
+-	TP_ARGS(fdin, fdout, len, flags),
+-	TP_STRUCT__entry(__field(int, fdin) __field(int, fdout) __field(size_t, len) __field(unsigned int, flags)),
+-	TP_fast_assign(tp_assign(fdin, fdin) tp_assign(fdout, fdout) tp_assign(len, len) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mremap
+-SC_TRACE_EVENT(sys_mremap,
+-	TP_PROTO(unsigned long addr, unsigned long old_len, unsigned long new_len, unsigned long flags, unsigned long new_addr),
+-	TP_ARGS(addr, old_len, new_len, flags, new_addr),
+-	TP_STRUCT__entry(__field_hex(unsigned long, addr) __field(unsigned long, old_len) __field(unsigned long, new_len) __field(unsigned long, flags) __field_hex(unsigned long, new_addr)),
+-	TP_fast_assign(tp_assign(addr, addr) tp_assign(old_len, old_len) tp_assign(new_len, new_len) tp_assign(flags, flags) tp_assign(new_addr, new_addr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_prctl
+-SC_TRACE_EVENT(sys_prctl,
+-	TP_PROTO(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5),
+-	TP_ARGS(option, arg2, arg3, arg4, arg5),
+-	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg2) __field(unsigned long, arg3) __field(unsigned long, arg4) __field(unsigned long, arg5)),
+-	TP_fast_assign(tp_assign(option, option) tp_assign(arg2, arg2) tp_assign(arg3, arg3) tp_assign(arg4, arg4) tp_assign(arg5, arg5)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_remap_file_pages
+-SC_TRACE_EVENT(sys_remap_file_pages,
+-	TP_PROTO(unsigned long start, unsigned long size, unsigned long prot, unsigned long pgoff, unsigned long flags),
+-	TP_ARGS(start, size, prot, pgoff, flags),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(unsigned long, size) __field(unsigned long, prot) __field(unsigned long, pgoff) __field(unsigned long, flags)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(size, size) tp_assign(prot, prot) tp_assign(pgoff, pgoff) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_keyctl
+-SC_TRACE_EVENT(sys_keyctl,
+-	TP_PROTO(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5),
+-	TP_ARGS(option, arg2, arg3, arg4, arg5),
+-	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg2) __field(unsigned long, arg3) __field(unsigned long, arg4) __field(unsigned long, arg5)),
+-	TP_fast_assign(tp_assign(option, option) tp_assign(arg2, arg2) tp_assign(arg3, arg3) tp_assign(arg4, arg4) tp_assign(arg5, arg5)),
+-	TP_printk()
+-)
+-#endif
+-
+-#endif /*  _TRACE_SYSCALLS_INTEGERS_H */
+-
+-/* This part must be outside protection */
+-#include "../../../probes/define_trace.h"
+-
+-#else /* CREATE_SYSCALL_TABLE */
+-
+-#include "arm-32-syscalls-2.6.38_integers_override.h"
+-#include "syscalls_integers_override.h"
+-
+-#ifndef OVERRIDE_TABLE_32_sys_restart_syscall
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_restart_syscall, 0, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getpid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getpid, 20, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getuid16
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getuid16, 24, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pause
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_pause, 29, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sync
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_sync, 36, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getgid16
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getgid16, 47, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_geteuid16
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_geteuid16, 49, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getegid16
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getegid16, 50, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getppid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getppid, 64, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getpgrp
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getpgrp, 65, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setsid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_setsid, 66, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_vhangup
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_vhangup, 111, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_munlockall
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_munlockall, 153, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_yield
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_sched_yield, 158, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getuid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getuid, 199, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getgid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getgid, 200, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_geteuid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_geteuid, 201, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getegid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getegid, 202, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_gettid
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_gettid, 224, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_inotify_init
+-TRACE_SYSCALL_TABLE(syscalls_noargs, sys_inotify_init, 316, 0)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_exit
+-TRACE_SYSCALL_TABLE(sys_exit, sys_exit, 1, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_close
+-TRACE_SYSCALL_TABLE(sys_close, sys_close, 6, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lseek
+-TRACE_SYSCALL_TABLE(sys_lseek, sys_lseek, 19, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setuid16
+-TRACE_SYSCALL_TABLE(sys_setuid16, sys_setuid16, 23, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ptrace
+-TRACE_SYSCALL_TABLE(sys_ptrace, sys_ptrace, 26, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_nice
+-TRACE_SYSCALL_TABLE(sys_nice, sys_nice, 34, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_kill
+-TRACE_SYSCALL_TABLE(sys_kill, sys_kill, 37, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_dup
+-TRACE_SYSCALL_TABLE(sys_dup, sys_dup, 41, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_brk
+-TRACE_SYSCALL_TABLE(sys_brk, sys_brk, 45, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setgid16
+-TRACE_SYSCALL_TABLE(sys_setgid16, sys_setgid16, 46, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ioctl
+-TRACE_SYSCALL_TABLE(sys_ioctl, sys_ioctl, 54, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fcntl
+-TRACE_SYSCALL_TABLE(sys_fcntl, sys_fcntl, 55, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setpgid
+-TRACE_SYSCALL_TABLE(sys_setpgid, sys_setpgid, 57, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_umask
+-TRACE_SYSCALL_TABLE(sys_umask, sys_umask, 60, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_dup2
+-TRACE_SYSCALL_TABLE(sys_dup2, sys_dup2, 63, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setreuid16
+-TRACE_SYSCALL_TABLE(sys_setreuid16, sys_setreuid16, 70, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setregid16
+-TRACE_SYSCALL_TABLE(sys_setregid16, sys_setregid16, 71, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_munmap
+-TRACE_SYSCALL_TABLE(sys_munmap, sys_munmap, 91, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ftruncate
+-TRACE_SYSCALL_TABLE(sys_ftruncate, sys_ftruncate, 93, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchmod
+-TRACE_SYSCALL_TABLE(sys_fchmod, sys_fchmod, 94, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchown16
+-TRACE_SYSCALL_TABLE(sys_fchown16, sys_fchown16, 95, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getpriority
+-TRACE_SYSCALL_TABLE(sys_getpriority, sys_getpriority, 96, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setpriority
+-TRACE_SYSCALL_TABLE(sys_setpriority, sys_setpriority, 97, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fsync
+-TRACE_SYSCALL_TABLE(sys_fsync, sys_fsync, 118, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mprotect
+-TRACE_SYSCALL_TABLE(sys_mprotect, sys_mprotect, 125, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getpgid
+-TRACE_SYSCALL_TABLE(sys_getpgid, sys_getpgid, 132, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchdir
+-TRACE_SYSCALL_TABLE(sys_fchdir, sys_fchdir, 133, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_bdflush
+-TRACE_SYSCALL_TABLE(sys_bdflush, sys_bdflush, 134, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sysfs
+-TRACE_SYSCALL_TABLE(sys_sysfs, sys_sysfs, 135, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_personality
+-TRACE_SYSCALL_TABLE(sys_personality, sys_personality, 136, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setfsuid16
+-TRACE_SYSCALL_TABLE(sys_setfsuid16, sys_setfsuid16, 138, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setfsgid16
+-TRACE_SYSCALL_TABLE(sys_setfsgid16, sys_setfsgid16, 139, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_flock
+-TRACE_SYSCALL_TABLE(sys_flock, sys_flock, 143, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_msync
+-TRACE_SYSCALL_TABLE(sys_msync, sys_msync, 144, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getsid
+-TRACE_SYSCALL_TABLE(sys_getsid, sys_getsid, 147, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fdatasync
+-TRACE_SYSCALL_TABLE(sys_fdatasync, sys_fdatasync, 148, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mlock
+-TRACE_SYSCALL_TABLE(sys_mlock, sys_mlock, 150, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_munlock
+-TRACE_SYSCALL_TABLE(sys_munlock, sys_munlock, 151, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mlockall
+-TRACE_SYSCALL_TABLE(sys_mlockall, sys_mlockall, 152, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_getscheduler
+-TRACE_SYSCALL_TABLE(sys_sched_getscheduler, sys_sched_getscheduler, 157, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_get_priority_max
+-TRACE_SYSCALL_TABLE(sys_sched_get_priority_max, sys_sched_get_priority_max, 159, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_get_priority_min
+-TRACE_SYSCALL_TABLE(sys_sched_get_priority_min, sys_sched_get_priority_min, 160, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mremap
+-TRACE_SYSCALL_TABLE(sys_mremap, sys_mremap, 163, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setresuid16
+-TRACE_SYSCALL_TABLE(sys_setresuid16, sys_setresuid16, 164, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setresgid16
+-TRACE_SYSCALL_TABLE(sys_setresgid16, sys_setresgid16, 170, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_prctl
+-TRACE_SYSCALL_TABLE(sys_prctl, sys_prctl, 172, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setreuid
+-TRACE_SYSCALL_TABLE(sys_setreuid, sys_setreuid, 203, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setregid
+-TRACE_SYSCALL_TABLE(sys_setregid, sys_setregid, 204, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchown
+-TRACE_SYSCALL_TABLE(sys_fchown, sys_fchown, 207, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setresuid
+-TRACE_SYSCALL_TABLE(sys_setresuid, sys_setresuid, 208, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setresgid
+-TRACE_SYSCALL_TABLE(sys_setresgid, sys_setresgid, 210, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setuid
+-TRACE_SYSCALL_TABLE(sys_setuid, sys_setuid, 213, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setgid
+-TRACE_SYSCALL_TABLE(sys_setgid, sys_setgid, 214, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setfsuid
+-TRACE_SYSCALL_TABLE(sys_setfsuid, sys_setfsuid, 215, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setfsgid
+-TRACE_SYSCALL_TABLE(sys_setfsgid, sys_setfsgid, 216, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_madvise
+-TRACE_SYSCALL_TABLE(sys_madvise, sys_madvise, 220, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fcntl64
+-TRACE_SYSCALL_TABLE(sys_fcntl64, sys_fcntl64, 221, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_tkill
+-TRACE_SYSCALL_TABLE(sys_tkill, sys_tkill, 238, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_io_destroy
+-TRACE_SYSCALL_TABLE(sys_io_destroy, sys_io_destroy, 244, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_exit_group
+-TRACE_SYSCALL_TABLE(sys_exit_group, sys_exit_group, 248, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_epoll_create
+-TRACE_SYSCALL_TABLE(sys_epoll_create, sys_epoll_create, 250, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_remap_file_pages
+-TRACE_SYSCALL_TABLE(sys_remap_file_pages, sys_remap_file_pages, 253, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timer_getoverrun
+-TRACE_SYSCALL_TABLE(sys_timer_getoverrun, sys_timer_getoverrun, 260, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timer_delete
+-TRACE_SYSCALL_TABLE(sys_timer_delete, sys_timer_delete, 261, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_tgkill
+-TRACE_SYSCALL_TABLE(sys_tgkill, sys_tgkill, 268, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_socket
+-TRACE_SYSCALL_TABLE(sys_socket, sys_socket, 281, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_listen
+-TRACE_SYSCALL_TABLE(sys_listen, sys_listen, 284, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_shutdown
+-TRACE_SYSCALL_TABLE(sys_shutdown, sys_shutdown, 293, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_semget
+-TRACE_SYSCALL_TABLE(sys_semget, sys_semget, 299, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_msgget
+-TRACE_SYSCALL_TABLE(sys_msgget, sys_msgget, 303, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_shmget
+-TRACE_SYSCALL_TABLE(sys_shmget, sys_shmget, 307, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_keyctl
+-TRACE_SYSCALL_TABLE(sys_keyctl, sys_keyctl, 311, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ioprio_set
+-TRACE_SYSCALL_TABLE(sys_ioprio_set, sys_ioprio_set, 314, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ioprio_get
+-TRACE_SYSCALL_TABLE(sys_ioprio_get, sys_ioprio_get, 315, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_inotify_rm_watch
+-TRACE_SYSCALL_TABLE(sys_inotify_rm_watch, sys_inotify_rm_watch, 318, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_unshare
+-TRACE_SYSCALL_TABLE(sys_unshare, sys_unshare, 337, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_tee
+-TRACE_SYSCALL_TABLE(sys_tee, sys_tee, 342, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timerfd_create
+-TRACE_SYSCALL_TABLE(sys_timerfd_create, sys_timerfd_create, 350, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_eventfd
+-TRACE_SYSCALL_TABLE(sys_eventfd, sys_eventfd, 351, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_eventfd2
+-TRACE_SYSCALL_TABLE(sys_eventfd2, sys_eventfd2, 356, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_epoll_create1
+-TRACE_SYSCALL_TABLE(sys_epoll_create1, sys_epoll_create1, 357, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_dup3
+-TRACE_SYSCALL_TABLE(sys_dup3, sys_dup3, 358, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_inotify_init1
+-TRACE_SYSCALL_TABLE(sys_inotify_init1, sys_inotify_init1, 360, 1)
+-#endif
+-
+-#endif /* CREATE_SYSCALL_TABLE */
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers_override.h b/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers_override.h
+deleted file mode 100644
+index 895370f..0000000
+--- a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_integers_override.h
++++ /dev/null
+@@ -1,52 +0,0 @@
+-
+-
+-#define OVERRIDE_TABLE_32_sys_arm_fadvise64_64
+-#define OVERRIDE_TABLE_32_sys_sync_file_range2
+-
+-#ifndef CREATE_SYSCALL_TABLE
+-
+-SC_TRACE_EVENT(sys_arm_fadvise64_64,
+-	TP_PROTO(int fd, int advice, loff_t offset, loff_t len),
+-	TP_ARGS(fd, advice, offset, len),
+-	TP_STRUCT__entry(
+-		__field_hex(int, fd)
+-		__field_hex(int, advice)
+-		__field_hex(loff_t, offset)
+-		__field_hex(loff_t, len)),
+-	TP_fast_assign(
+-		tp_assign(fd, fd)
+-		tp_assign(advice, advice)
+-		tp_assign(offset, offset)
+-		tp_assign(len, len)),
+-	TP_printk()
+-)
+-
+-SC_TRACE_EVENT(sys_sync_file_range2,
+-	TP_PROTO(int fd, loff_t offset, loff_t nbytes, unsigned int flags),
+-	TP_ARGS(fd, offset, nbytes, flags),
+-	TP_STRUCT__entry(
+-		__field_hex(int, fd)
+-		__field_hex(loff_t, offset)
+-		__field_hex(loff_t, nbytes)
+-		__field_hex(unsigned int, flags)),
+-	TP_fast_assign(
+-		tp_assign(fd, fd)
+-		tp_assign(offset, offset)
+-		tp_assign(nbytes, nbytes)
+-		tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-
+-#else	/* CREATE_SYSCALL_TABLE */
+-
+-#define OVVERRIDE_TABLE_32_sys_mmap
+-TRACE_SYSCALL_TABLE(sys_mmap, sys_mmap, 90, 6)
+-
+-#define OVERRIDE_TABLE_32_sys_arm_fadvise64_64
+-TRACE_SYSCALL_TABLE(sys_arm_fadvise64_64, sys_arm_fadvise64_64, 270, 4)
+-#define OVERRIDE_TABLE_32_sys_sync_file_range2
+-TRACE_SYSCALL_TABLE(sys_sync_file_range2, sys_sync_file_range2, 341, 4)
+-
+-#endif /* CREATE_SYSCALL_TABLE */
+-
+-
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers.h b/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers.h
+deleted file mode 100644
+index fc3d8a1..0000000
+--- a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers.h
++++ /dev/null
+@@ -1,2184 +0,0 @@
+-/* THIS FILE IS AUTO-GENERATED. DO NOT EDIT */
+-#ifndef CREATE_SYSCALL_TABLE
+-
+-#if !defined(_TRACE_SYSCALLS_POINTERS_H) || defined(TRACE_HEADER_MULTI_READ)
+-#define _TRACE_SYSCALLS_POINTERS_H
+-
+-#include <linux/tracepoint.h>
+-#include <linux/syscalls.h>
+-#include "arm-32-syscalls-2.6.38_pointers_override.h"
+-#include "syscalls_pointers_override.h"
+-
+-#ifndef OVERRIDE_32_sys_unlink
+-SC_TRACE_EVENT(sys_unlink,
+-	TP_PROTO(const char * pathname),
+-	TP_ARGS(pathname),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_chdir
+-SC_TRACE_EVENT(sys_chdir,
+-	TP_PROTO(const char * filename),
+-	TP_ARGS(filename),
+-	TP_STRUCT__entry(__string_from_user(filename, filename)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rmdir
+-SC_TRACE_EVENT(sys_rmdir,
+-	TP_PROTO(const char * pathname),
+-	TP_ARGS(pathname),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_pipe
+-SC_TRACE_EVENT(sys_pipe,
+-	TP_PROTO(int * fildes),
+-	TP_ARGS(fildes),
+-	TP_STRUCT__entry(__field_hex(int *, fildes)),
+-	TP_fast_assign(tp_assign(fildes, fildes)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_times
+-SC_TRACE_EVENT(sys_times,
+-	TP_PROTO(struct tms * tbuf),
+-	TP_ARGS(tbuf),
+-	TP_STRUCT__entry(__field_hex(struct tms *, tbuf)),
+-	TP_fast_assign(tp_assign(tbuf, tbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_chroot
+-SC_TRACE_EVENT(sys_chroot,
+-	TP_PROTO(const char * filename),
+-	TP_ARGS(filename),
+-	TP_STRUCT__entry(__string_from_user(filename, filename)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sigpending
+-SC_TRACE_EVENT(sys_sigpending,
+-	TP_PROTO(old_sigset_t * set),
+-	TP_ARGS(set),
+-	TP_STRUCT__entry(__field_hex(old_sigset_t *, set)),
+-	TP_fast_assign(tp_assign(set, set)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_uselib
+-SC_TRACE_EVENT(sys_uselib,
+-	TP_PROTO(const char * library),
+-	TP_ARGS(library),
+-	TP_STRUCT__entry(__field_hex(const char *, library)),
+-	TP_fast_assign(tp_assign(library, library)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sysinfo
+-SC_TRACE_EVENT(sys_sysinfo,
+-	TP_PROTO(struct sysinfo * info),
+-	TP_ARGS(info),
+-	TP_STRUCT__entry(__field_hex(struct sysinfo *, info)),
+-	TP_fast_assign(tp_assign(info, info)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_newuname
+-SC_TRACE_EVENT(sys_newuname,
+-	TP_PROTO(struct new_utsname * name),
+-	TP_ARGS(name),
+-	TP_STRUCT__entry(__field_hex(struct new_utsname *, name)),
+-	TP_fast_assign(tp_assign(name, name)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_adjtimex
+-SC_TRACE_EVENT(sys_adjtimex,
+-	TP_PROTO(struct timex * txc_p),
+-	TP_ARGS(txc_p),
+-	TP_STRUCT__entry(__field_hex(struct timex *, txc_p)),
+-	TP_fast_assign(tp_assign(txc_p, txc_p)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sysctl
+-SC_TRACE_EVENT(sys_sysctl,
+-	TP_PROTO(struct __sysctl_args * args),
+-	TP_ARGS(args),
+-	TP_STRUCT__entry(__field_hex(struct __sysctl_args *, args)),
+-	TP_fast_assign(tp_assign(args, args)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_set_tid_address
+-SC_TRACE_EVENT(sys_set_tid_address,
+-	TP_PROTO(int * tidptr),
+-	TP_ARGS(tidptr),
+-	TP_STRUCT__entry(__field_hex(int *, tidptr)),
+-	TP_fast_assign(tp_assign(tidptr, tidptr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_unlink
+-SC_TRACE_EVENT(sys_mq_unlink,
+-	TP_PROTO(const char * u_name),
+-	TP_ARGS(u_name),
+-	TP_STRUCT__entry(__string_from_user(u_name, u_name)),
+-	TP_fast_assign(tp_copy_string_from_user(u_name, u_name)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_shmdt
+-SC_TRACE_EVENT(sys_shmdt,
+-	TP_PROTO(char * shmaddr),
+-	TP_ARGS(shmaddr),
+-	TP_STRUCT__entry(__field_hex(char *, shmaddr)),
+-	TP_fast_assign(tp_assign(shmaddr, shmaddr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_creat
+-SC_TRACE_EVENT(sys_creat,
+-	TP_PROTO(const char * pathname, int mode),
+-	TP_ARGS(pathname, mode),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field(int, mode)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_link
+-SC_TRACE_EVENT(sys_link,
+-	TP_PROTO(const char * oldname, const char * newname),
+-	TP_ARGS(oldname, newname),
+-	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
+-	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_chmod
+-SC_TRACE_EVENT(sys_chmod,
+-	TP_PROTO(const char * filename, mode_t mode),
+-	TP_ARGS(filename, mode),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(mode_t, mode)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_access
+-SC_TRACE_EVENT(sys_access,
+-	TP_PROTO(const char * filename, int mode),
+-	TP_ARGS(filename, mode),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(int, mode)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rename
+-SC_TRACE_EVENT(sys_rename,
+-	TP_PROTO(const char * oldname, const char * newname),
+-	TP_ARGS(oldname, newname),
+-	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
+-	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mkdir
+-SC_TRACE_EVENT(sys_mkdir,
+-	TP_PROTO(const char * pathname, int mode),
+-	TP_ARGS(pathname, mode),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field(int, mode)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_umount
+-SC_TRACE_EVENT(sys_umount,
+-	TP_PROTO(char * name, int flags),
+-	TP_ARGS(name, flags),
+-	TP_STRUCT__entry(__string_from_user(name, name) __field(int, flags)),
+-	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ustat
+-SC_TRACE_EVENT(sys_ustat,
+-	TP_PROTO(unsigned dev, struct ustat * ubuf),
+-	TP_ARGS(dev, ubuf),
+-	TP_STRUCT__entry(__field(unsigned, dev) __field_hex(struct ustat *, ubuf)),
+-	TP_fast_assign(tp_assign(dev, dev) tp_assign(ubuf, ubuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sethostname
+-SC_TRACE_EVENT(sys_sethostname,
+-	TP_PROTO(char * name, int len),
+-	TP_ARGS(name, len),
+-	TP_STRUCT__entry(__string_from_user(name, name) __field(int, len)),
+-	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setrlimit
+-SC_TRACE_EVENT(sys_setrlimit,
+-	TP_PROTO(unsigned int resource, struct rlimit * rlim),
+-	TP_ARGS(resource, rlim),
+-	TP_STRUCT__entry(__field(unsigned int, resource) __field_hex(struct rlimit *, rlim)),
+-	TP_fast_assign(tp_assign(resource, resource) tp_assign(rlim, rlim)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getrusage
+-SC_TRACE_EVENT(sys_getrusage,
+-	TP_PROTO(int who, struct rusage * ru),
+-	TP_ARGS(who, ru),
+-	TP_STRUCT__entry(__field(int, who) __field_hex(struct rusage *, ru)),
+-	TP_fast_assign(tp_assign(who, who) tp_assign(ru, ru)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_gettimeofday
+-SC_TRACE_EVENT(sys_gettimeofday,
+-	TP_PROTO(struct timeval * tv, struct timezone * tz),
+-	TP_ARGS(tv, tz),
+-	TP_STRUCT__entry(__field_hex(struct timeval *, tv) __field_hex(struct timezone *, tz)),
+-	TP_fast_assign(tp_assign(tv, tv) tp_assign(tz, tz)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_settimeofday
+-SC_TRACE_EVENT(sys_settimeofday,
+-	TP_PROTO(struct timeval * tv, struct timezone * tz),
+-	TP_ARGS(tv, tz),
+-	TP_STRUCT__entry(__field_hex(struct timeval *, tv) __field_hex(struct timezone *, tz)),
+-	TP_fast_assign(tp_assign(tv, tv) tp_assign(tz, tz)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getgroups16
+-SC_TRACE_EVENT(sys_getgroups16,
+-	TP_PROTO(int gidsetsize, old_gid_t * grouplist),
+-	TP_ARGS(gidsetsize, grouplist),
+-	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(old_gid_t *, grouplist)),
+-	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setgroups16
+-SC_TRACE_EVENT(sys_setgroups16,
+-	TP_PROTO(int gidsetsize, old_gid_t * grouplist),
+-	TP_ARGS(gidsetsize, grouplist),
+-	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(old_gid_t *, grouplist)),
+-	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_symlink
+-SC_TRACE_EVENT(sys_symlink,
+-	TP_PROTO(const char * oldname, const char * newname),
+-	TP_ARGS(oldname, newname),
+-	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
+-	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_truncate
+-SC_TRACE_EVENT(sys_truncate,
+-	TP_PROTO(const char * path, long length),
+-	TP_ARGS(path, length),
+-	TP_STRUCT__entry(__string_from_user(path, path) __field(long, length)),
+-	TP_fast_assign(tp_copy_string_from_user(path, path) tp_assign(length, length)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_statfs
+-SC_TRACE_EVENT(sys_statfs,
+-	TP_PROTO(const char * pathname, struct statfs * buf),
+-	TP_ARGS(pathname, buf),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(struct statfs *, buf)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(buf, buf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fstatfs
+-SC_TRACE_EVENT(sys_fstatfs,
+-	TP_PROTO(unsigned int fd, struct statfs * buf),
+-	TP_ARGS(fd, buf),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct statfs *, buf)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getitimer
+-SC_TRACE_EVENT(sys_getitimer,
+-	TP_PROTO(int which, struct itimerval * value),
+-	TP_ARGS(which, value),
+-	TP_STRUCT__entry(__field(int, which) __field_hex(struct itimerval *, value)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(value, value)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_newstat
+-SC_TRACE_EVENT(sys_newstat,
+-	TP_PROTO(const char * filename, struct stat * statbuf),
+-	TP_ARGS(filename, statbuf),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat *, statbuf)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_newlstat
+-SC_TRACE_EVENT(sys_newlstat,
+-	TP_PROTO(const char * filename, struct stat * statbuf),
+-	TP_ARGS(filename, statbuf),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat *, statbuf)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_newfstat
+-SC_TRACE_EVENT(sys_newfstat,
+-	TP_PROTO(unsigned int fd, struct stat * statbuf),
+-	TP_ARGS(fd, statbuf),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct stat *, statbuf)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setdomainname
+-SC_TRACE_EVENT(sys_setdomainname,
+-	TP_PROTO(char * name, int len),
+-	TP_ARGS(name, len),
+-	TP_STRUCT__entry(__string_from_user(name, name) __field(int, len)),
+-	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_delete_module
+-SC_TRACE_EVENT(sys_delete_module,
+-	TP_PROTO(const char * name_user, unsigned int flags),
+-	TP_ARGS(name_user, flags),
+-	TP_STRUCT__entry(__string_from_user(name_user, name_user) __field(unsigned int, flags)),
+-	TP_fast_assign(tp_copy_string_from_user(name_user, name_user) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_setparam
+-SC_TRACE_EVENT(sys_sched_setparam,
+-	TP_PROTO(pid_t pid, struct sched_param * param),
+-	TP_ARGS(pid, param),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct sched_param *, param)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(param, param)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_getparam
+-SC_TRACE_EVENT(sys_sched_getparam,
+-	TP_PROTO(pid_t pid, struct sched_param * param),
+-	TP_ARGS(pid, param),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct sched_param *, param)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(param, param)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_rr_get_interval
+-SC_TRACE_EVENT(sys_sched_rr_get_interval,
+-	TP_PROTO(pid_t pid, struct timespec * interval),
+-	TP_ARGS(pid, interval),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct timespec *, interval)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(interval, interval)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_nanosleep
+-SC_TRACE_EVENT(sys_nanosleep,
+-	TP_PROTO(struct timespec * rqtp, struct timespec * rmtp),
+-	TP_ARGS(rqtp, rmtp),
+-	TP_STRUCT__entry(__field_hex(struct timespec *, rqtp) __field_hex(struct timespec *, rmtp)),
+-	TP_fast_assign(tp_assign(rqtp, rqtp) tp_assign(rmtp, rmtp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigpending
+-SC_TRACE_EVENT(sys_rt_sigpending,
+-	TP_PROTO(sigset_t * set, size_t sigsetsize),
+-	TP_ARGS(set, sigsetsize),
+-	TP_STRUCT__entry(__field_hex(sigset_t *, set) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(set, set) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigsuspend
+-SC_TRACE_EVENT(sys_rt_sigsuspend,
+-	TP_PROTO(sigset_t * unewset, size_t sigsetsize),
+-	TP_ARGS(unewset, sigsetsize),
+-	TP_STRUCT__entry(__field_hex(sigset_t *, unewset) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(unewset, unewset) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getcwd
+-SC_TRACE_EVENT(sys_getcwd,
+-	TP_PROTO(char * buf, unsigned long size),
+-	TP_ARGS(buf, size),
+-	TP_STRUCT__entry(__field_hex(char *, buf) __field(unsigned long, size)),
+-	TP_fast_assign(tp_assign(buf, buf) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getrlimit
+-SC_TRACE_EVENT(sys_getrlimit,
+-	TP_PROTO(unsigned int resource, struct rlimit * rlim),
+-	TP_ARGS(resource, rlim),
+-	TP_STRUCT__entry(__field(unsigned int, resource) __field_hex(struct rlimit *, rlim)),
+-	TP_fast_assign(tp_assign(resource, resource) tp_assign(rlim, rlim)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_stat64
+-SC_TRACE_EVENT(sys_stat64,
+-	TP_PROTO(const char * filename, struct stat64 * statbuf),
+-	TP_ARGS(filename, statbuf),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lstat64
+-SC_TRACE_EVENT(sys_lstat64,
+-	TP_PROTO(const char * filename, struct stat64 * statbuf),
+-	TP_ARGS(filename, statbuf),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fstat64
+-SC_TRACE_EVENT(sys_fstat64,
+-	TP_PROTO(unsigned long fd, struct stat64 * statbuf),
+-	TP_ARGS(fd, statbuf),
+-	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(struct stat64 *, statbuf)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(statbuf, statbuf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getgroups
+-SC_TRACE_EVENT(sys_getgroups,
+-	TP_PROTO(int gidsetsize, gid_t * grouplist),
+-	TP_ARGS(gidsetsize, grouplist),
+-	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(gid_t *, grouplist)),
+-	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setgroups
+-SC_TRACE_EVENT(sys_setgroups,
+-	TP_PROTO(int gidsetsize, gid_t * grouplist),
+-	TP_ARGS(gidsetsize, grouplist),
+-	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(gid_t *, grouplist)),
+-	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_pivot_root
+-SC_TRACE_EVENT(sys_pivot_root,
+-	TP_PROTO(const char * new_root, const char * put_old),
+-	TP_ARGS(new_root, put_old),
+-	TP_STRUCT__entry(__string_from_user(new_root, new_root) __string_from_user(put_old, put_old)),
+-	TP_fast_assign(tp_copy_string_from_user(new_root, new_root) tp_copy_string_from_user(put_old, put_old)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_removexattr
+-SC_TRACE_EVENT(sys_removexattr,
+-	TP_PROTO(const char * pathname, const char * name),
+-	TP_ARGS(pathname, name),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lremovexattr
+-SC_TRACE_EVENT(sys_lremovexattr,
+-	TP_PROTO(const char * pathname, const char * name),
+-	TP_ARGS(pathname, name),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fremovexattr
+-SC_TRACE_EVENT(sys_fremovexattr,
+-	TP_PROTO(int fd, const char * name),
+-	TP_ARGS(fd, name),
+-	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_io_setup
+-SC_TRACE_EVENT(sys_io_setup,
+-	TP_PROTO(unsigned nr_events, aio_context_t * ctxp),
+-	TP_ARGS(nr_events, ctxp),
+-	TP_STRUCT__entry(__field(unsigned, nr_events) __field_hex(aio_context_t *, ctxp)),
+-	TP_fast_assign(tp_assign(nr_events, nr_events) tp_assign(ctxp, ctxp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timer_gettime
+-SC_TRACE_EVENT(sys_timer_gettime,
+-	TP_PROTO(timer_t timer_id, struct itimerspec * setting),
+-	TP_ARGS(timer_id, setting),
+-	TP_STRUCT__entry(__field(timer_t, timer_id) __field_hex(struct itimerspec *, setting)),
+-	TP_fast_assign(tp_assign(timer_id, timer_id) tp_assign(setting, setting)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_clock_settime
+-SC_TRACE_EVENT(sys_clock_settime,
+-	TP_PROTO(const clockid_t which_clock, const struct timespec * tp),
+-	TP_ARGS(which_clock, tp),
+-	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(const struct timespec *, tp)),
+-	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_clock_gettime
+-SC_TRACE_EVENT(sys_clock_gettime,
+-	TP_PROTO(const clockid_t which_clock, struct timespec * tp),
+-	TP_ARGS(which_clock, tp),
+-	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct timespec *, tp)),
+-	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_clock_getres
+-SC_TRACE_EVENT(sys_clock_getres,
+-	TP_PROTO(const clockid_t which_clock, struct timespec * tp),
+-	TP_ARGS(which_clock, tp),
+-	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct timespec *, tp)),
+-	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_utimes
+-SC_TRACE_EVENT(sys_utimes,
+-	TP_PROTO(char * filename, struct timeval * utimes),
+-	TP_ARGS(filename, utimes),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct timeval *, utimes)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_notify
+-SC_TRACE_EVENT(sys_mq_notify,
+-	TP_PROTO(mqd_t mqdes, const struct sigevent * u_notification),
+-	TP_ARGS(mqdes, u_notification),
+-	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const struct sigevent *, u_notification)),
+-	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_notification, u_notification)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_set_robust_list
+-SC_TRACE_EVENT(sys_set_robust_list,
+-	TP_PROTO(struct robust_list_head * head, size_t len),
+-	TP_ARGS(head, len),
+-	TP_STRUCT__entry(__field_hex(struct robust_list_head *, head) __field(size_t, len)),
+-	TP_fast_assign(tp_assign(head, head) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timerfd_gettime
+-SC_TRACE_EVENT(sys_timerfd_gettime,
+-	TP_PROTO(int ufd, struct itimerspec * otmr),
+-	TP_ARGS(ufd, otmr),
+-	TP_STRUCT__entry(__field(int, ufd) __field_hex(struct itimerspec *, otmr)),
+-	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(otmr, otmr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_pipe2
+-SC_TRACE_EVENT(sys_pipe2,
+-	TP_PROTO(int * fildes, int flags),
+-	TP_ARGS(fildes, flags),
+-	TP_STRUCT__entry(__field_hex(int *, fildes) __field(int, flags)),
+-	TP_fast_assign(tp_assign(fildes, fildes) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_read
+-SC_TRACE_EVENT(sys_read,
+-	TP_PROTO(unsigned int fd, char * buf, size_t count),
+-	TP_ARGS(fd, buf, count),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(char *, buf) __field(size_t, count)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_write
+-SC_TRACE_EVENT(sys_write,
+-	TP_PROTO(unsigned int fd, const char * buf, size_t count),
+-	TP_ARGS(fd, buf, count),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(const char *, buf) __field(size_t, count)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_open
+-SC_TRACE_EVENT(sys_open,
+-	TP_PROTO(const char * filename, int flags, int mode),
+-	TP_ARGS(filename, flags, mode),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(int, flags) __field(int, mode)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(flags, flags) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mknod
+-SC_TRACE_EVENT(sys_mknod,
+-	TP_PROTO(const char * filename, int mode, unsigned dev),
+-	TP_ARGS(filename, mode, dev),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(int, mode) __field(unsigned, dev)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode) tp_assign(dev, dev)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lchown16
+-SC_TRACE_EVENT(sys_lchown16,
+-	TP_PROTO(const char * filename, old_uid_t user, old_gid_t group),
+-	TP_ARGS(filename, user, group),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(old_uid_t, user) __field(old_gid_t, group)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_readlink
+-SC_TRACE_EVENT(sys_readlink,
+-	TP_PROTO(const char * path, char * buf, int bufsiz),
+-	TP_ARGS(path, buf, bufsiz),
+-	TP_STRUCT__entry(__string_from_user(path, path) __field_hex(char *, buf) __field(int, bufsiz)),
+-	TP_fast_assign(tp_copy_string_from_user(path, path) tp_assign(buf, buf) tp_assign(bufsiz, bufsiz)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_syslog
+-SC_TRACE_EVENT(sys_syslog,
+-	TP_PROTO(int type, char * buf, int len),
+-	TP_ARGS(type, buf, len),
+-	TP_STRUCT__entry(__field(int, type) __field_hex(char *, buf) __field(int, len)),
+-	TP_fast_assign(tp_assign(type, type) tp_assign(buf, buf) tp_assign(len, len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setitimer
+-SC_TRACE_EVENT(sys_setitimer,
+-	TP_PROTO(int which, struct itimerval * value, struct itimerval * ovalue),
+-	TP_ARGS(which, value, ovalue),
+-	TP_STRUCT__entry(__field(int, which) __field_hex(struct itimerval *, value) __field_hex(struct itimerval *, ovalue)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(value, value) tp_assign(ovalue, ovalue)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sigprocmask
+-SC_TRACE_EVENT(sys_sigprocmask,
+-	TP_PROTO(int how, old_sigset_t * set, old_sigset_t * oset),
+-	TP_ARGS(how, set, oset),
+-	TP_STRUCT__entry(__field(int, how) __field_hex(old_sigset_t *, set) __field_hex(old_sigset_t *, oset)),
+-	TP_fast_assign(tp_assign(how, how) tp_assign(set, set) tp_assign(oset, oset)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_init_module
+-SC_TRACE_EVENT(sys_init_module,
+-	TP_PROTO(void * umod, unsigned long len, const char * uargs),
+-	TP_ARGS(umod, len, uargs),
+-	TP_STRUCT__entry(__field_hex(void *, umod) __field(unsigned long, len) __field_hex(const char *, uargs)),
+-	TP_fast_assign(tp_assign(umod, umod) tp_assign(len, len) tp_assign(uargs, uargs)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getdents
+-SC_TRACE_EVENT(sys_getdents,
+-	TP_PROTO(unsigned int fd, struct linux_dirent * dirent, unsigned int count),
+-	TP_ARGS(fd, dirent, count),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct linux_dirent *, dirent) __field(unsigned int, count)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(dirent, dirent) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_readv
+-SC_TRACE_EVENT(sys_readv,
+-	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen),
+-	TP_ARGS(fd, vec, vlen),
+-	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_writev
+-SC_TRACE_EVENT(sys_writev,
+-	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen),
+-	TP_ARGS(fd, vec, vlen),
+-	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_setscheduler
+-SC_TRACE_EVENT(sys_sched_setscheduler,
+-	TP_PROTO(pid_t pid, int policy, struct sched_param * param),
+-	TP_ARGS(pid, policy, param),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(int, policy) __field_hex(struct sched_param *, param)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(policy, policy) tp_assign(param, param)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getresuid16
+-SC_TRACE_EVENT(sys_getresuid16,
+-	TP_PROTO(old_uid_t * ruid, old_uid_t * euid, old_uid_t * suid),
+-	TP_ARGS(ruid, euid, suid),
+-	TP_STRUCT__entry(__field_hex(old_uid_t *, ruid) __field_hex(old_uid_t *, euid) __field_hex(old_uid_t *, suid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_poll
+-SC_TRACE_EVENT(sys_poll,
+-	TP_PROTO(struct pollfd * ufds, unsigned int nfds, long timeout_msecs),
+-	TP_ARGS(ufds, nfds, timeout_msecs),
+-	TP_STRUCT__entry(__field_hex(struct pollfd *, ufds) __field(unsigned int, nfds) __field(long, timeout_msecs)),
+-	TP_fast_assign(tp_assign(ufds, ufds) tp_assign(nfds, nfds) tp_assign(timeout_msecs, timeout_msecs)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getresgid16
+-SC_TRACE_EVENT(sys_getresgid16,
+-	TP_PROTO(old_gid_t * rgid, old_gid_t * egid, old_gid_t * sgid),
+-	TP_ARGS(rgid, egid, sgid),
+-	TP_STRUCT__entry(__field_hex(old_gid_t *, rgid) __field_hex(old_gid_t *, egid) __field_hex(old_gid_t *, sgid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigqueueinfo
+-SC_TRACE_EVENT(sys_rt_sigqueueinfo,
+-	TP_PROTO(pid_t pid, int sig, siginfo_t * uinfo),
+-	TP_ARGS(pid, sig, uinfo),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig) __field_hex(siginfo_t *, uinfo)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig) tp_assign(uinfo, uinfo)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_chown16
+-SC_TRACE_EVENT(sys_chown16,
+-	TP_PROTO(const char * filename, old_uid_t user, old_gid_t group),
+-	TP_ARGS(filename, user, group),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(old_uid_t, user) __field(old_gid_t, group)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lchown
+-SC_TRACE_EVENT(sys_lchown,
+-	TP_PROTO(const char * filename, uid_t user, gid_t group),
+-	TP_ARGS(filename, user, group),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getresuid
+-SC_TRACE_EVENT(sys_getresuid,
+-	TP_PROTO(uid_t * ruid, uid_t * euid, uid_t * suid),
+-	TP_ARGS(ruid, euid, suid),
+-	TP_STRUCT__entry(__field_hex(uid_t *, ruid) __field_hex(uid_t *, euid) __field_hex(uid_t *, suid)),
+-	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getresgid
+-SC_TRACE_EVENT(sys_getresgid,
+-	TP_PROTO(gid_t * rgid, gid_t * egid, gid_t * sgid),
+-	TP_ARGS(rgid, egid, sgid),
+-	TP_STRUCT__entry(__field_hex(gid_t *, rgid) __field_hex(gid_t *, egid) __field_hex(gid_t *, sgid)),
+-	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_chown
+-SC_TRACE_EVENT(sys_chown,
+-	TP_PROTO(const char * filename, uid_t user, gid_t group),
+-	TP_ARGS(filename, user, group),
+-	TP_STRUCT__entry(__string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group)),
+-	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getdents64
+-SC_TRACE_EVENT(sys_getdents64,
+-	TP_PROTO(unsigned int fd, struct linux_dirent64 * dirent, unsigned int count),
+-	TP_ARGS(fd, dirent, count),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct linux_dirent64 *, dirent) __field(unsigned int, count)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(dirent, dirent) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mincore
+-SC_TRACE_EVENT(sys_mincore,
+-	TP_PROTO(unsigned long start, size_t len, unsigned char * vec),
+-	TP_ARGS(start, len, vec),
+-	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field_hex(unsigned char *, vec)),
+-	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(vec, vec)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_listxattr
+-SC_TRACE_EVENT(sys_listxattr,
+-	TP_PROTO(const char * pathname, char * list, size_t size),
+-	TP_ARGS(pathname, list, size),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(char *, list) __field(size_t, size)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(list, list) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_llistxattr
+-SC_TRACE_EVENT(sys_llistxattr,
+-	TP_PROTO(const char * pathname, char * list, size_t size),
+-	TP_ARGS(pathname, list, size),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(char *, list) __field(size_t, size)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(list, list) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_flistxattr
+-SC_TRACE_EVENT(sys_flistxattr,
+-	TP_PROTO(int fd, char * list, size_t size),
+-	TP_ARGS(fd, list, size),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(char *, list) __field(size_t, size)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(list, list) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_setaffinity
+-SC_TRACE_EVENT(sys_sched_setaffinity,
+-	TP_PROTO(pid_t pid, unsigned int len, unsigned long * user_mask_ptr),
+-	TP_ARGS(pid, len, user_mask_ptr),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, len) __field_hex(unsigned long *, user_mask_ptr)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(len, len) tp_assign(user_mask_ptr, user_mask_ptr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sched_getaffinity
+-SC_TRACE_EVENT(sys_sched_getaffinity,
+-	TP_PROTO(pid_t pid, unsigned int len, unsigned long * user_mask_ptr),
+-	TP_ARGS(pid, len, user_mask_ptr),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, len) __field_hex(unsigned long *, user_mask_ptr)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(len, len) tp_assign(user_mask_ptr, user_mask_ptr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_io_submit
+-SC_TRACE_EVENT(sys_io_submit,
+-	TP_PROTO(aio_context_t ctx_id, long nr, struct iocb * * iocbpp),
+-	TP_ARGS(ctx_id, nr, iocbpp),
+-	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field(long, nr) __field_hex(struct iocb * *, iocbpp)),
+-	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(nr, nr) tp_assign(iocbpp, iocbpp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_io_cancel
+-SC_TRACE_EVENT(sys_io_cancel,
+-	TP_PROTO(aio_context_t ctx_id, struct iocb * iocb, struct io_event * result),
+-	TP_ARGS(ctx_id, iocb, result),
+-	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field_hex(struct iocb *, iocb) __field_hex(struct io_event *, result)),
+-	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(iocb, iocb) tp_assign(result, result)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timer_create
+-SC_TRACE_EVENT(sys_timer_create,
+-	TP_PROTO(const clockid_t which_clock, struct sigevent * timer_event_spec, timer_t * created_timer_id),
+-	TP_ARGS(which_clock, timer_event_spec, created_timer_id),
+-	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct sigevent *, timer_event_spec) __field_hex(timer_t *, created_timer_id)),
+-	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(timer_event_spec, timer_event_spec) tp_assign(created_timer_id, created_timer_id)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_getsetattr
+-SC_TRACE_EVENT(sys_mq_getsetattr,
+-	TP_PROTO(mqd_t mqdes, const struct mq_attr * u_mqstat, struct mq_attr * u_omqstat),
+-	TP_ARGS(mqdes, u_mqstat, u_omqstat),
+-	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const struct mq_attr *, u_mqstat) __field_hex(struct mq_attr *, u_omqstat)),
+-	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_mqstat, u_mqstat) tp_assign(u_omqstat, u_omqstat)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_bind
+-SC_TRACE_EVENT(sys_bind,
+-	TP_PROTO(int fd, struct sockaddr * umyaddr, int addrlen),
+-	TP_ARGS(fd, umyaddr, addrlen),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, umyaddr) __field_hex(int, addrlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(umyaddr, umyaddr) tp_assign(addrlen, addrlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_connect
+-SC_TRACE_EVENT(sys_connect,
+-	TP_PROTO(int fd, struct sockaddr * uservaddr, int addrlen),
+-	TP_ARGS(fd, uservaddr, addrlen),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, uservaddr) __field_hex(int, addrlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(uservaddr, uservaddr) tp_assign(addrlen, addrlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_accept
+-SC_TRACE_EVENT(sys_accept,
+-	TP_PROTO(int fd, struct sockaddr * upeer_sockaddr, int * upeer_addrlen),
+-	TP_ARGS(fd, upeer_sockaddr, upeer_addrlen),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, upeer_sockaddr) __field_hex(int *, upeer_addrlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(upeer_sockaddr, upeer_sockaddr) tp_assign(upeer_addrlen, upeer_addrlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getsockname
+-SC_TRACE_EVENT(sys_getsockname,
+-	TP_PROTO(int fd, struct sockaddr * usockaddr, int * usockaddr_len),
+-	TP_ARGS(fd, usockaddr, usockaddr_len),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, usockaddr) __field_hex(int *, usockaddr_len)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(usockaddr, usockaddr) tp_assign(usockaddr_len, usockaddr_len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getpeername
+-SC_TRACE_EVENT(sys_getpeername,
+-	TP_PROTO(int fd, struct sockaddr * usockaddr, int * usockaddr_len),
+-	TP_ARGS(fd, usockaddr, usockaddr_len),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, usockaddr) __field_hex(int *, usockaddr_len)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(usockaddr, usockaddr) tp_assign(usockaddr_len, usockaddr_len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sendmsg
+-SC_TRACE_EVENT(sys_sendmsg,
+-	TP_PROTO(int fd, struct msghdr * msg, unsigned flags),
+-	TP_ARGS(fd, msg, flags),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct msghdr *, msg) __field(unsigned, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(msg, msg) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_recvmsg
+-SC_TRACE_EVENT(sys_recvmsg,
+-	TP_PROTO(int fd, struct msghdr * msg, unsigned int flags),
+-	TP_ARGS(fd, msg, flags),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct msghdr *, msg) __field(unsigned int, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(msg, msg) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_semop
+-SC_TRACE_EVENT(sys_semop,
+-	TP_PROTO(int semid, struct sembuf * tsops, unsigned nsops),
+-	TP_ARGS(semid, tsops, nsops),
+-	TP_STRUCT__entry(__field(int, semid) __field_hex(struct sembuf *, tsops) __field(unsigned, nsops)),
+-	TP_fast_assign(tp_assign(semid, semid) tp_assign(tsops, tsops) tp_assign(nsops, nsops)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_msgctl
+-SC_TRACE_EVENT(sys_msgctl,
+-	TP_PROTO(int msqid, int cmd, struct msqid_ds * buf),
+-	TP_ARGS(msqid, cmd, buf),
+-	TP_STRUCT__entry(__field(int, msqid) __field(int, cmd) __field_hex(struct msqid_ds *, buf)),
+-	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(cmd, cmd) tp_assign(buf, buf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_shmat
+-SC_TRACE_EVENT(sys_shmat,
+-	TP_PROTO(int shmid, char * shmaddr, int shmflg),
+-	TP_ARGS(shmid, shmaddr, shmflg),
+-	TP_STRUCT__entry(__field(int, shmid) __field_hex(char *, shmaddr) __field(int, shmflg)),
+-	TP_fast_assign(tp_assign(shmid, shmid) tp_assign(shmaddr, shmaddr) tp_assign(shmflg, shmflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_shmctl
+-SC_TRACE_EVENT(sys_shmctl,
+-	TP_PROTO(int shmid, int cmd, struct shmid_ds * buf),
+-	TP_ARGS(shmid, cmd, buf),
+-	TP_STRUCT__entry(__field(int, shmid) __field(int, cmd) __field_hex(struct shmid_ds *, buf)),
+-	TP_fast_assign(tp_assign(shmid, shmid) tp_assign(cmd, cmd) tp_assign(buf, buf)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_inotify_add_watch
+-SC_TRACE_EVENT(sys_inotify_add_watch,
+-	TP_PROTO(int fd, const char * pathname, u32 mask),
+-	TP_ARGS(fd, pathname, mask),
+-	TP_STRUCT__entry(__field(int, fd) __string_from_user(pathname, pathname) __field(u32, mask)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(pathname, pathname) tp_assign(mask, mask)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mkdirat
+-SC_TRACE_EVENT(sys_mkdirat,
+-	TP_PROTO(int dfd, const char * pathname, int mode),
+-	TP_ARGS(dfd, pathname, mode),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field(int, mode)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_futimesat
+-SC_TRACE_EVENT(sys_futimesat,
+-	TP_PROTO(int dfd, const char * filename, struct timeval * utimes),
+-	TP_ARGS(dfd, filename, utimes),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct timeval *, utimes)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_unlinkat
+-SC_TRACE_EVENT(sys_unlinkat,
+-	TP_PROTO(int dfd, const char * pathname, int flag),
+-	TP_ARGS(dfd, pathname, flag),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field(int, flag)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(flag, flag)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_symlinkat
+-SC_TRACE_EVENT(sys_symlinkat,
+-	TP_PROTO(const char * oldname, int newdfd, const char * newname),
+-	TP_ARGS(oldname, newdfd, newname),
+-	TP_STRUCT__entry(__string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname)),
+-	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchmodat
+-SC_TRACE_EVENT(sys_fchmodat,
+-	TP_PROTO(int dfd, const char * filename, mode_t mode),
+-	TP_ARGS(dfd, filename, mode),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(mode_t, mode)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_faccessat
+-SC_TRACE_EVENT(sys_faccessat,
+-	TP_PROTO(int dfd, const char * filename, int mode),
+-	TP_ARGS(dfd, filename, mode),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(int, mode)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_get_robust_list
+-SC_TRACE_EVENT(sys_get_robust_list,
+-	TP_PROTO(int pid, struct robust_list_head * * head_ptr, size_t * len_ptr),
+-	TP_ARGS(pid, head_ptr, len_ptr),
+-	TP_STRUCT__entry(__field(int, pid) __field_hex(struct robust_list_head * *, head_ptr) __field_hex(size_t *, len_ptr)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(head_ptr, head_ptr) tp_assign(len_ptr, len_ptr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getcpu
+-SC_TRACE_EVENT(sys_getcpu,
+-	TP_PROTO(unsigned * cpup, unsigned * nodep, struct getcpu_cache * unused),
+-	TP_ARGS(cpup, nodep, unused),
+-	TP_STRUCT__entry(__field_hex(unsigned *, cpup) __field_hex(unsigned *, nodep) __field_hex(struct getcpu_cache *, unused)),
+-	TP_fast_assign(tp_assign(cpup, cpup) tp_assign(nodep, nodep) tp_assign(unused, unused)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_signalfd
+-SC_TRACE_EVENT(sys_signalfd,
+-	TP_PROTO(int ufd, sigset_t * user_mask, size_t sizemask),
+-	TP_ARGS(ufd, user_mask, sizemask),
+-	TP_STRUCT__entry(__field(int, ufd) __field_hex(sigset_t *, user_mask) __field(size_t, sizemask)),
+-	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(user_mask, user_mask) tp_assign(sizemask, sizemask)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_reboot
+-SC_TRACE_EVENT(sys_reboot,
+-	TP_PROTO(int magic1, int magic2, unsigned int cmd, void * arg),
+-	TP_ARGS(magic1, magic2, cmd, arg),
+-	TP_STRUCT__entry(__field(int, magic1) __field(int, magic2) __field(unsigned int, cmd) __field_hex(void *, arg)),
+-	TP_fast_assign(tp_assign(magic1, magic1) tp_assign(magic2, magic2) tp_assign(cmd, cmd) tp_assign(arg, arg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_wait4
+-SC_TRACE_EVENT(sys_wait4,
+-	TP_PROTO(pid_t upid, int * stat_addr, int options, struct rusage * ru),
+-	TP_ARGS(upid, stat_addr, options, ru),
+-	TP_STRUCT__entry(__field(pid_t, upid) __field_hex(int *, stat_addr) __field(int, options) __field_hex(struct rusage *, ru)),
+-	TP_fast_assign(tp_assign(upid, upid) tp_assign(stat_addr, stat_addr) tp_assign(options, options) tp_assign(ru, ru)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigaction
+-SC_TRACE_EVENT(sys_rt_sigaction,
+-	TP_PROTO(int sig, const struct sigaction * act, struct sigaction * oact, size_t sigsetsize),
+-	TP_ARGS(sig, act, oact, sigsetsize),
+-	TP_STRUCT__entry(__field(int, sig) __field_hex(const struct sigaction *, act) __field_hex(struct sigaction *, oact) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(sig, sig) tp_assign(act, act) tp_assign(oact, oact) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigprocmask
+-SC_TRACE_EVENT(sys_rt_sigprocmask,
+-	TP_PROTO(int how, sigset_t * set, sigset_t * oset, size_t sigsetsize),
+-	TP_ARGS(how, set, oset, sigsetsize),
+-	TP_STRUCT__entry(__field(int, how) __field_hex(sigset_t *, set) __field_hex(sigset_t *, oset) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(how, how) tp_assign(set, set) tp_assign(oset, oset) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_sigtimedwait
+-SC_TRACE_EVENT(sys_rt_sigtimedwait,
+-	TP_PROTO(const sigset_t * uthese, siginfo_t * uinfo, const struct timespec * uts, size_t sigsetsize),
+-	TP_ARGS(uthese, uinfo, uts, sigsetsize),
+-	TP_STRUCT__entry(__field_hex(const sigset_t *, uthese) __field_hex(siginfo_t *, uinfo) __field_hex(const struct timespec *, uts) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(uthese, uthese) tp_assign(uinfo, uinfo) tp_assign(uts, uts) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sendfile
+-SC_TRACE_EVENT(sys_sendfile,
+-	TP_PROTO(int out_fd, int in_fd, off_t * offset, size_t count),
+-	TP_ARGS(out_fd, in_fd, offset, count),
+-	TP_STRUCT__entry(__field(int, out_fd) __field(int, in_fd) __field_hex(off_t *, offset) __field(size_t, count)),
+-	TP_fast_assign(tp_assign(out_fd, out_fd) tp_assign(in_fd, in_fd) tp_assign(offset, offset) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getxattr
+-SC_TRACE_EVENT(sys_getxattr,
+-	TP_PROTO(const char * pathname, const char * name, void * value, size_t size),
+-	TP_ARGS(pathname, name, value, size),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lgetxattr
+-SC_TRACE_EVENT(sys_lgetxattr,
+-	TP_PROTO(const char * pathname, const char * name, void * value, size_t size),
+-	TP_ARGS(pathname, name, value, size),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fgetxattr
+-SC_TRACE_EVENT(sys_fgetxattr,
+-	TP_PROTO(int fd, const char * name, void * value, size_t size),
+-	TP_ARGS(fd, name, value, size),
+-	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sendfile64
+-SC_TRACE_EVENT(sys_sendfile64,
+-	TP_PROTO(int out_fd, int in_fd, loff_t * offset, size_t count),
+-	TP_ARGS(out_fd, in_fd, offset, count),
+-	TP_STRUCT__entry(__field(int, out_fd) __field(int, in_fd) __field_hex(loff_t *, offset) __field(size_t, count)),
+-	TP_fast_assign(tp_assign(out_fd, out_fd) tp_assign(in_fd, in_fd) tp_assign(offset, offset) tp_assign(count, count)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_epoll_ctl
+-SC_TRACE_EVENT(sys_epoll_ctl,
+-	TP_PROTO(int epfd, int op, int fd, struct epoll_event * event),
+-	TP_ARGS(epfd, op, fd, event),
+-	TP_STRUCT__entry(__field(int, epfd) __field(int, op) __field(int, fd) __field_hex(struct epoll_event *, event)),
+-	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(op, op) tp_assign(fd, fd) tp_assign(event, event)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_epoll_wait
+-SC_TRACE_EVENT(sys_epoll_wait,
+-	TP_PROTO(int epfd, struct epoll_event * events, int maxevents, int timeout),
+-	TP_ARGS(epfd, events, maxevents, timeout),
+-	TP_STRUCT__entry(__field(int, epfd) __field_hex(struct epoll_event *, events) __field(int, maxevents) __field(int, timeout)),
+-	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(events, events) tp_assign(maxevents, maxevents) tp_assign(timeout, timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timer_settime
+-SC_TRACE_EVENT(sys_timer_settime,
+-	TP_PROTO(timer_t timer_id, int flags, const struct itimerspec * new_setting, struct itimerspec * old_setting),
+-	TP_ARGS(timer_id, flags, new_setting, old_setting),
+-	TP_STRUCT__entry(__field(timer_t, timer_id) __field(int, flags) __field_hex(const struct itimerspec *, new_setting) __field_hex(struct itimerspec *, old_setting)),
+-	TP_fast_assign(tp_assign(timer_id, timer_id) tp_assign(flags, flags) tp_assign(new_setting, new_setting) tp_assign(old_setting, old_setting)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_clock_nanosleep
+-SC_TRACE_EVENT(sys_clock_nanosleep,
+-	TP_PROTO(const clockid_t which_clock, int flags, const struct timespec * rqtp, struct timespec * rmtp),
+-	TP_ARGS(which_clock, flags, rqtp, rmtp),
+-	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field(int, flags) __field_hex(const struct timespec *, rqtp) __field_hex(struct timespec *, rmtp)),
+-	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(flags, flags) tp_assign(rqtp, rqtp) tp_assign(rmtp, rmtp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_open
+-SC_TRACE_EVENT(sys_mq_open,
+-	TP_PROTO(const char * u_name, int oflag, mode_t mode, struct mq_attr * u_attr),
+-	TP_ARGS(u_name, oflag, mode, u_attr),
+-	TP_STRUCT__entry(__string_from_user(u_name, u_name) __field(int, oflag) __field(mode_t, mode) __field_hex(struct mq_attr *, u_attr)),
+-	TP_fast_assign(tp_copy_string_from_user(u_name, u_name) tp_assign(oflag, oflag) tp_assign(mode, mode) tp_assign(u_attr, u_attr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_socketpair
+-SC_TRACE_EVENT(sys_socketpair,
+-	TP_PROTO(int family, int type, int protocol, int * usockvec),
+-	TP_ARGS(family, type, protocol, usockvec),
+-	TP_STRUCT__entry(__field(int, family) __field(int, type) __field(int, protocol) __field_hex(int *, usockvec)),
+-	TP_fast_assign(tp_assign(family, family) tp_assign(type, type) tp_assign(protocol, protocol) tp_assign(usockvec, usockvec)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_send
+-SC_TRACE_EVENT(sys_send,
+-	TP_PROTO(int fd, void * buff, size_t len, unsigned flags),
+-	TP_ARGS(fd, buff, len, flags),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, buff) __field(size_t, len) __field(unsigned, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(buff, buff) tp_assign(len, len) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_msgsnd
+-SC_TRACE_EVENT(sys_msgsnd,
+-	TP_PROTO(int msqid, struct msgbuf * msgp, size_t msgsz, int msgflg),
+-	TP_ARGS(msqid, msgp, msgsz, msgflg),
+-	TP_STRUCT__entry(__field(int, msqid) __field_hex(struct msgbuf *, msgp) __field(size_t, msgsz) __field(int, msgflg)),
+-	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(msgp, msgp) tp_assign(msgsz, msgsz) tp_assign(msgflg, msgflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_request_key
+-SC_TRACE_EVENT(sys_request_key,
+-	TP_PROTO(const char * _type, const char * _description, const char * _callout_info, key_serial_t destringid),
+-	TP_ARGS(_type, _description, _callout_info, destringid),
+-	TP_STRUCT__entry(__string_from_user(_type, _type) __field_hex(const char *, _description) __field_hex(const char *, _callout_info) __field(key_serial_t, destringid)),
+-	TP_fast_assign(tp_copy_string_from_user(_type, _type) tp_assign(_description, _description) tp_assign(_callout_info, _callout_info) tp_assign(destringid, destringid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_semtimedop
+-SC_TRACE_EVENT(sys_semtimedop,
+-	TP_PROTO(int semid, struct sembuf * tsops, unsigned nsops, const struct timespec * timeout),
+-	TP_ARGS(semid, tsops, nsops, timeout),
+-	TP_STRUCT__entry(__field(int, semid) __field_hex(struct sembuf *, tsops) __field(unsigned, nsops) __field_hex(const struct timespec *, timeout)),
+-	TP_fast_assign(tp_assign(semid, semid) tp_assign(tsops, tsops) tp_assign(nsops, nsops) tp_assign(timeout, timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_openat
+-SC_TRACE_EVENT(sys_openat,
+-	TP_PROTO(int dfd, const char * filename, int flags, int mode),
+-	TP_ARGS(dfd, filename, flags, mode),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(int, flags) __field(int, mode)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(flags, flags) tp_assign(mode, mode)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mknodat
+-SC_TRACE_EVENT(sys_mknodat,
+-	TP_PROTO(int dfd, const char * filename, int mode, unsigned dev),
+-	TP_ARGS(dfd, filename, mode, dev),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(int, mode) __field(unsigned, dev)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode) tp_assign(dev, dev)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fstatat64
+-SC_TRACE_EVENT(sys_fstatat64,
+-	TP_PROTO(int dfd, const char * filename, struct stat64 * statbuf, int flag),
+-	TP_ARGS(dfd, filename, statbuf, flag),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf) __field(int, flag)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf) tp_assign(flag, flag)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_renameat
+-SC_TRACE_EVENT(sys_renameat,
+-	TP_PROTO(int olddfd, const char * oldname, int newdfd, const char * newname),
+-	TP_ARGS(olddfd, oldname, newdfd, newname),
+-	TP_STRUCT__entry(__field(int, olddfd) __string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname)),
+-	TP_fast_assign(tp_assign(olddfd, olddfd) tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_readlinkat
+-SC_TRACE_EVENT(sys_readlinkat,
+-	TP_PROTO(int dfd, const char * pathname, char * buf, int bufsiz),
+-	TP_ARGS(dfd, pathname, buf, bufsiz),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field_hex(char *, buf) __field(int, bufsiz)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(buf, buf) tp_assign(bufsiz, bufsiz)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_vmsplice
+-SC_TRACE_EVENT(sys_vmsplice,
+-	TP_PROTO(int fd, const struct iovec * iov, unsigned long nr_segs, unsigned int flags),
+-	TP_ARGS(fd, iov, nr_segs, flags),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(const struct iovec *, iov) __field(unsigned long, nr_segs) __field(unsigned int, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(iov, iov) tp_assign(nr_segs, nr_segs) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_utimensat
+-SC_TRACE_EVENT(sys_utimensat,
+-	TP_PROTO(int dfd, const char * filename, struct timespec * utimes, int flags),
+-	TP_ARGS(dfd, filename, utimes, flags),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct timespec *, utimes) __field(int, flags)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_timerfd_settime
+-SC_TRACE_EVENT(sys_timerfd_settime,
+-	TP_PROTO(int ufd, int flags, const struct itimerspec * utmr, struct itimerspec * otmr),
+-	TP_ARGS(ufd, flags, utmr, otmr),
+-	TP_STRUCT__entry(__field(int, ufd) __field(int, flags) __field_hex(const struct itimerspec *, utmr) __field_hex(struct itimerspec *, otmr)),
+-	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(flags, flags) tp_assign(utmr, utmr) tp_assign(otmr, otmr)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_signalfd4
+-SC_TRACE_EVENT(sys_signalfd4,
+-	TP_PROTO(int ufd, sigset_t * user_mask, size_t sizemask, int flags),
+-	TP_ARGS(ufd, user_mask, sizemask, flags),
+-	TP_STRUCT__entry(__field(int, ufd) __field_hex(sigset_t *, user_mask) __field(size_t, sizemask) __field(int, flags)),
+-	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(user_mask, user_mask) tp_assign(sizemask, sizemask) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_rt_tgsigqueueinfo
+-SC_TRACE_EVENT(sys_rt_tgsigqueueinfo,
+-	TP_PROTO(pid_t tgid, pid_t pid, int sig, siginfo_t * uinfo),
+-	TP_ARGS(tgid, pid, sig, uinfo),
+-	TP_STRUCT__entry(__field(pid_t, tgid) __field(pid_t, pid) __field(int, sig) __field_hex(siginfo_t *, uinfo)),
+-	TP_fast_assign(tp_assign(tgid, tgid) tp_assign(pid, pid) tp_assign(sig, sig) tp_assign(uinfo, uinfo)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_accept4
+-SC_TRACE_EVENT(sys_accept4,
+-	TP_PROTO(int fd, struct sockaddr * upeer_sockaddr, int * upeer_addrlen, int flags),
+-	TP_ARGS(fd, upeer_sockaddr, upeer_addrlen, flags),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, upeer_sockaddr) __field_hex(int *, upeer_addrlen) __field(int, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(upeer_sockaddr, upeer_sockaddr) tp_assign(upeer_addrlen, upeer_addrlen) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_prlimit64
+-SC_TRACE_EVENT(sys_prlimit64,
+-	TP_PROTO(pid_t pid, unsigned int resource, const struct rlimit64 * new_rlim, struct rlimit64 * old_rlim),
+-	TP_ARGS(pid, resource, new_rlim, old_rlim),
+-	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, resource) __field_hex(const struct rlimit64 *, new_rlim) __field_hex(struct rlimit64 *, old_rlim)),
+-	TP_fast_assign(tp_assign(pid, pid) tp_assign(resource, resource) tp_assign(new_rlim, new_rlim) tp_assign(old_rlim, old_rlim)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mount
+-SC_TRACE_EVENT(sys_mount,
+-	TP_PROTO(char * dev_name, char * dir_name, char * type, unsigned long flags, void * data),
+-	TP_ARGS(dev_name, dir_name, type, flags, data),
+-	TP_STRUCT__entry(__string_from_user(dev_name, dev_name) __string_from_user(dir_name, dir_name) __string_from_user(type, type) __field(unsigned long, flags) __field_hex(void *, data)),
+-	TP_fast_assign(tp_copy_string_from_user(dev_name, dev_name) tp_copy_string_from_user(dir_name, dir_name) tp_copy_string_from_user(type, type) tp_assign(flags, flags) tp_assign(data, data)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_llseek
+-SC_TRACE_EVENT(sys_llseek,
+-	TP_PROTO(unsigned int fd, unsigned long offset_high, unsigned long offset_low, loff_t * result, unsigned int origin),
+-	TP_ARGS(fd, offset_high, offset_low, result, origin),
+-	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned long, offset_high) __field(unsigned long, offset_low) __field_hex(loff_t *, result) __field(unsigned int, origin)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(offset_high, offset_high) tp_assign(offset_low, offset_low) tp_assign(result, result) tp_assign(origin, origin)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_select
+-SC_TRACE_EVENT(sys_select,
+-	TP_PROTO(int n, fd_set * inp, fd_set * outp, fd_set * exp, struct timeval * tvp),
+-	TP_ARGS(n, inp, outp, exp, tvp),
+-	TP_STRUCT__entry(__field(int, n) __field_hex(fd_set *, inp) __field_hex(fd_set *, outp) __field_hex(fd_set *, exp) __field_hex(struct timeval *, tvp)),
+-	TP_fast_assign(tp_assign(n, n) tp_assign(inp, inp) tp_assign(outp, outp) tp_assign(exp, exp) tp_assign(tvp, tvp)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setxattr
+-SC_TRACE_EVENT(sys_setxattr,
+-	TP_PROTO(const char * pathname, const char * name, const void * value, size_t size, int flags),
+-	TP_ARGS(pathname, name, value, size, flags),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_lsetxattr
+-SC_TRACE_EVENT(sys_lsetxattr,
+-	TP_PROTO(const char * pathname, const char * name, const void * value, size_t size, int flags),
+-	TP_ARGS(pathname, name, value, size, flags),
+-	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
+-	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fsetxattr
+-SC_TRACE_EVENT(sys_fsetxattr,
+-	TP_PROTO(int fd, const char * name, const void * value, size_t size, int flags),
+-	TP_ARGS(fd, name, value, size, flags),
+-	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_io_getevents
+-SC_TRACE_EVENT(sys_io_getevents,
+-	TP_PROTO(aio_context_t ctx_id, long min_nr, long nr, struct io_event * events, struct timespec * timeout),
+-	TP_ARGS(ctx_id, min_nr, nr, events, timeout),
+-	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field(long, min_nr) __field(long, nr) __field_hex(struct io_event *, events) __field_hex(struct timespec *, timeout)),
+-	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(min_nr, min_nr) tp_assign(nr, nr) tp_assign(events, events) tp_assign(timeout, timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_timedsend
+-SC_TRACE_EVENT(sys_mq_timedsend,
+-	TP_PROTO(mqd_t mqdes, const char * u_msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec * u_abs_timeout),
+-	TP_ARGS(mqdes, u_msg_ptr, msg_len, msg_prio, u_abs_timeout),
+-	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const char *, u_msg_ptr) __field(size_t, msg_len) __field(unsigned int, msg_prio) __field_hex(const struct timespec *, u_abs_timeout)),
+-	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_msg_ptr, u_msg_ptr) tp_assign(msg_len, msg_len) tp_assign(msg_prio, msg_prio) tp_assign(u_abs_timeout, u_abs_timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_mq_timedreceive
+-SC_TRACE_EVENT(sys_mq_timedreceive,
+-	TP_PROTO(mqd_t mqdes, char * u_msg_ptr, size_t msg_len, unsigned int * u_msg_prio, const struct timespec * u_abs_timeout),
+-	TP_ARGS(mqdes, u_msg_ptr, msg_len, u_msg_prio, u_abs_timeout),
+-	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(char *, u_msg_ptr) __field(size_t, msg_len) __field_hex(unsigned int *, u_msg_prio) __field_hex(const struct timespec *, u_abs_timeout)),
+-	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_msg_ptr, u_msg_ptr) tp_assign(msg_len, msg_len) tp_assign(u_msg_prio, u_msg_prio) tp_assign(u_abs_timeout, u_abs_timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_waitid
+-SC_TRACE_EVENT(sys_waitid,
+-	TP_PROTO(int which, pid_t upid, struct siginfo * infop, int options, struct rusage * ru),
+-	TP_ARGS(which, upid, infop, options, ru),
+-	TP_STRUCT__entry(__field(int, which) __field(pid_t, upid) __field_hex(struct siginfo *, infop) __field(int, options) __field_hex(struct rusage *, ru)),
+-	TP_fast_assign(tp_assign(which, which) tp_assign(upid, upid) tp_assign(infop, infop) tp_assign(options, options) tp_assign(ru, ru)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_setsockopt
+-SC_TRACE_EVENT(sys_setsockopt,
+-	TP_PROTO(int fd, int level, int optname, char * optval, int optlen),
+-	TP_ARGS(fd, level, optname, optval, optlen),
+-	TP_STRUCT__entry(__field(int, fd) __field(int, level) __field(int, optname) __field_hex(char *, optval) __field(int, optlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(level, level) tp_assign(optname, optname) tp_assign(optval, optval) tp_assign(optlen, optlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_getsockopt
+-SC_TRACE_EVENT(sys_getsockopt,
+-	TP_PROTO(int fd, int level, int optname, char * optval, int * optlen),
+-	TP_ARGS(fd, level, optname, optval, optlen),
+-	TP_STRUCT__entry(__field(int, fd) __field(int, level) __field(int, optname) __field_hex(char *, optval) __field_hex(int *, optlen)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(level, level) tp_assign(optname, optname) tp_assign(optval, optval) tp_assign(optlen, optlen)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_msgrcv
+-SC_TRACE_EVENT(sys_msgrcv,
+-	TP_PROTO(int msqid, struct msgbuf * msgp, size_t msgsz, long msgtyp, int msgflg),
+-	TP_ARGS(msqid, msgp, msgsz, msgtyp, msgflg),
+-	TP_STRUCT__entry(__field(int, msqid) __field_hex(struct msgbuf *, msgp) __field(size_t, msgsz) __field(long, msgtyp) __field(int, msgflg)),
+-	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(msgp, msgp) tp_assign(msgsz, msgsz) tp_assign(msgtyp, msgtyp) tp_assign(msgflg, msgflg)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_add_key
+-SC_TRACE_EVENT(sys_add_key,
+-	TP_PROTO(const char * _type, const char * _description, const void * _payload, size_t plen, key_serial_t ringid),
+-	TP_ARGS(_type, _description, _payload, plen, ringid),
+-	TP_STRUCT__entry(__string_from_user(_type, _type) __field_hex(const char *, _description) __field_hex(const void *, _payload) __field(size_t, plen) __field(key_serial_t, ringid)),
+-	TP_fast_assign(tp_copy_string_from_user(_type, _type) tp_assign(_description, _description) tp_assign(_payload, _payload) tp_assign(plen, plen) tp_assign(ringid, ringid)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_fchownat
+-SC_TRACE_EVENT(sys_fchownat,
+-	TP_PROTO(int dfd, const char * filename, uid_t user, gid_t group, int flag),
+-	TP_ARGS(dfd, filename, user, group, flag),
+-	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group) __field(int, flag)),
+-	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group) tp_assign(flag, flag)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_linkat
+-SC_TRACE_EVENT(sys_linkat,
+-	TP_PROTO(int olddfd, const char * oldname, int newdfd, const char * newname, int flags),
+-	TP_ARGS(olddfd, oldname, newdfd, newname, flags),
+-	TP_STRUCT__entry(__field(int, olddfd) __string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname) __field(int, flags)),
+-	TP_fast_assign(tp_assign(olddfd, olddfd) tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_ppoll
+-SC_TRACE_EVENT(sys_ppoll,
+-	TP_PROTO(struct pollfd * ufds, unsigned int nfds, struct timespec * tsp, const sigset_t * sigmask, size_t sigsetsize),
+-	TP_ARGS(ufds, nfds, tsp, sigmask, sigsetsize),
+-	TP_STRUCT__entry(__field_hex(struct pollfd *, ufds) __field(unsigned int, nfds) __field_hex(struct timespec *, tsp) __field_hex(const sigset_t *, sigmask) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(ufds, ufds) tp_assign(nfds, nfds) tp_assign(tsp, tsp) tp_assign(sigmask, sigmask) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_preadv
+-SC_TRACE_EVENT(sys_preadv,
+-	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen, unsigned long pos_l, unsigned long pos_h),
+-	TP_ARGS(fd, vec, vlen, pos_l, pos_h),
+-	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen) __field(unsigned long, pos_l) __field(unsigned long, pos_h)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen) tp_assign(pos_l, pos_l) tp_assign(pos_h, pos_h)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_pwritev
+-SC_TRACE_EVENT(sys_pwritev,
+-	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen, unsigned long pos_l, unsigned long pos_h),
+-	TP_ARGS(fd, vec, vlen, pos_l, pos_h),
+-	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen) __field(unsigned long, pos_l) __field(unsigned long, pos_h)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen) tp_assign(pos_l, pos_l) tp_assign(pos_h, pos_h)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_recvmmsg
+-SC_TRACE_EVENT(sys_recvmmsg,
+-	TP_PROTO(int fd, struct mmsghdr * mmsg, unsigned int vlen, unsigned int flags, struct timespec * timeout),
+-	TP_ARGS(fd, mmsg, vlen, flags, timeout),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(struct mmsghdr *, mmsg) __field(unsigned int, vlen) __field(unsigned int, flags) __field_hex(struct timespec *, timeout)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(mmsg, mmsg) tp_assign(vlen, vlen) tp_assign(flags, flags) tp_assign(timeout, timeout)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_futex
+-SC_TRACE_EVENT(sys_futex,
+-	TP_PROTO(u32 * uaddr, int op, u32 val, struct timespec * utime, u32 * uaddr2, u32 val3),
+-	TP_ARGS(uaddr, op, val, utime, uaddr2, val3),
+-	TP_STRUCT__entry(__field_hex(u32 *, uaddr) __field(int, op) __field(u32, val) __field_hex(struct timespec *, utime) __field_hex(u32 *, uaddr2) __field(u32, val3)),
+-	TP_fast_assign(tp_assign(uaddr, uaddr) tp_assign(op, op) tp_assign(val, val) tp_assign(utime, utime) tp_assign(uaddr2, uaddr2) tp_assign(val3, val3)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_sendto
+-SC_TRACE_EVENT(sys_sendto,
+-	TP_PROTO(int fd, void * buff, size_t len, unsigned flags, struct sockaddr * addr, int addr_len),
+-	TP_ARGS(fd, buff, len, flags, addr, addr_len),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, buff) __field(size_t, len) __field(unsigned, flags) __field_hex(struct sockaddr *, addr) __field_hex(int, addr_len)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(buff, buff) tp_assign(len, len) tp_assign(flags, flags) tp_assign(addr, addr) tp_assign(addr_len, addr_len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_recvfrom
+-SC_TRACE_EVENT(sys_recvfrom,
+-	TP_PROTO(int fd, void * ubuf, size_t size, unsigned flags, struct sockaddr * addr, int * addr_len),
+-	TP_ARGS(fd, ubuf, size, flags, addr, addr_len),
+-	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, ubuf) __field(size_t, size) __field(unsigned, flags) __field_hex(struct sockaddr *, addr) __field_hex(int *, addr_len)),
+-	TP_fast_assign(tp_assign(fd, fd) tp_assign(ubuf, ubuf) tp_assign(size, size) tp_assign(flags, flags) tp_assign(addr, addr) tp_assign(addr_len, addr_len)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_pselect6
+-SC_TRACE_EVENT(sys_pselect6,
+-	TP_PROTO(int n, fd_set * inp, fd_set * outp, fd_set * exp, struct timespec * tsp, void * sig),
+-	TP_ARGS(n, inp, outp, exp, tsp, sig),
+-	TP_STRUCT__entry(__field(int, n) __field_hex(fd_set *, inp) __field_hex(fd_set *, outp) __field_hex(fd_set *, exp) __field_hex(struct timespec *, tsp) __field_hex(void *, sig)),
+-	TP_fast_assign(tp_assign(n, n) tp_assign(inp, inp) tp_assign(outp, outp) tp_assign(exp, exp) tp_assign(tsp, tsp) tp_assign(sig, sig)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_splice
+-SC_TRACE_EVENT(sys_splice,
+-	TP_PROTO(int fd_in, loff_t * off_in, int fd_out, loff_t * off_out, size_t len, unsigned int flags),
+-	TP_ARGS(fd_in, off_in, fd_out, off_out, len, flags),
+-	TP_STRUCT__entry(__field(int, fd_in) __field_hex(loff_t *, off_in) __field(int, fd_out) __field_hex(loff_t *, off_out) __field(size_t, len) __field(unsigned int, flags)),
+-	TP_fast_assign(tp_assign(fd_in, fd_in) tp_assign(off_in, off_in) tp_assign(fd_out, fd_out) tp_assign(off_out, off_out) tp_assign(len, len) tp_assign(flags, flags)),
+-	TP_printk()
+-)
+-#endif
+-#ifndef OVERRIDE_32_sys_epoll_pwait
+-SC_TRACE_EVENT(sys_epoll_pwait,
+-	TP_PROTO(int epfd, struct epoll_event * events, int maxevents, int timeout, const sigset_t * sigmask, size_t sigsetsize),
+-	TP_ARGS(epfd, events, maxevents, timeout, sigmask, sigsetsize),
+-	TP_STRUCT__entry(__field(int, epfd) __field_hex(struct epoll_event *, events) __field(int, maxevents) __field(int, timeout) __field_hex(const sigset_t *, sigmask) __field(size_t, sigsetsize)),
+-	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(events, events) tp_assign(maxevents, maxevents) tp_assign(timeout, timeout) tp_assign(sigmask, sigmask) tp_assign(sigsetsize, sigsetsize)),
+-	TP_printk()
+-)
+-#endif
+-
+-#endif /*  _TRACE_SYSCALLS_POINTERS_H */
+-
+-/* This part must be outside protection */
+-#include "../../../probes/define_trace.h"
+-
+-#else /* CREATE_SYSCALL_TABLE */
+-
+-#include "arm-32-syscalls-2.6.38_pointers_override.h"
+-#include "syscalls_pointers_override.h"
+-
+-#ifndef OVERRIDE_TABLE_32_sys_read
+-TRACE_SYSCALL_TABLE(sys_read, sys_read, 3, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_write
+-TRACE_SYSCALL_TABLE(sys_write, sys_write, 4, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_open
+-TRACE_SYSCALL_TABLE(sys_open, sys_open, 5, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_creat
+-TRACE_SYSCALL_TABLE(sys_creat, sys_creat, 8, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_link
+-TRACE_SYSCALL_TABLE(sys_link, sys_link, 9, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_unlink
+-TRACE_SYSCALL_TABLE(sys_unlink, sys_unlink, 10, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_chdir
+-TRACE_SYSCALL_TABLE(sys_chdir, sys_chdir, 12, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mknod
+-TRACE_SYSCALL_TABLE(sys_mknod, sys_mknod, 14, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_chmod
+-TRACE_SYSCALL_TABLE(sys_chmod, sys_chmod, 15, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lchown16
+-TRACE_SYSCALL_TABLE(sys_lchown16, sys_lchown16, 16, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mount
+-TRACE_SYSCALL_TABLE(sys_mount, sys_mount, 21, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_access
+-TRACE_SYSCALL_TABLE(sys_access, sys_access, 33, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rename
+-TRACE_SYSCALL_TABLE(sys_rename, sys_rename, 38, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mkdir
+-TRACE_SYSCALL_TABLE(sys_mkdir, sys_mkdir, 39, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rmdir
+-TRACE_SYSCALL_TABLE(sys_rmdir, sys_rmdir, 40, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pipe
+-TRACE_SYSCALL_TABLE(sys_pipe, sys_pipe, 42, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_times
+-TRACE_SYSCALL_TABLE(sys_times, sys_times, 43, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_umount
+-TRACE_SYSCALL_TABLE(sys_umount, sys_umount, 52, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_chroot
+-TRACE_SYSCALL_TABLE(sys_chroot, sys_chroot, 61, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ustat
+-TRACE_SYSCALL_TABLE(sys_ustat, sys_ustat, 62, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sigpending
+-TRACE_SYSCALL_TABLE(sys_sigpending, sys_sigpending, 73, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sethostname
+-TRACE_SYSCALL_TABLE(sys_sethostname, sys_sethostname, 74, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setrlimit
+-TRACE_SYSCALL_TABLE(sys_setrlimit, sys_setrlimit, 75, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getrusage
+-TRACE_SYSCALL_TABLE(sys_getrusage, sys_getrusage, 77, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_gettimeofday
+-TRACE_SYSCALL_TABLE(sys_gettimeofday, sys_gettimeofday, 78, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_settimeofday
+-TRACE_SYSCALL_TABLE(sys_settimeofday, sys_settimeofday, 79, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getgroups16
+-TRACE_SYSCALL_TABLE(sys_getgroups16, sys_getgroups16, 80, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setgroups16
+-TRACE_SYSCALL_TABLE(sys_setgroups16, sys_setgroups16, 81, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_symlink
+-TRACE_SYSCALL_TABLE(sys_symlink, sys_symlink, 83, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_readlink
+-TRACE_SYSCALL_TABLE(sys_readlink, sys_readlink, 85, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_uselib
+-TRACE_SYSCALL_TABLE(sys_uselib, sys_uselib, 86, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_reboot
+-TRACE_SYSCALL_TABLE(sys_reboot, sys_reboot, 88, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_truncate
+-TRACE_SYSCALL_TABLE(sys_truncate, sys_truncate, 92, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_statfs
+-TRACE_SYSCALL_TABLE(sys_statfs, sys_statfs, 99, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fstatfs
+-TRACE_SYSCALL_TABLE(sys_fstatfs, sys_fstatfs, 100, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_syslog
+-TRACE_SYSCALL_TABLE(sys_syslog, sys_syslog, 103, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setitimer
+-TRACE_SYSCALL_TABLE(sys_setitimer, sys_setitimer, 104, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getitimer
+-TRACE_SYSCALL_TABLE(sys_getitimer, sys_getitimer, 105, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_newstat
+-TRACE_SYSCALL_TABLE(sys_newstat, sys_newstat, 106, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_newlstat
+-TRACE_SYSCALL_TABLE(sys_newlstat, sys_newlstat, 107, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_newfstat
+-TRACE_SYSCALL_TABLE(sys_newfstat, sys_newfstat, 108, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_wait4
+-TRACE_SYSCALL_TABLE(sys_wait4, sys_wait4, 114, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sysinfo
+-TRACE_SYSCALL_TABLE(sys_sysinfo, sys_sysinfo, 116, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setdomainname
+-TRACE_SYSCALL_TABLE(sys_setdomainname, sys_setdomainname, 121, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_newuname
+-TRACE_SYSCALL_TABLE(sys_newuname, sys_newuname, 122, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_adjtimex
+-TRACE_SYSCALL_TABLE(sys_adjtimex, sys_adjtimex, 124, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sigprocmask
+-TRACE_SYSCALL_TABLE(sys_sigprocmask, sys_sigprocmask, 126, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_init_module
+-TRACE_SYSCALL_TABLE(sys_init_module, sys_init_module, 128, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_delete_module
+-TRACE_SYSCALL_TABLE(sys_delete_module, sys_delete_module, 129, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_llseek
+-TRACE_SYSCALL_TABLE(sys_llseek, sys_llseek, 140, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getdents
+-TRACE_SYSCALL_TABLE(sys_getdents, sys_getdents, 141, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_select
+-TRACE_SYSCALL_TABLE(sys_select, sys_select, 142, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_readv
+-TRACE_SYSCALL_TABLE(sys_readv, sys_readv, 145, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_writev
+-TRACE_SYSCALL_TABLE(sys_writev, sys_writev, 146, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sysctl
+-TRACE_SYSCALL_TABLE(sys_sysctl, sys_sysctl, 149, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_setparam
+-TRACE_SYSCALL_TABLE(sys_sched_setparam, sys_sched_setparam, 154, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_getparam
+-TRACE_SYSCALL_TABLE(sys_sched_getparam, sys_sched_getparam, 155, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_setscheduler
+-TRACE_SYSCALL_TABLE(sys_sched_setscheduler, sys_sched_setscheduler, 156, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_rr_get_interval
+-TRACE_SYSCALL_TABLE(sys_sched_rr_get_interval, sys_sched_rr_get_interval, 161, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_nanosleep
+-TRACE_SYSCALL_TABLE(sys_nanosleep, sys_nanosleep, 162, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getresuid16
+-TRACE_SYSCALL_TABLE(sys_getresuid16, sys_getresuid16, 165, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_poll
+-TRACE_SYSCALL_TABLE(sys_poll, sys_poll, 168, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getresgid16
+-TRACE_SYSCALL_TABLE(sys_getresgid16, sys_getresgid16, 171, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigaction
+-TRACE_SYSCALL_TABLE(sys_rt_sigaction, sys_rt_sigaction, 174, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigprocmask
+-TRACE_SYSCALL_TABLE(sys_rt_sigprocmask, sys_rt_sigprocmask, 175, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigpending
+-TRACE_SYSCALL_TABLE(sys_rt_sigpending, sys_rt_sigpending, 176, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigtimedwait
+-TRACE_SYSCALL_TABLE(sys_rt_sigtimedwait, sys_rt_sigtimedwait, 177, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigqueueinfo
+-TRACE_SYSCALL_TABLE(sys_rt_sigqueueinfo, sys_rt_sigqueueinfo, 178, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_sigsuspend
+-TRACE_SYSCALL_TABLE(sys_rt_sigsuspend, sys_rt_sigsuspend, 179, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_chown16
+-TRACE_SYSCALL_TABLE(sys_chown16, sys_chown16, 182, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getcwd
+-TRACE_SYSCALL_TABLE(sys_getcwd, sys_getcwd, 183, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sendfile
+-TRACE_SYSCALL_TABLE(sys_sendfile, sys_sendfile, 187, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getrlimit
+-TRACE_SYSCALL_TABLE(sys_getrlimit, sys_getrlimit, 191, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_stat64
+-TRACE_SYSCALL_TABLE(sys_stat64, sys_stat64, 195, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lstat64
+-TRACE_SYSCALL_TABLE(sys_lstat64, sys_lstat64, 196, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fstat64
+-TRACE_SYSCALL_TABLE(sys_fstat64, sys_fstat64, 197, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lchown
+-TRACE_SYSCALL_TABLE(sys_lchown, sys_lchown, 198, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getgroups
+-TRACE_SYSCALL_TABLE(sys_getgroups, sys_getgroups, 205, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setgroups
+-TRACE_SYSCALL_TABLE(sys_setgroups, sys_setgroups, 206, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getresuid
+-TRACE_SYSCALL_TABLE(sys_getresuid, sys_getresuid, 209, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getresgid
+-TRACE_SYSCALL_TABLE(sys_getresgid, sys_getresgid, 211, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_chown
+-TRACE_SYSCALL_TABLE(sys_chown, sys_chown, 212, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getdents64
+-TRACE_SYSCALL_TABLE(sys_getdents64, sys_getdents64, 217, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pivot_root
+-TRACE_SYSCALL_TABLE(sys_pivot_root, sys_pivot_root, 218, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mincore
+-TRACE_SYSCALL_TABLE(sys_mincore, sys_mincore, 219, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setxattr
+-TRACE_SYSCALL_TABLE(sys_setxattr, sys_setxattr, 226, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lsetxattr
+-TRACE_SYSCALL_TABLE(sys_lsetxattr, sys_lsetxattr, 227, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fsetxattr
+-TRACE_SYSCALL_TABLE(sys_fsetxattr, sys_fsetxattr, 228, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getxattr
+-TRACE_SYSCALL_TABLE(sys_getxattr, sys_getxattr, 229, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lgetxattr
+-TRACE_SYSCALL_TABLE(sys_lgetxattr, sys_lgetxattr, 230, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fgetxattr
+-TRACE_SYSCALL_TABLE(sys_fgetxattr, sys_fgetxattr, 231, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_listxattr
+-TRACE_SYSCALL_TABLE(sys_listxattr, sys_listxattr, 232, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_llistxattr
+-TRACE_SYSCALL_TABLE(sys_llistxattr, sys_llistxattr, 233, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_flistxattr
+-TRACE_SYSCALL_TABLE(sys_flistxattr, sys_flistxattr, 234, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_removexattr
+-TRACE_SYSCALL_TABLE(sys_removexattr, sys_removexattr, 235, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_lremovexattr
+-TRACE_SYSCALL_TABLE(sys_lremovexattr, sys_lremovexattr, 236, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fremovexattr
+-TRACE_SYSCALL_TABLE(sys_fremovexattr, sys_fremovexattr, 237, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sendfile64
+-TRACE_SYSCALL_TABLE(sys_sendfile64, sys_sendfile64, 239, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_futex
+-TRACE_SYSCALL_TABLE(sys_futex, sys_futex, 240, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_setaffinity
+-TRACE_SYSCALL_TABLE(sys_sched_setaffinity, sys_sched_setaffinity, 241, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sched_getaffinity
+-TRACE_SYSCALL_TABLE(sys_sched_getaffinity, sys_sched_getaffinity, 242, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_io_setup
+-TRACE_SYSCALL_TABLE(sys_io_setup, sys_io_setup, 243, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_io_getevents
+-TRACE_SYSCALL_TABLE(sys_io_getevents, sys_io_getevents, 245, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_io_submit
+-TRACE_SYSCALL_TABLE(sys_io_submit, sys_io_submit, 246, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_io_cancel
+-TRACE_SYSCALL_TABLE(sys_io_cancel, sys_io_cancel, 247, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_epoll_ctl
+-TRACE_SYSCALL_TABLE(sys_epoll_ctl, sys_epoll_ctl, 251, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_epoll_wait
+-TRACE_SYSCALL_TABLE(sys_epoll_wait, sys_epoll_wait, 252, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_set_tid_address
+-TRACE_SYSCALL_TABLE(sys_set_tid_address, sys_set_tid_address, 256, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timer_create
+-TRACE_SYSCALL_TABLE(sys_timer_create, sys_timer_create, 257, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timer_settime
+-TRACE_SYSCALL_TABLE(sys_timer_settime, sys_timer_settime, 258, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timer_gettime
+-TRACE_SYSCALL_TABLE(sys_timer_gettime, sys_timer_gettime, 259, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_clock_settime
+-TRACE_SYSCALL_TABLE(sys_clock_settime, sys_clock_settime, 262, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_clock_gettime
+-TRACE_SYSCALL_TABLE(sys_clock_gettime, sys_clock_gettime, 263, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_clock_getres
+-TRACE_SYSCALL_TABLE(sys_clock_getres, sys_clock_getres, 264, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_clock_nanosleep
+-TRACE_SYSCALL_TABLE(sys_clock_nanosleep, sys_clock_nanosleep, 265, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_utimes
+-TRACE_SYSCALL_TABLE(sys_utimes, sys_utimes, 269, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_open
+-TRACE_SYSCALL_TABLE(sys_mq_open, sys_mq_open, 274, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_unlink
+-TRACE_SYSCALL_TABLE(sys_mq_unlink, sys_mq_unlink, 275, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_timedsend
+-TRACE_SYSCALL_TABLE(sys_mq_timedsend, sys_mq_timedsend, 276, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_timedreceive
+-TRACE_SYSCALL_TABLE(sys_mq_timedreceive, sys_mq_timedreceive, 277, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_notify
+-TRACE_SYSCALL_TABLE(sys_mq_notify, sys_mq_notify, 278, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mq_getsetattr
+-TRACE_SYSCALL_TABLE(sys_mq_getsetattr, sys_mq_getsetattr, 279, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_waitid
+-TRACE_SYSCALL_TABLE(sys_waitid, sys_waitid, 280, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_bind
+-TRACE_SYSCALL_TABLE(sys_bind, sys_bind, 282, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_connect
+-TRACE_SYSCALL_TABLE(sys_connect, sys_connect, 283, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_accept
+-TRACE_SYSCALL_TABLE(sys_accept, sys_accept, 285, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getsockname
+-TRACE_SYSCALL_TABLE(sys_getsockname, sys_getsockname, 286, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getpeername
+-TRACE_SYSCALL_TABLE(sys_getpeername, sys_getpeername, 287, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_socketpair
+-TRACE_SYSCALL_TABLE(sys_socketpair, sys_socketpair, 288, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_send
+-TRACE_SYSCALL_TABLE(sys_send, sys_send, 289, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sendto
+-TRACE_SYSCALL_TABLE(sys_sendto, sys_sendto, 290, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_recvfrom
+-TRACE_SYSCALL_TABLE(sys_recvfrom, sys_recvfrom, 292, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_setsockopt
+-TRACE_SYSCALL_TABLE(sys_setsockopt, sys_setsockopt, 294, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getsockopt
+-TRACE_SYSCALL_TABLE(sys_getsockopt, sys_getsockopt, 295, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_sendmsg
+-TRACE_SYSCALL_TABLE(sys_sendmsg, sys_sendmsg, 296, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_recvmsg
+-TRACE_SYSCALL_TABLE(sys_recvmsg, sys_recvmsg, 297, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_semop
+-TRACE_SYSCALL_TABLE(sys_semop, sys_semop, 298, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_msgsnd
+-TRACE_SYSCALL_TABLE(sys_msgsnd, sys_msgsnd, 301, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_msgrcv
+-TRACE_SYSCALL_TABLE(sys_msgrcv, sys_msgrcv, 302, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_msgctl
+-TRACE_SYSCALL_TABLE(sys_msgctl, sys_msgctl, 304, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_shmat
+-TRACE_SYSCALL_TABLE(sys_shmat, sys_shmat, 305, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_shmdt
+-TRACE_SYSCALL_TABLE(sys_shmdt, sys_shmdt, 306, 1)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_shmctl
+-TRACE_SYSCALL_TABLE(sys_shmctl, sys_shmctl, 308, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_add_key
+-TRACE_SYSCALL_TABLE(sys_add_key, sys_add_key, 309, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_request_key
+-TRACE_SYSCALL_TABLE(sys_request_key, sys_request_key, 310, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_semtimedop
+-TRACE_SYSCALL_TABLE(sys_semtimedop, sys_semtimedop, 312, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_inotify_add_watch
+-TRACE_SYSCALL_TABLE(sys_inotify_add_watch, sys_inotify_add_watch, 317, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_openat
+-TRACE_SYSCALL_TABLE(sys_openat, sys_openat, 322, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mkdirat
+-TRACE_SYSCALL_TABLE(sys_mkdirat, sys_mkdirat, 323, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_mknodat
+-TRACE_SYSCALL_TABLE(sys_mknodat, sys_mknodat, 324, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchownat
+-TRACE_SYSCALL_TABLE(sys_fchownat, sys_fchownat, 325, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_futimesat
+-TRACE_SYSCALL_TABLE(sys_futimesat, sys_futimesat, 326, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fstatat64
+-TRACE_SYSCALL_TABLE(sys_fstatat64, sys_fstatat64, 327, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_unlinkat
+-TRACE_SYSCALL_TABLE(sys_unlinkat, sys_unlinkat, 328, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_renameat
+-TRACE_SYSCALL_TABLE(sys_renameat, sys_renameat, 329, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_linkat
+-TRACE_SYSCALL_TABLE(sys_linkat, sys_linkat, 330, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_symlinkat
+-TRACE_SYSCALL_TABLE(sys_symlinkat, sys_symlinkat, 331, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_readlinkat
+-TRACE_SYSCALL_TABLE(sys_readlinkat, sys_readlinkat, 332, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_fchmodat
+-TRACE_SYSCALL_TABLE(sys_fchmodat, sys_fchmodat, 333, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_faccessat
+-TRACE_SYSCALL_TABLE(sys_faccessat, sys_faccessat, 334, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pselect6
+-TRACE_SYSCALL_TABLE(sys_pselect6, sys_pselect6, 335, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_ppoll
+-TRACE_SYSCALL_TABLE(sys_ppoll, sys_ppoll, 336, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_set_robust_list
+-TRACE_SYSCALL_TABLE(sys_set_robust_list, sys_set_robust_list, 338, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_get_robust_list
+-TRACE_SYSCALL_TABLE(sys_get_robust_list, sys_get_robust_list, 339, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_splice
+-TRACE_SYSCALL_TABLE(sys_splice, sys_splice, 340, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_vmsplice
+-TRACE_SYSCALL_TABLE(sys_vmsplice, sys_vmsplice, 343, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_getcpu
+-TRACE_SYSCALL_TABLE(sys_getcpu, sys_getcpu, 345, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_epoll_pwait
+-TRACE_SYSCALL_TABLE(sys_epoll_pwait, sys_epoll_pwait, 346, 6)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_utimensat
+-TRACE_SYSCALL_TABLE(sys_utimensat, sys_utimensat, 348, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_signalfd
+-TRACE_SYSCALL_TABLE(sys_signalfd, sys_signalfd, 349, 3)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timerfd_settime
+-TRACE_SYSCALL_TABLE(sys_timerfd_settime, sys_timerfd_settime, 353, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_timerfd_gettime
+-TRACE_SYSCALL_TABLE(sys_timerfd_gettime, sys_timerfd_gettime, 354, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_signalfd4
+-TRACE_SYSCALL_TABLE(sys_signalfd4, sys_signalfd4, 355, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pipe2
+-TRACE_SYSCALL_TABLE(sys_pipe2, sys_pipe2, 359, 2)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_preadv
+-TRACE_SYSCALL_TABLE(sys_preadv, sys_preadv, 361, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_pwritev
+-TRACE_SYSCALL_TABLE(sys_pwritev, sys_pwritev, 362, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_rt_tgsigqueueinfo
+-TRACE_SYSCALL_TABLE(sys_rt_tgsigqueueinfo, sys_rt_tgsigqueueinfo, 363, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_recvmmsg
+-TRACE_SYSCALL_TABLE(sys_recvmmsg, sys_recvmmsg, 365, 5)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_accept4
+-TRACE_SYSCALL_TABLE(sys_accept4, sys_accept4, 366, 4)
+-#endif
+-#ifndef OVERRIDE_TABLE_32_sys_prlimit64
+-TRACE_SYSCALL_TABLE(sys_prlimit64, sys_prlimit64, 369, 4)
+-#endif
+-
+-#endif /* CREATE_SYSCALL_TABLE */
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers_override.h b/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers_override.h
+deleted file mode 100644
+index 65131bb..0000000
+--- a/instrumentation/syscalls/headers/arm-32-syscalls-2.6.38_pointers_override.h
++++ /dev/null
+@@ -1,39 +0,0 @@
+-
+-#define OVERRIDE_TABLE_32_sys_mmap2
+-
+-
+-#ifndef CREATE_SYSCALL_TABLE
+-
+-SC_TRACE_EVENT(sys_mmap2,
+-	TP_PROTO(void *addr, size_t len, int prot,
+-                 int flags, int fd, off_t pgoff),
+-	TP_ARGS(addr, len, prot, flags, fd, pgoff),
+-	TP_STRUCT__entry(
+-		__field_hex(void *, addr)
+-		__field(size_t, len)
+-		__field(int, prot)
+-		__field(int, flags)
+-		__field(int, fd)
+-		__field(off_t, pgoff)),
+-	TP_fast_assign(
+-		tp_assign(addr, addr)
+-		tp_assign(len, len)
+-		tp_assign(prot, prot)
+-		tp_assign(flags, flags)
+-		tp_assign(fd, fd)
+-		tp_assign(pgoff, pgoff)),
+-	TP_printk()
+-)
+-
+-#else	/* CREATE_SYSCALL_TABLE */
+-
+-#define OVERRIDE_TABLE_32_sys_execve
+-TRACE_SYSCALL_TABLE(sys_execve, sys_execve, 11, 3)
+-#define OVERRIDE_TABLE_32_sys_clone
+-TRACE_SYSCALL_TABLE(sys_clone, sys_clone, 120, 5)
+-#define OVERRIDE_TABLE_32_sys_mmap2
+-TRACE_SYSCALL_TABLE(sys_mmap2, sys_mmap2, 192, 6)
+-
+-#endif /* CREATE_SYSCALL_TABLE */
+-
+-
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers.h b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers.h
+new file mode 100644
+index 0000000..9b10e5e
+--- /dev/null
++++ b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers.h
+@@ -0,0 +1,1181 @@
++/* THIS FILE IS AUTO-GENERATED. DO NOT EDIT */
++#ifndef CREATE_SYSCALL_TABLE
++
++#if !defined(_TRACE_SYSCALLS_INTEGERS_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _TRACE_SYSCALLS_INTEGERS_H
++
++#include <linux/tracepoint.h>
++#include <linux/syscalls.h>
++#include "arm-32-syscalls-3.4.25_integers_override.h"
++#include "syscalls_integers_override.h"
++
++SC_DECLARE_EVENT_CLASS_NOARGS(syscalls_noargs,
++	TP_STRUCT__entry(),
++	TP_fast_assign(),
++	TP_printk()
++)
++#ifndef OVERRIDE_32_sys_restart_syscall
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_restart_syscall)
++#endif
++#ifndef OVERRIDE_32_sys_getpid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getpid)
++#endif
++#ifndef OVERRIDE_32_sys_getuid16
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getuid16)
++#endif
++#ifndef OVERRIDE_32_sys_pause
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_pause)
++#endif
++#ifndef OVERRIDE_32_sys_sync
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_sync)
++#endif
++#ifndef OVERRIDE_32_sys_getgid16
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getgid16)
++#endif
++#ifndef OVERRIDE_32_sys_geteuid16
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_geteuid16)
++#endif
++#ifndef OVERRIDE_32_sys_getegid16
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getegid16)
++#endif
++#ifndef OVERRIDE_32_sys_getppid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getppid)
++#endif
++#ifndef OVERRIDE_32_sys_getpgrp
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getpgrp)
++#endif
++#ifndef OVERRIDE_32_sys_setsid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_setsid)
++#endif
++#ifndef OVERRIDE_32_sys_vhangup
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_vhangup)
++#endif
++#ifndef OVERRIDE_32_sys_munlockall
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_munlockall)
++#endif
++#ifndef OVERRIDE_32_sys_sched_yield
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_sched_yield)
++#endif
++#ifndef OVERRIDE_32_sys_getuid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getuid)
++#endif
++#ifndef OVERRIDE_32_sys_getgid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getgid)
++#endif
++#ifndef OVERRIDE_32_sys_geteuid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_geteuid)
++#endif
++#ifndef OVERRIDE_32_sys_getegid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_getegid)
++#endif
++#ifndef OVERRIDE_32_sys_gettid
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_gettid)
++#endif
++#ifndef OVERRIDE_32_sys_inotify_init
++SC_DEFINE_EVENT_NOARGS(syscalls_noargs, sys_inotify_init)
++#endif
++#ifndef OVERRIDE_32_sys_exit
++SC_TRACE_EVENT(sys_exit,
++	TP_PROTO(int error_code),
++	TP_ARGS(error_code),
++	TP_STRUCT__entry(__field(int, error_code)),
++	TP_fast_assign(tp_assign(error_code, error_code)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_close
++SC_TRACE_EVENT(sys_close,
++	TP_PROTO(unsigned int fd),
++	TP_ARGS(fd),
++	TP_STRUCT__entry(__field(unsigned int, fd)),
++	TP_fast_assign(tp_assign(fd, fd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setuid16
++SC_TRACE_EVENT(sys_setuid16,
++	TP_PROTO(old_uid_t uid),
++	TP_ARGS(uid),
++	TP_STRUCT__entry(__field(old_uid_t, uid)),
++	TP_fast_assign(tp_assign(uid, uid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_nice
++SC_TRACE_EVENT(sys_nice,
++	TP_PROTO(int increment),
++	TP_ARGS(increment),
++	TP_STRUCT__entry(__field(int, increment)),
++	TP_fast_assign(tp_assign(increment, increment)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_dup
++SC_TRACE_EVENT(sys_dup,
++	TP_PROTO(unsigned int fildes),
++	TP_ARGS(fildes),
++	TP_STRUCT__entry(__field(unsigned int, fildes)),
++	TP_fast_assign(tp_assign(fildes, fildes)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_brk
++SC_TRACE_EVENT(sys_brk,
++	TP_PROTO(unsigned long brk),
++	TP_ARGS(brk),
++	TP_STRUCT__entry(__field(unsigned long, brk)),
++	TP_fast_assign(tp_assign(brk, brk)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setgid16
++SC_TRACE_EVENT(sys_setgid16,
++	TP_PROTO(old_gid_t gid),
++	TP_ARGS(gid),
++	TP_STRUCT__entry(__field(old_gid_t, gid)),
++	TP_fast_assign(tp_assign(gid, gid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_umask
++SC_TRACE_EVENT(sys_umask,
++	TP_PROTO(int mask),
++	TP_ARGS(mask),
++	TP_STRUCT__entry(__field(int, mask)),
++	TP_fast_assign(tp_assign(mask, mask)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fsync
++SC_TRACE_EVENT(sys_fsync,
++	TP_PROTO(unsigned int fd),
++	TP_ARGS(fd),
++	TP_STRUCT__entry(__field(unsigned int, fd)),
++	TP_fast_assign(tp_assign(fd, fd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getpgid
++SC_TRACE_EVENT(sys_getpgid,
++	TP_PROTO(pid_t pid),
++	TP_ARGS(pid),
++	TP_STRUCT__entry(__field(pid_t, pid)),
++	TP_fast_assign(tp_assign(pid, pid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchdir
++SC_TRACE_EVENT(sys_fchdir,
++	TP_PROTO(unsigned int fd),
++	TP_ARGS(fd),
++	TP_STRUCT__entry(__field(unsigned int, fd)),
++	TP_fast_assign(tp_assign(fd, fd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_personality
++SC_TRACE_EVENT(sys_personality,
++	TP_PROTO(unsigned int personality),
++	TP_ARGS(personality),
++	TP_STRUCT__entry(__field(unsigned int, personality)),
++	TP_fast_assign(tp_assign(personality, personality)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setfsuid16
++SC_TRACE_EVENT(sys_setfsuid16,
++	TP_PROTO(old_uid_t uid),
++	TP_ARGS(uid),
++	TP_STRUCT__entry(__field(old_uid_t, uid)),
++	TP_fast_assign(tp_assign(uid, uid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setfsgid16
++SC_TRACE_EVENT(sys_setfsgid16,
++	TP_PROTO(old_gid_t gid),
++	TP_ARGS(gid),
++	TP_STRUCT__entry(__field(old_gid_t, gid)),
++	TP_fast_assign(tp_assign(gid, gid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getsid
++SC_TRACE_EVENT(sys_getsid,
++	TP_PROTO(pid_t pid),
++	TP_ARGS(pid),
++	TP_STRUCT__entry(__field(pid_t, pid)),
++	TP_fast_assign(tp_assign(pid, pid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fdatasync
++SC_TRACE_EVENT(sys_fdatasync,
++	TP_PROTO(unsigned int fd),
++	TP_ARGS(fd),
++	TP_STRUCT__entry(__field(unsigned int, fd)),
++	TP_fast_assign(tp_assign(fd, fd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mlockall
++SC_TRACE_EVENT(sys_mlockall,
++	TP_PROTO(int flags),
++	TP_ARGS(flags),
++	TP_STRUCT__entry(__field(int, flags)),
++	TP_fast_assign(tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_getscheduler
++SC_TRACE_EVENT(sys_sched_getscheduler,
++	TP_PROTO(pid_t pid),
++	TP_ARGS(pid),
++	TP_STRUCT__entry(__field(pid_t, pid)),
++	TP_fast_assign(tp_assign(pid, pid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_get_priority_max
++SC_TRACE_EVENT(sys_sched_get_priority_max,
++	TP_PROTO(int policy),
++	TP_ARGS(policy),
++	TP_STRUCT__entry(__field(int, policy)),
++	TP_fast_assign(tp_assign(policy, policy)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_get_priority_min
++SC_TRACE_EVENT(sys_sched_get_priority_min,
++	TP_PROTO(int policy),
++	TP_ARGS(policy),
++	TP_STRUCT__entry(__field(int, policy)),
++	TP_fast_assign(tp_assign(policy, policy)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setuid
++SC_TRACE_EVENT(sys_setuid,
++	TP_PROTO(uid_t uid),
++	TP_ARGS(uid),
++	TP_STRUCT__entry(__field(uid_t, uid)),
++	TP_fast_assign(tp_assign(uid, uid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setgid
++SC_TRACE_EVENT(sys_setgid,
++	TP_PROTO(gid_t gid),
++	TP_ARGS(gid),
++	TP_STRUCT__entry(__field(gid_t, gid)),
++	TP_fast_assign(tp_assign(gid, gid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setfsuid
++SC_TRACE_EVENT(sys_setfsuid,
++	TP_PROTO(uid_t uid),
++	TP_ARGS(uid),
++	TP_STRUCT__entry(__field(uid_t, uid)),
++	TP_fast_assign(tp_assign(uid, uid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setfsgid
++SC_TRACE_EVENT(sys_setfsgid,
++	TP_PROTO(gid_t gid),
++	TP_ARGS(gid),
++	TP_STRUCT__entry(__field(gid_t, gid)),
++	TP_fast_assign(tp_assign(gid, gid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_io_destroy
++SC_TRACE_EVENT(sys_io_destroy,
++	TP_PROTO(aio_context_t ctx),
++	TP_ARGS(ctx),
++	TP_STRUCT__entry(__field(aio_context_t, ctx)),
++	TP_fast_assign(tp_assign(ctx, ctx)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_exit_group
++SC_TRACE_EVENT(sys_exit_group,
++	TP_PROTO(int error_code),
++	TP_ARGS(error_code),
++	TP_STRUCT__entry(__field(int, error_code)),
++	TP_fast_assign(tp_assign(error_code, error_code)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_epoll_create
++SC_TRACE_EVENT(sys_epoll_create,
++	TP_PROTO(int size),
++	TP_ARGS(size),
++	TP_STRUCT__entry(__field(int, size)),
++	TP_fast_assign(tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timer_getoverrun
++SC_TRACE_EVENT(sys_timer_getoverrun,
++	TP_PROTO(timer_t timer_id),
++	TP_ARGS(timer_id),
++	TP_STRUCT__entry(__field(timer_t, timer_id)),
++	TP_fast_assign(tp_assign(timer_id, timer_id)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timer_delete
++SC_TRACE_EVENT(sys_timer_delete,
++	TP_PROTO(timer_t timer_id),
++	TP_ARGS(timer_id),
++	TP_STRUCT__entry(__field(timer_t, timer_id)),
++	TP_fast_assign(tp_assign(timer_id, timer_id)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_unshare
++SC_TRACE_EVENT(sys_unshare,
++	TP_PROTO(unsigned long unshare_flags),
++	TP_ARGS(unshare_flags),
++	TP_STRUCT__entry(__field(unsigned long, unshare_flags)),
++	TP_fast_assign(tp_assign(unshare_flags, unshare_flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_eventfd
++SC_TRACE_EVENT(sys_eventfd,
++	TP_PROTO(unsigned int count),
++	TP_ARGS(count),
++	TP_STRUCT__entry(__field(unsigned int, count)),
++	TP_fast_assign(tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_epoll_create1
++SC_TRACE_EVENT(sys_epoll_create1,
++	TP_PROTO(int flags),
++	TP_ARGS(flags),
++	TP_STRUCT__entry(__field(int, flags)),
++	TP_fast_assign(tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_inotify_init1
++SC_TRACE_EVENT(sys_inotify_init1,
++	TP_PROTO(int flags),
++	TP_ARGS(flags),
++	TP_STRUCT__entry(__field(int, flags)),
++	TP_fast_assign(tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_syncfs
++SC_TRACE_EVENT(sys_syncfs,
++	TP_PROTO(int fd),
++	TP_ARGS(fd),
++	TP_STRUCT__entry(__field(int, fd)),
++	TP_fast_assign(tp_assign(fd, fd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_kill
++SC_TRACE_EVENT(sys_kill,
++	TP_PROTO(pid_t pid, int sig),
++	TP_ARGS(pid, sig),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setpgid
++SC_TRACE_EVENT(sys_setpgid,
++	TP_PROTO(pid_t pid, pid_t pgid),
++	TP_ARGS(pid, pgid),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(pid_t, pgid)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(pgid, pgid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_dup2
++SC_TRACE_EVENT(sys_dup2,
++	TP_PROTO(unsigned int oldfd, unsigned int newfd),
++	TP_ARGS(oldfd, newfd),
++	TP_STRUCT__entry(__field(unsigned int, oldfd) __field(unsigned int, newfd)),
++	TP_fast_assign(tp_assign(oldfd, oldfd) tp_assign(newfd, newfd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setreuid16
++SC_TRACE_EVENT(sys_setreuid16,
++	TP_PROTO(old_uid_t ruid, old_uid_t euid),
++	TP_ARGS(ruid, euid),
++	TP_STRUCT__entry(__field(old_uid_t, ruid) __field(old_uid_t, euid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setregid16
++SC_TRACE_EVENT(sys_setregid16,
++	TP_PROTO(old_gid_t rgid, old_gid_t egid),
++	TP_ARGS(rgid, egid),
++	TP_STRUCT__entry(__field(old_gid_t, rgid) __field(old_gid_t, egid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_munmap
++SC_TRACE_EVENT(sys_munmap,
++	TP_PROTO(unsigned long addr, size_t len),
++	TP_ARGS(addr, len),
++	TP_STRUCT__entry(__field_hex(unsigned long, addr) __field(size_t, len)),
++	TP_fast_assign(tp_assign(addr, addr) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ftruncate
++SC_TRACE_EVENT(sys_ftruncate,
++	TP_PROTO(unsigned int fd, unsigned long length),
++	TP_ARGS(fd, length),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned long, length)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(length, length)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchmod
++SC_TRACE_EVENT(sys_fchmod,
++	TP_PROTO(unsigned int fd, umode_t mode),
++	TP_ARGS(fd, mode),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(umode_t, mode)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getpriority
++SC_TRACE_EVENT(sys_getpriority,
++	TP_PROTO(int which, int who),
++	TP_ARGS(which, who),
++	TP_STRUCT__entry(__field(int, which) __field(int, who)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(who, who)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_bdflush
++SC_TRACE_EVENT(sys_bdflush,
++	TP_PROTO(int func, long data),
++	TP_ARGS(func, data),
++	TP_STRUCT__entry(__field(int, func) __field(long, data)),
++	TP_fast_assign(tp_assign(func, func) tp_assign(data, data)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_flock
++SC_TRACE_EVENT(sys_flock,
++	TP_PROTO(unsigned int fd, unsigned int cmd),
++	TP_ARGS(fd, cmd),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mlock
++SC_TRACE_EVENT(sys_mlock,
++	TP_PROTO(unsigned long start, size_t len),
++	TP_ARGS(start, len),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_munlock
++SC_TRACE_EVENT(sys_munlock,
++	TP_PROTO(unsigned long start, size_t len),
++	TP_ARGS(start, len),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setreuid
++SC_TRACE_EVENT(sys_setreuid,
++	TP_PROTO(uid_t ruid, uid_t euid),
++	TP_ARGS(ruid, euid),
++	TP_STRUCT__entry(__field(uid_t, ruid) __field(uid_t, euid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setregid
++SC_TRACE_EVENT(sys_setregid,
++	TP_PROTO(gid_t rgid, gid_t egid),
++	TP_ARGS(rgid, egid),
++	TP_STRUCT__entry(__field(gid_t, rgid) __field(gid_t, egid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_tkill
++SC_TRACE_EVENT(sys_tkill,
++	TP_PROTO(pid_t pid, int sig),
++	TP_ARGS(pid, sig),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_listen
++SC_TRACE_EVENT(sys_listen,
++	TP_PROTO(int fd, int backlog),
++	TP_ARGS(fd, backlog),
++	TP_STRUCT__entry(__field(int, fd) __field(int, backlog)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(backlog, backlog)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_shutdown
++SC_TRACE_EVENT(sys_shutdown,
++	TP_PROTO(int fd, int how),
++	TP_ARGS(fd, how),
++	TP_STRUCT__entry(__field(int, fd) __field(int, how)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(how, how)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_msgget
++SC_TRACE_EVENT(sys_msgget,
++	TP_PROTO(key_t key, int msgflg),
++	TP_ARGS(key, msgflg),
++	TP_STRUCT__entry(__field(key_t, key) __field(int, msgflg)),
++	TP_fast_assign(tp_assign(key, key) tp_assign(msgflg, msgflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ioprio_get
++SC_TRACE_EVENT(sys_ioprio_get,
++	TP_PROTO(int which, int who),
++	TP_ARGS(which, who),
++	TP_STRUCT__entry(__field(int, which) __field(int, who)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(who, who)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_inotify_rm_watch
++SC_TRACE_EVENT(sys_inotify_rm_watch,
++	TP_PROTO(int fd, __s32 wd),
++	TP_ARGS(fd, wd),
++	TP_STRUCT__entry(__field(int, fd) __field(__s32, wd)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(wd, wd)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timerfd_create
++SC_TRACE_EVENT(sys_timerfd_create,
++	TP_PROTO(int clockid, int flags),
++	TP_ARGS(clockid, flags),
++	TP_STRUCT__entry(__field(int, clockid) __field(int, flags)),
++	TP_fast_assign(tp_assign(clockid, clockid) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_eventfd2
++SC_TRACE_EVENT(sys_eventfd2,
++	TP_PROTO(unsigned int count, int flags),
++	TP_ARGS(count, flags),
++	TP_STRUCT__entry(__field(unsigned int, count) __field(int, flags)),
++	TP_fast_assign(tp_assign(count, count) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fanotify_init
++SC_TRACE_EVENT(sys_fanotify_init,
++	TP_PROTO(unsigned int flags, unsigned int event_f_flags),
++	TP_ARGS(flags, event_f_flags),
++	TP_STRUCT__entry(__field(unsigned int, flags) __field(unsigned int, event_f_flags)),
++	TP_fast_assign(tp_assign(flags, flags) tp_assign(event_f_flags, event_f_flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setns
++SC_TRACE_EVENT(sys_setns,
++	TP_PROTO(int fd, int nstype),
++	TP_ARGS(fd, nstype),
++	TP_STRUCT__entry(__field(int, fd) __field(int, nstype)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(nstype, nstype)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lseek
++SC_TRACE_EVENT(sys_lseek,
++	TP_PROTO(unsigned int fd, off_t offset, unsigned int origin),
++	TP_ARGS(fd, offset, origin),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(off_t, offset) __field(unsigned int, origin)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(offset, offset) tp_assign(origin, origin)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ioctl
++SC_TRACE_EVENT(sys_ioctl,
++	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
++	TP_ARGS(fd, cmd, arg),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fcntl
++SC_TRACE_EVENT(sys_fcntl,
++	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
++	TP_ARGS(fd, cmd, arg),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchown16
++SC_TRACE_EVENT(sys_fchown16,
++	TP_PROTO(unsigned int fd, old_uid_t user, old_gid_t group),
++	TP_ARGS(fd, user, group),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(old_uid_t, user) __field(old_gid_t, group)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setpriority
++SC_TRACE_EVENT(sys_setpriority,
++	TP_PROTO(int which, int who, int niceval),
++	TP_ARGS(which, who, niceval),
++	TP_STRUCT__entry(__field(int, which) __field(int, who) __field(int, niceval)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(who, who) tp_assign(niceval, niceval)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mprotect
++SC_TRACE_EVENT(sys_mprotect,
++	TP_PROTO(unsigned long start, size_t len, unsigned long prot),
++	TP_ARGS(start, len, prot),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field(unsigned long, prot)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(prot, prot)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sysfs
++SC_TRACE_EVENT(sys_sysfs,
++	TP_PROTO(int option, unsigned long arg1, unsigned long arg2),
++	TP_ARGS(option, arg1, arg2),
++	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg1) __field(unsigned long, arg2)),
++	TP_fast_assign(tp_assign(option, option) tp_assign(arg1, arg1) tp_assign(arg2, arg2)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_msync
++SC_TRACE_EVENT(sys_msync,
++	TP_PROTO(unsigned long start, size_t len, int flags),
++	TP_ARGS(start, len, flags),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field(int, flags)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setresuid16
++SC_TRACE_EVENT(sys_setresuid16,
++	TP_PROTO(old_uid_t ruid, old_uid_t euid, old_uid_t suid),
++	TP_ARGS(ruid, euid, suid),
++	TP_STRUCT__entry(__field(old_uid_t, ruid) __field(old_uid_t, euid) __field(old_uid_t, suid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setresgid16
++SC_TRACE_EVENT(sys_setresgid16,
++	TP_PROTO(old_gid_t rgid, old_gid_t egid, old_gid_t sgid),
++	TP_ARGS(rgid, egid, sgid),
++	TP_STRUCT__entry(__field(old_gid_t, rgid) __field(old_gid_t, egid) __field(old_gid_t, sgid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchown
++SC_TRACE_EVENT(sys_fchown,
++	TP_PROTO(unsigned int fd, uid_t user, gid_t group),
++	TP_ARGS(fd, user, group),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(uid_t, user) __field(gid_t, group)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setresuid
++SC_TRACE_EVENT(sys_setresuid,
++	TP_PROTO(uid_t ruid, uid_t euid, uid_t suid),
++	TP_ARGS(ruid, euid, suid),
++	TP_STRUCT__entry(__field(uid_t, ruid) __field(uid_t, euid) __field(uid_t, suid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setresgid
++SC_TRACE_EVENT(sys_setresgid,
++	TP_PROTO(gid_t rgid, gid_t egid, gid_t sgid),
++	TP_ARGS(rgid, egid, sgid),
++	TP_STRUCT__entry(__field(gid_t, rgid) __field(gid_t, egid) __field(gid_t, sgid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_madvise
++SC_TRACE_EVENT(sys_madvise,
++	TP_PROTO(unsigned long start, size_t len_in, int behavior),
++	TP_ARGS(start, len_in, behavior),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len_in) __field(int, behavior)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len_in, len_in) tp_assign(behavior, behavior)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fcntl64
++SC_TRACE_EVENT(sys_fcntl64,
++	TP_PROTO(unsigned int fd, unsigned int cmd, unsigned long arg),
++	TP_ARGS(fd, cmd, arg),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned int, cmd) __field(unsigned long, arg)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(cmd, cmd) tp_assign(arg, arg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_tgkill
++SC_TRACE_EVENT(sys_tgkill,
++	TP_PROTO(pid_t tgid, pid_t pid, int sig),
++	TP_ARGS(tgid, pid, sig),
++	TP_STRUCT__entry(__field(pid_t, tgid) __field(pid_t, pid) __field(int, sig)),
++	TP_fast_assign(tp_assign(tgid, tgid) tp_assign(pid, pid) tp_assign(sig, sig)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_socket
++SC_TRACE_EVENT(sys_socket,
++	TP_PROTO(int family, int type, int protocol),
++	TP_ARGS(family, type, protocol),
++	TP_STRUCT__entry(__field(int, family) __field(int, type) __field(int, protocol)),
++	TP_fast_assign(tp_assign(family, family) tp_assign(type, type) tp_assign(protocol, protocol)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_semget
++SC_TRACE_EVENT(sys_semget,
++	TP_PROTO(key_t key, int nsems, int semflg),
++	TP_ARGS(key, nsems, semflg),
++	TP_STRUCT__entry(__field(key_t, key) __field(int, nsems) __field(int, semflg)),
++	TP_fast_assign(tp_assign(key, key) tp_assign(nsems, nsems) tp_assign(semflg, semflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_shmget
++SC_TRACE_EVENT(sys_shmget,
++	TP_PROTO(key_t key, size_t size, int shmflg),
++	TP_ARGS(key, size, shmflg),
++	TP_STRUCT__entry(__field(key_t, key) __field(size_t, size) __field(int, shmflg)),
++	TP_fast_assign(tp_assign(key, key) tp_assign(size, size) tp_assign(shmflg, shmflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ioprio_set
++SC_TRACE_EVENT(sys_ioprio_set,
++	TP_PROTO(int which, int who, int ioprio),
++	TP_ARGS(which, who, ioprio),
++	TP_STRUCT__entry(__field(int, which) __field(int, who) __field(int, ioprio)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(who, who) tp_assign(ioprio, ioprio)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_dup3
++SC_TRACE_EVENT(sys_dup3,
++	TP_PROTO(unsigned int oldfd, unsigned int newfd, int flags),
++	TP_ARGS(oldfd, newfd, flags),
++	TP_STRUCT__entry(__field(unsigned int, oldfd) __field(unsigned int, newfd) __field(int, flags)),
++	TP_fast_assign(tp_assign(oldfd, oldfd) tp_assign(newfd, newfd) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ptrace
++SC_TRACE_EVENT(sys_ptrace,
++	TP_PROTO(long request, long pid, unsigned long addr, unsigned long data),
++	TP_ARGS(request, pid, addr, data),
++	TP_STRUCT__entry(__field(long, request) __field(long, pid) __field_hex(unsigned long, addr) __field(unsigned long, data)),
++	TP_fast_assign(tp_assign(request, request) tp_assign(pid, pid) tp_assign(addr, addr) tp_assign(data, data)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_tee
++SC_TRACE_EVENT(sys_tee,
++	TP_PROTO(int fdin, int fdout, size_t len, unsigned int flags),
++	TP_ARGS(fdin, fdout, len, flags),
++	TP_STRUCT__entry(__field(int, fdin) __field(int, fdout) __field(size_t, len) __field(unsigned int, flags)),
++	TP_fast_assign(tp_assign(fdin, fdin) tp_assign(fdout, fdout) tp_assign(len, len) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mremap
++SC_TRACE_EVENT(sys_mremap,
++	TP_PROTO(unsigned long addr, unsigned long old_len, unsigned long new_len, unsigned long flags, unsigned long new_addr),
++	TP_ARGS(addr, old_len, new_len, flags, new_addr),
++	TP_STRUCT__entry(__field_hex(unsigned long, addr) __field(unsigned long, old_len) __field(unsigned long, new_len) __field(unsigned long, flags) __field_hex(unsigned long, new_addr)),
++	TP_fast_assign(tp_assign(addr, addr) tp_assign(old_len, old_len) tp_assign(new_len, new_len) tp_assign(flags, flags) tp_assign(new_addr, new_addr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_prctl
++SC_TRACE_EVENT(sys_prctl,
++	TP_PROTO(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5),
++	TP_ARGS(option, arg2, arg3, arg4, arg5),
++	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg2) __field(unsigned long, arg3) __field(unsigned long, arg4) __field(unsigned long, arg5)),
++	TP_fast_assign(tp_assign(option, option) tp_assign(arg2, arg2) tp_assign(arg3, arg3) tp_assign(arg4, arg4) tp_assign(arg5, arg5)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_remap_file_pages
++SC_TRACE_EVENT(sys_remap_file_pages,
++	TP_PROTO(unsigned long start, unsigned long size, unsigned long prot, unsigned long pgoff, unsigned long flags),
++	TP_ARGS(start, size, prot, pgoff, flags),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(unsigned long, size) __field(unsigned long, prot) __field(unsigned long, pgoff) __field(unsigned long, flags)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(size, size) tp_assign(prot, prot) tp_assign(pgoff, pgoff) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_keyctl
++SC_TRACE_EVENT(sys_keyctl,
++	TP_PROTO(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5),
++	TP_ARGS(option, arg2, arg3, arg4, arg5),
++	TP_STRUCT__entry(__field(int, option) __field(unsigned long, arg2) __field(unsigned long, arg3) __field(unsigned long, arg4) __field(unsigned long, arg5)),
++	TP_fast_assign(tp_assign(option, option) tp_assign(arg2, arg2) tp_assign(arg3, arg3) tp_assign(arg4, arg4) tp_assign(arg5, arg5)),
++	TP_printk()
++)
++#endif
++
++#endif /*  _TRACE_SYSCALLS_INTEGERS_H */
++
++/* This part must be outside protection */
++#include "../../../probes/define_trace.h"
++
++#else /* CREATE_SYSCALL_TABLE */
++
++#include "arm-32-syscalls-3.4.25_integers_override.h"
++#include "syscalls_integers_override.h"
++
++#ifndef OVERRIDE_TABLE_32_sys_restart_syscall
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_restart_syscall, 0, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getpid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getpid, 20, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getuid16
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getuid16, 24, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pause
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_pause, 29, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sync
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_sync, 36, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getgid16
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getgid16, 47, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_geteuid16
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_geteuid16, 49, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getegid16
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getegid16, 50, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getppid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getppid, 64, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getpgrp
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getpgrp, 65, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setsid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_setsid, 66, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_vhangup
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_vhangup, 111, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_munlockall
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_munlockall, 153, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_yield
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_sched_yield, 158, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getuid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getuid, 199, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getgid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getgid, 200, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_geteuid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_geteuid, 201, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getegid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_getegid, 202, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_gettid
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_gettid, 224, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_inotify_init
++TRACE_SYSCALL_TABLE(syscalls_noargs, sys_inotify_init, 316, 0)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_exit
++TRACE_SYSCALL_TABLE(sys_exit, sys_exit, 1, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_close
++TRACE_SYSCALL_TABLE(sys_close, sys_close, 6, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lseek
++TRACE_SYSCALL_TABLE(sys_lseek, sys_lseek, 19, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setuid16
++TRACE_SYSCALL_TABLE(sys_setuid16, sys_setuid16, 23, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ptrace
++TRACE_SYSCALL_TABLE(sys_ptrace, sys_ptrace, 26, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_nice
++TRACE_SYSCALL_TABLE(sys_nice, sys_nice, 34, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_kill
++TRACE_SYSCALL_TABLE(sys_kill, sys_kill, 37, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_dup
++TRACE_SYSCALL_TABLE(sys_dup, sys_dup, 41, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_brk
++TRACE_SYSCALL_TABLE(sys_brk, sys_brk, 45, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setgid16
++TRACE_SYSCALL_TABLE(sys_setgid16, sys_setgid16, 46, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ioctl
++TRACE_SYSCALL_TABLE(sys_ioctl, sys_ioctl, 54, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fcntl
++TRACE_SYSCALL_TABLE(sys_fcntl, sys_fcntl, 55, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setpgid
++TRACE_SYSCALL_TABLE(sys_setpgid, sys_setpgid, 57, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_umask
++TRACE_SYSCALL_TABLE(sys_umask, sys_umask, 60, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_dup2
++TRACE_SYSCALL_TABLE(sys_dup2, sys_dup2, 63, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setreuid16
++TRACE_SYSCALL_TABLE(sys_setreuid16, sys_setreuid16, 70, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setregid16
++TRACE_SYSCALL_TABLE(sys_setregid16, sys_setregid16, 71, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_munmap
++TRACE_SYSCALL_TABLE(sys_munmap, sys_munmap, 91, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ftruncate
++TRACE_SYSCALL_TABLE(sys_ftruncate, sys_ftruncate, 93, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchmod
++TRACE_SYSCALL_TABLE(sys_fchmod, sys_fchmod, 94, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchown16
++TRACE_SYSCALL_TABLE(sys_fchown16, sys_fchown16, 95, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getpriority
++TRACE_SYSCALL_TABLE(sys_getpriority, sys_getpriority, 96, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setpriority
++TRACE_SYSCALL_TABLE(sys_setpriority, sys_setpriority, 97, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fsync
++TRACE_SYSCALL_TABLE(sys_fsync, sys_fsync, 118, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mprotect
++TRACE_SYSCALL_TABLE(sys_mprotect, sys_mprotect, 125, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getpgid
++TRACE_SYSCALL_TABLE(sys_getpgid, sys_getpgid, 132, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchdir
++TRACE_SYSCALL_TABLE(sys_fchdir, sys_fchdir, 133, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_bdflush
++TRACE_SYSCALL_TABLE(sys_bdflush, sys_bdflush, 134, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sysfs
++TRACE_SYSCALL_TABLE(sys_sysfs, sys_sysfs, 135, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_personality
++TRACE_SYSCALL_TABLE(sys_personality, sys_personality, 136, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setfsuid16
++TRACE_SYSCALL_TABLE(sys_setfsuid16, sys_setfsuid16, 138, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setfsgid16
++TRACE_SYSCALL_TABLE(sys_setfsgid16, sys_setfsgid16, 139, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_flock
++TRACE_SYSCALL_TABLE(sys_flock, sys_flock, 143, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_msync
++TRACE_SYSCALL_TABLE(sys_msync, sys_msync, 144, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getsid
++TRACE_SYSCALL_TABLE(sys_getsid, sys_getsid, 147, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fdatasync
++TRACE_SYSCALL_TABLE(sys_fdatasync, sys_fdatasync, 148, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mlock
++TRACE_SYSCALL_TABLE(sys_mlock, sys_mlock, 150, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_munlock
++TRACE_SYSCALL_TABLE(sys_munlock, sys_munlock, 151, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mlockall
++TRACE_SYSCALL_TABLE(sys_mlockall, sys_mlockall, 152, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_getscheduler
++TRACE_SYSCALL_TABLE(sys_sched_getscheduler, sys_sched_getscheduler, 157, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_get_priority_max
++TRACE_SYSCALL_TABLE(sys_sched_get_priority_max, sys_sched_get_priority_max, 159, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_get_priority_min
++TRACE_SYSCALL_TABLE(sys_sched_get_priority_min, sys_sched_get_priority_min, 160, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mremap
++TRACE_SYSCALL_TABLE(sys_mremap, sys_mremap, 163, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setresuid16
++TRACE_SYSCALL_TABLE(sys_setresuid16, sys_setresuid16, 164, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setresgid16
++TRACE_SYSCALL_TABLE(sys_setresgid16, sys_setresgid16, 170, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_prctl
++TRACE_SYSCALL_TABLE(sys_prctl, sys_prctl, 172, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setreuid
++TRACE_SYSCALL_TABLE(sys_setreuid, sys_setreuid, 203, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setregid
++TRACE_SYSCALL_TABLE(sys_setregid, sys_setregid, 204, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchown
++TRACE_SYSCALL_TABLE(sys_fchown, sys_fchown, 207, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setresuid
++TRACE_SYSCALL_TABLE(sys_setresuid, sys_setresuid, 208, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setresgid
++TRACE_SYSCALL_TABLE(sys_setresgid, sys_setresgid, 210, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setuid
++TRACE_SYSCALL_TABLE(sys_setuid, sys_setuid, 213, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setgid
++TRACE_SYSCALL_TABLE(sys_setgid, sys_setgid, 214, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setfsuid
++TRACE_SYSCALL_TABLE(sys_setfsuid, sys_setfsuid, 215, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setfsgid
++TRACE_SYSCALL_TABLE(sys_setfsgid, sys_setfsgid, 216, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_madvise
++TRACE_SYSCALL_TABLE(sys_madvise, sys_madvise, 220, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fcntl64
++TRACE_SYSCALL_TABLE(sys_fcntl64, sys_fcntl64, 221, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_tkill
++TRACE_SYSCALL_TABLE(sys_tkill, sys_tkill, 238, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_io_destroy
++TRACE_SYSCALL_TABLE(sys_io_destroy, sys_io_destroy, 244, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_exit_group
++TRACE_SYSCALL_TABLE(sys_exit_group, sys_exit_group, 248, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_epoll_create
++TRACE_SYSCALL_TABLE(sys_epoll_create, sys_epoll_create, 250, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_remap_file_pages
++TRACE_SYSCALL_TABLE(sys_remap_file_pages, sys_remap_file_pages, 253, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timer_getoverrun
++TRACE_SYSCALL_TABLE(sys_timer_getoverrun, sys_timer_getoverrun, 260, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timer_delete
++TRACE_SYSCALL_TABLE(sys_timer_delete, sys_timer_delete, 261, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_tgkill
++TRACE_SYSCALL_TABLE(sys_tgkill, sys_tgkill, 268, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_socket
++TRACE_SYSCALL_TABLE(sys_socket, sys_socket, 281, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_listen
++TRACE_SYSCALL_TABLE(sys_listen, sys_listen, 284, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_shutdown
++TRACE_SYSCALL_TABLE(sys_shutdown, sys_shutdown, 293, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_semget
++TRACE_SYSCALL_TABLE(sys_semget, sys_semget, 299, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_msgget
++TRACE_SYSCALL_TABLE(sys_msgget, sys_msgget, 303, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_shmget
++TRACE_SYSCALL_TABLE(sys_shmget, sys_shmget, 307, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_keyctl
++TRACE_SYSCALL_TABLE(sys_keyctl, sys_keyctl, 311, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ioprio_set
++TRACE_SYSCALL_TABLE(sys_ioprio_set, sys_ioprio_set, 314, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ioprio_get
++TRACE_SYSCALL_TABLE(sys_ioprio_get, sys_ioprio_get, 315, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_inotify_rm_watch
++TRACE_SYSCALL_TABLE(sys_inotify_rm_watch, sys_inotify_rm_watch, 318, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_unshare
++TRACE_SYSCALL_TABLE(sys_unshare, sys_unshare, 337, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_tee
++TRACE_SYSCALL_TABLE(sys_tee, sys_tee, 342, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timerfd_create
++TRACE_SYSCALL_TABLE(sys_timerfd_create, sys_timerfd_create, 350, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_eventfd
++TRACE_SYSCALL_TABLE(sys_eventfd, sys_eventfd, 351, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_eventfd2
++TRACE_SYSCALL_TABLE(sys_eventfd2, sys_eventfd2, 356, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_epoll_create1
++TRACE_SYSCALL_TABLE(sys_epoll_create1, sys_epoll_create1, 357, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_dup3
++TRACE_SYSCALL_TABLE(sys_dup3, sys_dup3, 358, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_inotify_init1
++TRACE_SYSCALL_TABLE(sys_inotify_init1, sys_inotify_init1, 360, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fanotify_init
++TRACE_SYSCALL_TABLE(sys_fanotify_init, sys_fanotify_init, 367, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_syncfs
++TRACE_SYSCALL_TABLE(sys_syncfs, sys_syncfs, 373, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setns
++TRACE_SYSCALL_TABLE(sys_setns, sys_setns, 375, 2)
++#endif
++
++#endif /* CREATE_SYSCALL_TABLE */
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers_override.h b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers_override.h
+new file mode 100644
+index 0000000..895370f
+--- /dev/null
++++ b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_integers_override.h
+@@ -0,0 +1,52 @@
++
++
++#define OVERRIDE_TABLE_32_sys_arm_fadvise64_64
++#define OVERRIDE_TABLE_32_sys_sync_file_range2
++
++#ifndef CREATE_SYSCALL_TABLE
++
++SC_TRACE_EVENT(sys_arm_fadvise64_64,
++	TP_PROTO(int fd, int advice, loff_t offset, loff_t len),
++	TP_ARGS(fd, advice, offset, len),
++	TP_STRUCT__entry(
++		__field_hex(int, fd)
++		__field_hex(int, advice)
++		__field_hex(loff_t, offset)
++		__field_hex(loff_t, len)),
++	TP_fast_assign(
++		tp_assign(fd, fd)
++		tp_assign(advice, advice)
++		tp_assign(offset, offset)
++		tp_assign(len, len)),
++	TP_printk()
++)
++
++SC_TRACE_EVENT(sys_sync_file_range2,
++	TP_PROTO(int fd, loff_t offset, loff_t nbytes, unsigned int flags),
++	TP_ARGS(fd, offset, nbytes, flags),
++	TP_STRUCT__entry(
++		__field_hex(int, fd)
++		__field_hex(loff_t, offset)
++		__field_hex(loff_t, nbytes)
++		__field_hex(unsigned int, flags)),
++	TP_fast_assign(
++		tp_assign(fd, fd)
++		tp_assign(offset, offset)
++		tp_assign(nbytes, nbytes)
++		tp_assign(flags, flags)),
++	TP_printk()
++)
++
++#else	/* CREATE_SYSCALL_TABLE */
++
++#define OVVERRIDE_TABLE_32_sys_mmap
++TRACE_SYSCALL_TABLE(sys_mmap, sys_mmap, 90, 6)
++
++#define OVERRIDE_TABLE_32_sys_arm_fadvise64_64
++TRACE_SYSCALL_TABLE(sys_arm_fadvise64_64, sys_arm_fadvise64_64, 270, 4)
++#define OVERRIDE_TABLE_32_sys_sync_file_range2
++TRACE_SYSCALL_TABLE(sys_sync_file_range2, sys_sync_file_range2, 341, 4)
++
++#endif /* CREATE_SYSCALL_TABLE */
++
++
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers.h b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers.h
+new file mode 100644
+index 0000000..3a9c146
+--- /dev/null
++++ b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers.h
+@@ -0,0 +1,2316 @@
++/* THIS FILE IS AUTO-GENERATED. DO NOT EDIT */
++#ifndef CREATE_SYSCALL_TABLE
++
++#if !defined(_TRACE_SYSCALLS_POINTERS_H) || defined(TRACE_HEADER_MULTI_READ)
++#define _TRACE_SYSCALLS_POINTERS_H
++
++#include <linux/tracepoint.h>
++#include <linux/syscalls.h>
++#include "arm-32-syscalls-3.4.25_pointers_override.h"
++#include "syscalls_pointers_override.h"
++
++#ifndef OVERRIDE_32_sys_unlink
++SC_TRACE_EVENT(sys_unlink,
++	TP_PROTO(const char * pathname),
++	TP_ARGS(pathname),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_chdir
++SC_TRACE_EVENT(sys_chdir,
++	TP_PROTO(const char * filename),
++	TP_ARGS(filename),
++	TP_STRUCT__entry(__string_from_user(filename, filename)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rmdir
++SC_TRACE_EVENT(sys_rmdir,
++	TP_PROTO(const char * pathname),
++	TP_ARGS(pathname),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_pipe
++SC_TRACE_EVENT(sys_pipe,
++	TP_PROTO(int * fildes),
++	TP_ARGS(fildes),
++	TP_STRUCT__entry(__field_hex(int *, fildes)),
++	TP_fast_assign(tp_assign(fildes, fildes)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_times
++SC_TRACE_EVENT(sys_times,
++	TP_PROTO(struct tms * tbuf),
++	TP_ARGS(tbuf),
++	TP_STRUCT__entry(__field_hex(struct tms *, tbuf)),
++	TP_fast_assign(tp_assign(tbuf, tbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_acct
++SC_TRACE_EVENT(sys_acct,
++	TP_PROTO(const char * name),
++	TP_ARGS(name),
++	TP_STRUCT__entry(__string_from_user(name, name)),
++	TP_fast_assign(tp_copy_string_from_user(name, name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_chroot
++SC_TRACE_EVENT(sys_chroot,
++	TP_PROTO(const char * filename),
++	TP_ARGS(filename),
++	TP_STRUCT__entry(__string_from_user(filename, filename)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sigpending
++SC_TRACE_EVENT(sys_sigpending,
++	TP_PROTO(old_sigset_t * set),
++	TP_ARGS(set),
++	TP_STRUCT__entry(__field_hex(old_sigset_t *, set)),
++	TP_fast_assign(tp_assign(set, set)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_uselib
++SC_TRACE_EVENT(sys_uselib,
++	TP_PROTO(const char * library),
++	TP_ARGS(library),
++	TP_STRUCT__entry(__field_hex(const char *, library)),
++	TP_fast_assign(tp_assign(library, library)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_swapoff
++SC_TRACE_EVENT(sys_swapoff,
++	TP_PROTO(const char * specialfile),
++	TP_ARGS(specialfile),
++	TP_STRUCT__entry(__string_from_user(specialfile, specialfile)),
++	TP_fast_assign(tp_copy_string_from_user(specialfile, specialfile)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sysinfo
++SC_TRACE_EVENT(sys_sysinfo,
++	TP_PROTO(struct sysinfo * info),
++	TP_ARGS(info),
++	TP_STRUCT__entry(__field_hex(struct sysinfo *, info)),
++	TP_fast_assign(tp_assign(info, info)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_newuname
++SC_TRACE_EVENT(sys_newuname,
++	TP_PROTO(struct new_utsname * name),
++	TP_ARGS(name),
++	TP_STRUCT__entry(__field_hex(struct new_utsname *, name)),
++	TP_fast_assign(tp_assign(name, name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_adjtimex
++SC_TRACE_EVENT(sys_adjtimex,
++	TP_PROTO(struct timex * txc_p),
++	TP_ARGS(txc_p),
++	TP_STRUCT__entry(__field_hex(struct timex *, txc_p)),
++	TP_fast_assign(tp_assign(txc_p, txc_p)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sysctl
++SC_TRACE_EVENT(sys_sysctl,
++	TP_PROTO(struct __sysctl_args * args),
++	TP_ARGS(args),
++	TP_STRUCT__entry(__field_hex(struct __sysctl_args *, args)),
++	TP_fast_assign(tp_assign(args, args)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_set_tid_address
++SC_TRACE_EVENT(sys_set_tid_address,
++	TP_PROTO(int * tidptr),
++	TP_ARGS(tidptr),
++	TP_STRUCT__entry(__field_hex(int *, tidptr)),
++	TP_fast_assign(tp_assign(tidptr, tidptr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_unlink
++SC_TRACE_EVENT(sys_mq_unlink,
++	TP_PROTO(const char * u_name),
++	TP_ARGS(u_name),
++	TP_STRUCT__entry(__string_from_user(u_name, u_name)),
++	TP_fast_assign(tp_copy_string_from_user(u_name, u_name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_shmdt
++SC_TRACE_EVENT(sys_shmdt,
++	TP_PROTO(char * shmaddr),
++	TP_ARGS(shmaddr),
++	TP_STRUCT__entry(__field_hex(char *, shmaddr)),
++	TP_fast_assign(tp_assign(shmaddr, shmaddr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_creat
++SC_TRACE_EVENT(sys_creat,
++	TP_PROTO(const char * pathname, umode_t mode),
++	TP_ARGS(pathname, mode),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field(umode_t, mode)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_link
++SC_TRACE_EVENT(sys_link,
++	TP_PROTO(const char * oldname, const char * newname),
++	TP_ARGS(oldname, newname),
++	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
++	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_chmod
++SC_TRACE_EVENT(sys_chmod,
++	TP_PROTO(const char * filename, umode_t mode),
++	TP_ARGS(filename, mode),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(umode_t, mode)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_access
++SC_TRACE_EVENT(sys_access,
++	TP_PROTO(const char * filename, int mode),
++	TP_ARGS(filename, mode),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(int, mode)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rename
++SC_TRACE_EVENT(sys_rename,
++	TP_PROTO(const char * oldname, const char * newname),
++	TP_ARGS(oldname, newname),
++	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
++	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mkdir
++SC_TRACE_EVENT(sys_mkdir,
++	TP_PROTO(const char * pathname, umode_t mode),
++	TP_ARGS(pathname, mode),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field(umode_t, mode)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_umount
++SC_TRACE_EVENT(sys_umount,
++	TP_PROTO(char * name, int flags),
++	TP_ARGS(name, flags),
++	TP_STRUCT__entry(__string_from_user(name, name) __field(int, flags)),
++	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ustat
++SC_TRACE_EVENT(sys_ustat,
++	TP_PROTO(unsigned dev, struct ustat * ubuf),
++	TP_ARGS(dev, ubuf),
++	TP_STRUCT__entry(__field(unsigned, dev) __field_hex(struct ustat *, ubuf)),
++	TP_fast_assign(tp_assign(dev, dev) tp_assign(ubuf, ubuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sethostname
++SC_TRACE_EVENT(sys_sethostname,
++	TP_PROTO(char * name, int len),
++	TP_ARGS(name, len),
++	TP_STRUCT__entry(__string_from_user(name, name) __field(int, len)),
++	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setrlimit
++SC_TRACE_EVENT(sys_setrlimit,
++	TP_PROTO(unsigned int resource, struct rlimit * rlim),
++	TP_ARGS(resource, rlim),
++	TP_STRUCT__entry(__field(unsigned int, resource) __field_hex(struct rlimit *, rlim)),
++	TP_fast_assign(tp_assign(resource, resource) tp_assign(rlim, rlim)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getrusage
++SC_TRACE_EVENT(sys_getrusage,
++	TP_PROTO(int who, struct rusage * ru),
++	TP_ARGS(who, ru),
++	TP_STRUCT__entry(__field(int, who) __field_hex(struct rusage *, ru)),
++	TP_fast_assign(tp_assign(who, who) tp_assign(ru, ru)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_gettimeofday
++SC_TRACE_EVENT(sys_gettimeofday,
++	TP_PROTO(struct timeval * tv, struct timezone * tz),
++	TP_ARGS(tv, tz),
++	TP_STRUCT__entry(__field_hex(struct timeval *, tv) __field_hex(struct timezone *, tz)),
++	TP_fast_assign(tp_assign(tv, tv) tp_assign(tz, tz)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_settimeofday
++SC_TRACE_EVENT(sys_settimeofday,
++	TP_PROTO(struct timeval * tv, struct timezone * tz),
++	TP_ARGS(tv, tz),
++	TP_STRUCT__entry(__field_hex(struct timeval *, tv) __field_hex(struct timezone *, tz)),
++	TP_fast_assign(tp_assign(tv, tv) tp_assign(tz, tz)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getgroups16
++SC_TRACE_EVENT(sys_getgroups16,
++	TP_PROTO(int gidsetsize, old_gid_t * grouplist),
++	TP_ARGS(gidsetsize, grouplist),
++	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(old_gid_t *, grouplist)),
++	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setgroups16
++SC_TRACE_EVENT(sys_setgroups16,
++	TP_PROTO(int gidsetsize, old_gid_t * grouplist),
++	TP_ARGS(gidsetsize, grouplist),
++	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(old_gid_t *, grouplist)),
++	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_symlink
++SC_TRACE_EVENT(sys_symlink,
++	TP_PROTO(const char * oldname, const char * newname),
++	TP_ARGS(oldname, newname),
++	TP_STRUCT__entry(__string_from_user(oldname, oldname) __string_from_user(newname, newname)),
++	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_copy_string_from_user(newname, newname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_swapon
++SC_TRACE_EVENT(sys_swapon,
++	TP_PROTO(const char * specialfile, int swap_flags),
++	TP_ARGS(specialfile, swap_flags),
++	TP_STRUCT__entry(__string_from_user(specialfile, specialfile) __field(int, swap_flags)),
++	TP_fast_assign(tp_copy_string_from_user(specialfile, specialfile) tp_assign(swap_flags, swap_flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_truncate
++SC_TRACE_EVENT(sys_truncate,
++	TP_PROTO(const char * path, long length),
++	TP_ARGS(path, length),
++	TP_STRUCT__entry(__string_from_user(path, path) __field(long, length)),
++	TP_fast_assign(tp_copy_string_from_user(path, path) tp_assign(length, length)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_statfs
++SC_TRACE_EVENT(sys_statfs,
++	TP_PROTO(const char * pathname, struct statfs * buf),
++	TP_ARGS(pathname, buf),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(struct statfs *, buf)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(buf, buf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fstatfs
++SC_TRACE_EVENT(sys_fstatfs,
++	TP_PROTO(unsigned int fd, struct statfs * buf),
++	TP_ARGS(fd, buf),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct statfs *, buf)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getitimer
++SC_TRACE_EVENT(sys_getitimer,
++	TP_PROTO(int which, struct itimerval * value),
++	TP_ARGS(which, value),
++	TP_STRUCT__entry(__field(int, which) __field_hex(struct itimerval *, value)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(value, value)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_newstat
++SC_TRACE_EVENT(sys_newstat,
++	TP_PROTO(const char * filename, struct stat * statbuf),
++	TP_ARGS(filename, statbuf),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat *, statbuf)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_newlstat
++SC_TRACE_EVENT(sys_newlstat,
++	TP_PROTO(const char * filename, struct stat * statbuf),
++	TP_ARGS(filename, statbuf),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat *, statbuf)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_newfstat
++SC_TRACE_EVENT(sys_newfstat,
++	TP_PROTO(unsigned int fd, struct stat * statbuf),
++	TP_ARGS(fd, statbuf),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct stat *, statbuf)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setdomainname
++SC_TRACE_EVENT(sys_setdomainname,
++	TP_PROTO(char * name, int len),
++	TP_ARGS(name, len),
++	TP_STRUCT__entry(__string_from_user(name, name) __field(int, len)),
++	TP_fast_assign(tp_copy_string_from_user(name, name) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_delete_module
++SC_TRACE_EVENT(sys_delete_module,
++	TP_PROTO(const char * name_user, unsigned int flags),
++	TP_ARGS(name_user, flags),
++	TP_STRUCT__entry(__string_from_user(name_user, name_user) __field(unsigned int, flags)),
++	TP_fast_assign(tp_copy_string_from_user(name_user, name_user) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_setparam
++SC_TRACE_EVENT(sys_sched_setparam,
++	TP_PROTO(pid_t pid, struct sched_param * param),
++	TP_ARGS(pid, param),
++	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct sched_param *, param)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(param, param)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_getparam
++SC_TRACE_EVENT(sys_sched_getparam,
++	TP_PROTO(pid_t pid, struct sched_param * param),
++	TP_ARGS(pid, param),
++	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct sched_param *, param)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(param, param)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_rr_get_interval
++SC_TRACE_EVENT(sys_sched_rr_get_interval,
++	TP_PROTO(pid_t pid, struct timespec * interval),
++	TP_ARGS(pid, interval),
++	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(struct timespec *, interval)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(interval, interval)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_nanosleep
++SC_TRACE_EVENT(sys_nanosleep,
++	TP_PROTO(struct timespec * rqtp, struct timespec * rmtp),
++	TP_ARGS(rqtp, rmtp),
++	TP_STRUCT__entry(__field_hex(struct timespec *, rqtp) __field_hex(struct timespec *, rmtp)),
++	TP_fast_assign(tp_assign(rqtp, rqtp) tp_assign(rmtp, rmtp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigpending
++SC_TRACE_EVENT(sys_rt_sigpending,
++	TP_PROTO(sigset_t * set, size_t sigsetsize),
++	TP_ARGS(set, sigsetsize),
++	TP_STRUCT__entry(__field_hex(sigset_t *, set) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(set, set) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigsuspend
++SC_TRACE_EVENT(sys_rt_sigsuspend,
++	TP_PROTO(sigset_t * unewset, size_t sigsetsize),
++	TP_ARGS(unewset, sigsetsize),
++	TP_STRUCT__entry(__field_hex(sigset_t *, unewset) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(unewset, unewset) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getcwd
++SC_TRACE_EVENT(sys_getcwd,
++	TP_PROTO(char * buf, unsigned long size),
++	TP_ARGS(buf, size),
++	TP_STRUCT__entry(__field_hex(char *, buf) __field(unsigned long, size)),
++	TP_fast_assign(tp_assign(buf, buf) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getrlimit
++SC_TRACE_EVENT(sys_getrlimit,
++	TP_PROTO(unsigned int resource, struct rlimit * rlim),
++	TP_ARGS(resource, rlim),
++	TP_STRUCT__entry(__field(unsigned int, resource) __field_hex(struct rlimit *, rlim)),
++	TP_fast_assign(tp_assign(resource, resource) tp_assign(rlim, rlim)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_stat64
++SC_TRACE_EVENT(sys_stat64,
++	TP_PROTO(const char * filename, struct stat64 * statbuf),
++	TP_ARGS(filename, statbuf),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lstat64
++SC_TRACE_EVENT(sys_lstat64,
++	TP_PROTO(const char * filename, struct stat64 * statbuf),
++	TP_ARGS(filename, statbuf),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fstat64
++SC_TRACE_EVENT(sys_fstat64,
++	TP_PROTO(unsigned long fd, struct stat64 * statbuf),
++	TP_ARGS(fd, statbuf),
++	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(struct stat64 *, statbuf)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(statbuf, statbuf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getgroups
++SC_TRACE_EVENT(sys_getgroups,
++	TP_PROTO(int gidsetsize, gid_t * grouplist),
++	TP_ARGS(gidsetsize, grouplist),
++	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(gid_t *, grouplist)),
++	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setgroups
++SC_TRACE_EVENT(sys_setgroups,
++	TP_PROTO(int gidsetsize, gid_t * grouplist),
++	TP_ARGS(gidsetsize, grouplist),
++	TP_STRUCT__entry(__field(int, gidsetsize) __field_hex(gid_t *, grouplist)),
++	TP_fast_assign(tp_assign(gidsetsize, gidsetsize) tp_assign(grouplist, grouplist)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_pivot_root
++SC_TRACE_EVENT(sys_pivot_root,
++	TP_PROTO(const char * new_root, const char * put_old),
++	TP_ARGS(new_root, put_old),
++	TP_STRUCT__entry(__string_from_user(new_root, new_root) __string_from_user(put_old, put_old)),
++	TP_fast_assign(tp_copy_string_from_user(new_root, new_root) tp_copy_string_from_user(put_old, put_old)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_removexattr
++SC_TRACE_EVENT(sys_removexattr,
++	TP_PROTO(const char * pathname, const char * name),
++	TP_ARGS(pathname, name),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lremovexattr
++SC_TRACE_EVENT(sys_lremovexattr,
++	TP_PROTO(const char * pathname, const char * name),
++	TP_ARGS(pathname, name),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fremovexattr
++SC_TRACE_EVENT(sys_fremovexattr,
++	TP_PROTO(int fd, const char * name),
++	TP_ARGS(fd, name),
++	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name)),
++	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_io_setup
++SC_TRACE_EVENT(sys_io_setup,
++	TP_PROTO(unsigned nr_events, aio_context_t * ctxp),
++	TP_ARGS(nr_events, ctxp),
++	TP_STRUCT__entry(__field(unsigned, nr_events) __field_hex(aio_context_t *, ctxp)),
++	TP_fast_assign(tp_assign(nr_events, nr_events) tp_assign(ctxp, ctxp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timer_gettime
++SC_TRACE_EVENT(sys_timer_gettime,
++	TP_PROTO(timer_t timer_id, struct itimerspec * setting),
++	TP_ARGS(timer_id, setting),
++	TP_STRUCT__entry(__field(timer_t, timer_id) __field_hex(struct itimerspec *, setting)),
++	TP_fast_assign(tp_assign(timer_id, timer_id) tp_assign(setting, setting)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_clock_settime
++SC_TRACE_EVENT(sys_clock_settime,
++	TP_PROTO(const clockid_t which_clock, const struct timespec * tp),
++	TP_ARGS(which_clock, tp),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(const struct timespec *, tp)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_clock_gettime
++SC_TRACE_EVENT(sys_clock_gettime,
++	TP_PROTO(const clockid_t which_clock, struct timespec * tp),
++	TP_ARGS(which_clock, tp),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct timespec *, tp)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_clock_getres
++SC_TRACE_EVENT(sys_clock_getres,
++	TP_PROTO(const clockid_t which_clock, struct timespec * tp),
++	TP_ARGS(which_clock, tp),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct timespec *, tp)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(tp, tp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_utimes
++SC_TRACE_EVENT(sys_utimes,
++	TP_PROTO(char * filename, struct timeval * utimes),
++	TP_ARGS(filename, utimes),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field_hex(struct timeval *, utimes)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_notify
++SC_TRACE_EVENT(sys_mq_notify,
++	TP_PROTO(mqd_t mqdes, const struct sigevent * u_notification),
++	TP_ARGS(mqdes, u_notification),
++	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const struct sigevent *, u_notification)),
++	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_notification, u_notification)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_set_robust_list
++SC_TRACE_EVENT(sys_set_robust_list,
++	TP_PROTO(struct robust_list_head * head, size_t len),
++	TP_ARGS(head, len),
++	TP_STRUCT__entry(__field_hex(struct robust_list_head *, head) __field(size_t, len)),
++	TP_fast_assign(tp_assign(head, head) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timerfd_gettime
++SC_TRACE_EVENT(sys_timerfd_gettime,
++	TP_PROTO(int ufd, struct itimerspec * otmr),
++	TP_ARGS(ufd, otmr),
++	TP_STRUCT__entry(__field(int, ufd) __field_hex(struct itimerspec *, otmr)),
++	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(otmr, otmr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_pipe2
++SC_TRACE_EVENT(sys_pipe2,
++	TP_PROTO(int * fildes, int flags),
++	TP_ARGS(fildes, flags),
++	TP_STRUCT__entry(__field_hex(int *, fildes) __field(int, flags)),
++	TP_fast_assign(tp_assign(fildes, fildes) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_clock_adjtime
++SC_TRACE_EVENT(sys_clock_adjtime,
++	TP_PROTO(const clockid_t which_clock, struct timex * utx),
++	TP_ARGS(which_clock, utx),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct timex *, utx)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(utx, utx)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_read
++SC_TRACE_EVENT(sys_read,
++	TP_PROTO(unsigned int fd, char * buf, size_t count),
++	TP_ARGS(fd, buf, count),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(char *, buf) __field(size_t, count)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_write
++SC_TRACE_EVENT(sys_write,
++	TP_PROTO(unsigned int fd, const char * buf, size_t count),
++	TP_ARGS(fd, buf, count),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(const char *, buf) __field(size_t, count)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(buf, buf) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_open
++SC_TRACE_EVENT(sys_open,
++	TP_PROTO(const char * filename, int flags, umode_t mode),
++	TP_ARGS(filename, flags, mode),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(int, flags) __field(umode_t, mode)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(flags, flags) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mknod
++SC_TRACE_EVENT(sys_mknod,
++	TP_PROTO(const char * filename, umode_t mode, unsigned dev),
++	TP_ARGS(filename, mode, dev),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(umode_t, mode) __field(unsigned, dev)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(mode, mode) tp_assign(dev, dev)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lchown16
++SC_TRACE_EVENT(sys_lchown16,
++	TP_PROTO(const char * filename, old_uid_t user, old_gid_t group),
++	TP_ARGS(filename, user, group),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(old_uid_t, user) __field(old_gid_t, group)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_readlink
++SC_TRACE_EVENT(sys_readlink,
++	TP_PROTO(const char * path, char * buf, int bufsiz),
++	TP_ARGS(path, buf, bufsiz),
++	TP_STRUCT__entry(__string_from_user(path, path) __field_hex(char *, buf) __field(int, bufsiz)),
++	TP_fast_assign(tp_copy_string_from_user(path, path) tp_assign(buf, buf) tp_assign(bufsiz, bufsiz)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_syslog
++SC_TRACE_EVENT(sys_syslog,
++	TP_PROTO(int type, char * buf, int len),
++	TP_ARGS(type, buf, len),
++	TP_STRUCT__entry(__field(int, type) __field_hex(char *, buf) __field(int, len)),
++	TP_fast_assign(tp_assign(type, type) tp_assign(buf, buf) tp_assign(len, len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setitimer
++SC_TRACE_EVENT(sys_setitimer,
++	TP_PROTO(int which, struct itimerval * value, struct itimerval * ovalue),
++	TP_ARGS(which, value, ovalue),
++	TP_STRUCT__entry(__field(int, which) __field_hex(struct itimerval *, value) __field_hex(struct itimerval *, ovalue)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(value, value) tp_assign(ovalue, ovalue)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sigprocmask
++SC_TRACE_EVENT(sys_sigprocmask,
++	TP_PROTO(int how, old_sigset_t * nset, old_sigset_t * oset),
++	TP_ARGS(how, nset, oset),
++	TP_STRUCT__entry(__field(int, how) __field_hex(old_sigset_t *, nset) __field_hex(old_sigset_t *, oset)),
++	TP_fast_assign(tp_assign(how, how) tp_assign(nset, nset) tp_assign(oset, oset)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_init_module
++SC_TRACE_EVENT(sys_init_module,
++	TP_PROTO(void * umod, unsigned long len, const char * uargs),
++	TP_ARGS(umod, len, uargs),
++	TP_STRUCT__entry(__field_hex(void *, umod) __field(unsigned long, len) __field_hex(const char *, uargs)),
++	TP_fast_assign(tp_assign(umod, umod) tp_assign(len, len) tp_assign(uargs, uargs)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getdents
++SC_TRACE_EVENT(sys_getdents,
++	TP_PROTO(unsigned int fd, struct linux_dirent * dirent, unsigned int count),
++	TP_ARGS(fd, dirent, count),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct linux_dirent *, dirent) __field(unsigned int, count)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(dirent, dirent) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_readv
++SC_TRACE_EVENT(sys_readv,
++	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen),
++	TP_ARGS(fd, vec, vlen),
++	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_writev
++SC_TRACE_EVENT(sys_writev,
++	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen),
++	TP_ARGS(fd, vec, vlen),
++	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_setscheduler
++SC_TRACE_EVENT(sys_sched_setscheduler,
++	TP_PROTO(pid_t pid, int policy, struct sched_param * param),
++	TP_ARGS(pid, policy, param),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(int, policy) __field_hex(struct sched_param *, param)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(policy, policy) tp_assign(param, param)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getresuid16
++SC_TRACE_EVENT(sys_getresuid16,
++	TP_PROTO(old_uid_t * ruid, old_uid_t * euid, old_uid_t * suid),
++	TP_ARGS(ruid, euid, suid),
++	TP_STRUCT__entry(__field_hex(old_uid_t *, ruid) __field_hex(old_uid_t *, euid) __field_hex(old_uid_t *, suid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_poll
++SC_TRACE_EVENT(sys_poll,
++	TP_PROTO(struct pollfd * ufds, unsigned int nfds, int timeout_msecs),
++	TP_ARGS(ufds, nfds, timeout_msecs),
++	TP_STRUCT__entry(__field_hex(struct pollfd *, ufds) __field(unsigned int, nfds) __field(int, timeout_msecs)),
++	TP_fast_assign(tp_assign(ufds, ufds) tp_assign(nfds, nfds) tp_assign(timeout_msecs, timeout_msecs)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getresgid16
++SC_TRACE_EVENT(sys_getresgid16,
++	TP_PROTO(old_gid_t * rgid, old_gid_t * egid, old_gid_t * sgid),
++	TP_ARGS(rgid, egid, sgid),
++	TP_STRUCT__entry(__field_hex(old_gid_t *, rgid) __field_hex(old_gid_t *, egid) __field_hex(old_gid_t *, sgid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigqueueinfo
++SC_TRACE_EVENT(sys_rt_sigqueueinfo,
++	TP_PROTO(pid_t pid, int sig, siginfo_t * uinfo),
++	TP_ARGS(pid, sig, uinfo),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(int, sig) __field_hex(siginfo_t *, uinfo)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(sig, sig) tp_assign(uinfo, uinfo)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_chown16
++SC_TRACE_EVENT(sys_chown16,
++	TP_PROTO(const char * filename, old_uid_t user, old_gid_t group),
++	TP_ARGS(filename, user, group),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(old_uid_t, user) __field(old_gid_t, group)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lchown
++SC_TRACE_EVENT(sys_lchown,
++	TP_PROTO(const char * filename, uid_t user, gid_t group),
++	TP_ARGS(filename, user, group),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getresuid
++SC_TRACE_EVENT(sys_getresuid,
++	TP_PROTO(uid_t * ruid, uid_t * euid, uid_t * suid),
++	TP_ARGS(ruid, euid, suid),
++	TP_STRUCT__entry(__field_hex(uid_t *, ruid) __field_hex(uid_t *, euid) __field_hex(uid_t *, suid)),
++	TP_fast_assign(tp_assign(ruid, ruid) tp_assign(euid, euid) tp_assign(suid, suid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getresgid
++SC_TRACE_EVENT(sys_getresgid,
++	TP_PROTO(gid_t * rgid, gid_t * egid, gid_t * sgid),
++	TP_ARGS(rgid, egid, sgid),
++	TP_STRUCT__entry(__field_hex(gid_t *, rgid) __field_hex(gid_t *, egid) __field_hex(gid_t *, sgid)),
++	TP_fast_assign(tp_assign(rgid, rgid) tp_assign(egid, egid) tp_assign(sgid, sgid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_chown
++SC_TRACE_EVENT(sys_chown,
++	TP_PROTO(const char * filename, uid_t user, gid_t group),
++	TP_ARGS(filename, user, group),
++	TP_STRUCT__entry(__string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group)),
++	TP_fast_assign(tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getdents64
++SC_TRACE_EVENT(sys_getdents64,
++	TP_PROTO(unsigned int fd, struct linux_dirent64 * dirent, unsigned int count),
++	TP_ARGS(fd, dirent, count),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field_hex(struct linux_dirent64 *, dirent) __field(unsigned int, count)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(dirent, dirent) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mincore
++SC_TRACE_EVENT(sys_mincore,
++	TP_PROTO(unsigned long start, size_t len, unsigned char * vec),
++	TP_ARGS(start, len, vec),
++	TP_STRUCT__entry(__field(unsigned long, start) __field(size_t, len) __field_hex(unsigned char *, vec)),
++	TP_fast_assign(tp_assign(start, start) tp_assign(len, len) tp_assign(vec, vec)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_listxattr
++SC_TRACE_EVENT(sys_listxattr,
++	TP_PROTO(const char * pathname, char * list, size_t size),
++	TP_ARGS(pathname, list, size),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(char *, list) __field(size_t, size)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(list, list) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_llistxattr
++SC_TRACE_EVENT(sys_llistxattr,
++	TP_PROTO(const char * pathname, char * list, size_t size),
++	TP_ARGS(pathname, list, size),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __field_hex(char *, list) __field(size_t, size)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_assign(list, list) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_flistxattr
++SC_TRACE_EVENT(sys_flistxattr,
++	TP_PROTO(int fd, char * list, size_t size),
++	TP_ARGS(fd, list, size),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(char *, list) __field(size_t, size)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(list, list) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_setaffinity
++SC_TRACE_EVENT(sys_sched_setaffinity,
++	TP_PROTO(pid_t pid, unsigned int len, unsigned long * user_mask_ptr),
++	TP_ARGS(pid, len, user_mask_ptr),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, len) __field_hex(unsigned long *, user_mask_ptr)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(len, len) tp_assign(user_mask_ptr, user_mask_ptr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sched_getaffinity
++SC_TRACE_EVENT(sys_sched_getaffinity,
++	TP_PROTO(pid_t pid, unsigned int len, unsigned long * user_mask_ptr),
++	TP_ARGS(pid, len, user_mask_ptr),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, len) __field_hex(unsigned long *, user_mask_ptr)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(len, len) tp_assign(user_mask_ptr, user_mask_ptr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_io_submit
++SC_TRACE_EVENT(sys_io_submit,
++	TP_PROTO(aio_context_t ctx_id, long nr, struct iocb * * iocbpp),
++	TP_ARGS(ctx_id, nr, iocbpp),
++	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field(long, nr) __field_hex(struct iocb * *, iocbpp)),
++	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(nr, nr) tp_assign(iocbpp, iocbpp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_io_cancel
++SC_TRACE_EVENT(sys_io_cancel,
++	TP_PROTO(aio_context_t ctx_id, struct iocb * iocb, struct io_event * result),
++	TP_ARGS(ctx_id, iocb, result),
++	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field_hex(struct iocb *, iocb) __field_hex(struct io_event *, result)),
++	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(iocb, iocb) tp_assign(result, result)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timer_create
++SC_TRACE_EVENT(sys_timer_create,
++	TP_PROTO(const clockid_t which_clock, struct sigevent * timer_event_spec, timer_t * created_timer_id),
++	TP_ARGS(which_clock, timer_event_spec, created_timer_id),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field_hex(struct sigevent *, timer_event_spec) __field_hex(timer_t *, created_timer_id)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(timer_event_spec, timer_event_spec) tp_assign(created_timer_id, created_timer_id)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_getsetattr
++SC_TRACE_EVENT(sys_mq_getsetattr,
++	TP_PROTO(mqd_t mqdes, const struct mq_attr * u_mqstat, struct mq_attr * u_omqstat),
++	TP_ARGS(mqdes, u_mqstat, u_omqstat),
++	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const struct mq_attr *, u_mqstat) __field_hex(struct mq_attr *, u_omqstat)),
++	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_mqstat, u_mqstat) tp_assign(u_omqstat, u_omqstat)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_bind
++SC_TRACE_EVENT(sys_bind,
++	TP_PROTO(int fd, struct sockaddr * umyaddr, int addrlen),
++	TP_ARGS(fd, umyaddr, addrlen),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, umyaddr) __field_hex(int, addrlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(umyaddr, umyaddr) tp_assign(addrlen, addrlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_connect
++SC_TRACE_EVENT(sys_connect,
++	TP_PROTO(int fd, struct sockaddr * uservaddr, int addrlen),
++	TP_ARGS(fd, uservaddr, addrlen),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, uservaddr) __field_hex(int, addrlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(uservaddr, uservaddr) tp_assign(addrlen, addrlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_accept
++SC_TRACE_EVENT(sys_accept,
++	TP_PROTO(int fd, struct sockaddr * upeer_sockaddr, int * upeer_addrlen),
++	TP_ARGS(fd, upeer_sockaddr, upeer_addrlen),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, upeer_sockaddr) __field_hex(int *, upeer_addrlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(upeer_sockaddr, upeer_sockaddr) tp_assign(upeer_addrlen, upeer_addrlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getsockname
++SC_TRACE_EVENT(sys_getsockname,
++	TP_PROTO(int fd, struct sockaddr * usockaddr, int * usockaddr_len),
++	TP_ARGS(fd, usockaddr, usockaddr_len),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, usockaddr) __field_hex(int *, usockaddr_len)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(usockaddr, usockaddr) tp_assign(usockaddr_len, usockaddr_len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getpeername
++SC_TRACE_EVENT(sys_getpeername,
++	TP_PROTO(int fd, struct sockaddr * usockaddr, int * usockaddr_len),
++	TP_ARGS(fd, usockaddr, usockaddr_len),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, usockaddr) __field_hex(int *, usockaddr_len)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(usockaddr, usockaddr) tp_assign(usockaddr_len, usockaddr_len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sendmsg
++SC_TRACE_EVENT(sys_sendmsg,
++	TP_PROTO(int fd, struct msghdr * msg, unsigned flags),
++	TP_ARGS(fd, msg, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct msghdr *, msg) __field(unsigned, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(msg, msg) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_recvmsg
++SC_TRACE_EVENT(sys_recvmsg,
++	TP_PROTO(int fd, struct msghdr * msg, unsigned int flags),
++	TP_ARGS(fd, msg, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct msghdr *, msg) __field(unsigned int, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(msg, msg) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_semop
++SC_TRACE_EVENT(sys_semop,
++	TP_PROTO(int semid, struct sembuf * tsops, unsigned nsops),
++	TP_ARGS(semid, tsops, nsops),
++	TP_STRUCT__entry(__field(int, semid) __field_hex(struct sembuf *, tsops) __field(unsigned, nsops)),
++	TP_fast_assign(tp_assign(semid, semid) tp_assign(tsops, tsops) tp_assign(nsops, nsops)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_msgctl
++SC_TRACE_EVENT(sys_msgctl,
++	TP_PROTO(int msqid, int cmd, struct msqid_ds * buf),
++	TP_ARGS(msqid, cmd, buf),
++	TP_STRUCT__entry(__field(int, msqid) __field(int, cmd) __field_hex(struct msqid_ds *, buf)),
++	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(cmd, cmd) tp_assign(buf, buf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_shmat
++SC_TRACE_EVENT(sys_shmat,
++	TP_PROTO(int shmid, char * shmaddr, int shmflg),
++	TP_ARGS(shmid, shmaddr, shmflg),
++	TP_STRUCT__entry(__field(int, shmid) __field_hex(char *, shmaddr) __field(int, shmflg)),
++	TP_fast_assign(tp_assign(shmid, shmid) tp_assign(shmaddr, shmaddr) tp_assign(shmflg, shmflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_shmctl
++SC_TRACE_EVENT(sys_shmctl,
++	TP_PROTO(int shmid, int cmd, struct shmid_ds * buf),
++	TP_ARGS(shmid, cmd, buf),
++	TP_STRUCT__entry(__field(int, shmid) __field(int, cmd) __field_hex(struct shmid_ds *, buf)),
++	TP_fast_assign(tp_assign(shmid, shmid) tp_assign(cmd, cmd) tp_assign(buf, buf)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_inotify_add_watch
++SC_TRACE_EVENT(sys_inotify_add_watch,
++	TP_PROTO(int fd, const char * pathname, u32 mask),
++	TP_ARGS(fd, pathname, mask),
++	TP_STRUCT__entry(__field(int, fd) __string_from_user(pathname, pathname) __field(u32, mask)),
++	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(pathname, pathname) tp_assign(mask, mask)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mkdirat
++SC_TRACE_EVENT(sys_mkdirat,
++	TP_PROTO(int dfd, const char * pathname, umode_t mode),
++	TP_ARGS(dfd, pathname, mode),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field(umode_t, mode)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_futimesat
++SC_TRACE_EVENT(sys_futimesat,
++	TP_PROTO(int dfd, const char * filename, struct timeval * utimes),
++	TP_ARGS(dfd, filename, utimes),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct timeval *, utimes)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_unlinkat
++SC_TRACE_EVENT(sys_unlinkat,
++	TP_PROTO(int dfd, const char * pathname, int flag),
++	TP_ARGS(dfd, pathname, flag),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field(int, flag)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(flag, flag)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_symlinkat
++SC_TRACE_EVENT(sys_symlinkat,
++	TP_PROTO(const char * oldname, int newdfd, const char * newname),
++	TP_ARGS(oldname, newdfd, newname),
++	TP_STRUCT__entry(__string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname)),
++	TP_fast_assign(tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchmodat
++SC_TRACE_EVENT(sys_fchmodat,
++	TP_PROTO(int dfd, const char * filename, umode_t mode),
++	TP_ARGS(dfd, filename, mode),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(umode_t, mode)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_faccessat
++SC_TRACE_EVENT(sys_faccessat,
++	TP_PROTO(int dfd, const char * filename, int mode),
++	TP_ARGS(dfd, filename, mode),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(int, mode)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_get_robust_list
++SC_TRACE_EVENT(sys_get_robust_list,
++	TP_PROTO(int pid, struct robust_list_head * * head_ptr, size_t * len_ptr),
++	TP_ARGS(pid, head_ptr, len_ptr),
++	TP_STRUCT__entry(__field(int, pid) __field_hex(struct robust_list_head * *, head_ptr) __field_hex(size_t *, len_ptr)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(head_ptr, head_ptr) tp_assign(len_ptr, len_ptr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getcpu
++SC_TRACE_EVENT(sys_getcpu,
++	TP_PROTO(unsigned * cpup, unsigned * nodep, struct getcpu_cache * unused),
++	TP_ARGS(cpup, nodep, unused),
++	TP_STRUCT__entry(__field_hex(unsigned *, cpup) __field_hex(unsigned *, nodep) __field_hex(struct getcpu_cache *, unused)),
++	TP_fast_assign(tp_assign(cpup, cpup) tp_assign(nodep, nodep) tp_assign(unused, unused)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_signalfd
++SC_TRACE_EVENT(sys_signalfd,
++	TP_PROTO(int ufd, sigset_t * user_mask, size_t sizemask),
++	TP_ARGS(ufd, user_mask, sizemask),
++	TP_STRUCT__entry(__field(int, ufd) __field_hex(sigset_t *, user_mask) __field(size_t, sizemask)),
++	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(user_mask, user_mask) tp_assign(sizemask, sizemask)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_open_by_handle_at
++SC_TRACE_EVENT(sys_open_by_handle_at,
++	TP_PROTO(int mountdirfd, struct file_handle * handle, int flags),
++	TP_ARGS(mountdirfd, handle, flags),
++	TP_STRUCT__entry(__field(int, mountdirfd) __field_hex(struct file_handle *, handle) __field(int, flags)),
++	TP_fast_assign(tp_assign(mountdirfd, mountdirfd) tp_assign(handle, handle) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_reboot
++SC_TRACE_EVENT(sys_reboot,
++	TP_PROTO(int magic1, int magic2, unsigned int cmd, void * arg),
++	TP_ARGS(magic1, magic2, cmd, arg),
++	TP_STRUCT__entry(__field(int, magic1) __field(int, magic2) __field(unsigned int, cmd) __field_hex(void *, arg)),
++	TP_fast_assign(tp_assign(magic1, magic1) tp_assign(magic2, magic2) tp_assign(cmd, cmd) tp_assign(arg, arg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_wait4
++SC_TRACE_EVENT(sys_wait4,
++	TP_PROTO(pid_t upid, int * stat_addr, int options, struct rusage * ru),
++	TP_ARGS(upid, stat_addr, options, ru),
++	TP_STRUCT__entry(__field(pid_t, upid) __field_hex(int *, stat_addr) __field(int, options) __field_hex(struct rusage *, ru)),
++	TP_fast_assign(tp_assign(upid, upid) tp_assign(stat_addr, stat_addr) tp_assign(options, options) tp_assign(ru, ru)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_quotactl
++SC_TRACE_EVENT(sys_quotactl,
++	TP_PROTO(unsigned int cmd, const char * special, qid_t id, void * addr),
++	TP_ARGS(cmd, special, id, addr),
++	TP_STRUCT__entry(__field(unsigned int, cmd) __field_hex(const char *, special) __field(qid_t, id) __field_hex(void *, addr)),
++	TP_fast_assign(tp_assign(cmd, cmd) tp_assign(special, special) tp_assign(id, id) tp_assign(addr, addr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigaction
++SC_TRACE_EVENT(sys_rt_sigaction,
++	TP_PROTO(int sig, const struct sigaction * act, struct sigaction * oact, size_t sigsetsize),
++	TP_ARGS(sig, act, oact, sigsetsize),
++	TP_STRUCT__entry(__field(int, sig) __field_hex(const struct sigaction *, act) __field_hex(struct sigaction *, oact) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(sig, sig) tp_assign(act, act) tp_assign(oact, oact) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigprocmask
++SC_TRACE_EVENT(sys_rt_sigprocmask,
++	TP_PROTO(int how, sigset_t * nset, sigset_t * oset, size_t sigsetsize),
++	TP_ARGS(how, nset, oset, sigsetsize),
++	TP_STRUCT__entry(__field(int, how) __field_hex(sigset_t *, nset) __field_hex(sigset_t *, oset) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(how, how) tp_assign(nset, nset) tp_assign(oset, oset) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_sigtimedwait
++SC_TRACE_EVENT(sys_rt_sigtimedwait,
++	TP_PROTO(const sigset_t * uthese, siginfo_t * uinfo, const struct timespec * uts, size_t sigsetsize),
++	TP_ARGS(uthese, uinfo, uts, sigsetsize),
++	TP_STRUCT__entry(__field_hex(const sigset_t *, uthese) __field_hex(siginfo_t *, uinfo) __field_hex(const struct timespec *, uts) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(uthese, uthese) tp_assign(uinfo, uinfo) tp_assign(uts, uts) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sendfile
++SC_TRACE_EVENT(sys_sendfile,
++	TP_PROTO(int out_fd, int in_fd, off_t * offset, size_t count),
++	TP_ARGS(out_fd, in_fd, offset, count),
++	TP_STRUCT__entry(__field(int, out_fd) __field(int, in_fd) __field_hex(off_t *, offset) __field(size_t, count)),
++	TP_fast_assign(tp_assign(out_fd, out_fd) tp_assign(in_fd, in_fd) tp_assign(offset, offset) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getxattr
++SC_TRACE_EVENT(sys_getxattr,
++	TP_PROTO(const char * pathname, const char * name, void * value, size_t size),
++	TP_ARGS(pathname, name, value, size),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lgetxattr
++SC_TRACE_EVENT(sys_lgetxattr,
++	TP_PROTO(const char * pathname, const char * name, void * value, size_t size),
++	TP_ARGS(pathname, name, value, size),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fgetxattr
++SC_TRACE_EVENT(sys_fgetxattr,
++	TP_PROTO(int fd, const char * name, void * value, size_t size),
++	TP_ARGS(fd, name, value, size),
++	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name) __field_hex(void *, value) __field(size_t, size)),
++	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sendfile64
++SC_TRACE_EVENT(sys_sendfile64,
++	TP_PROTO(int out_fd, int in_fd, loff_t * offset, size_t count),
++	TP_ARGS(out_fd, in_fd, offset, count),
++	TP_STRUCT__entry(__field(int, out_fd) __field(int, in_fd) __field_hex(loff_t *, offset) __field(size_t, count)),
++	TP_fast_assign(tp_assign(out_fd, out_fd) tp_assign(in_fd, in_fd) tp_assign(offset, offset) tp_assign(count, count)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_epoll_ctl
++SC_TRACE_EVENT(sys_epoll_ctl,
++	TP_PROTO(int epfd, int op, int fd, struct epoll_event * event),
++	TP_ARGS(epfd, op, fd, event),
++	TP_STRUCT__entry(__field(int, epfd) __field(int, op) __field(int, fd) __field_hex(struct epoll_event *, event)),
++	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(op, op) tp_assign(fd, fd) tp_assign(event, event)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_epoll_wait
++SC_TRACE_EVENT(sys_epoll_wait,
++	TP_PROTO(int epfd, struct epoll_event * events, int maxevents, int timeout),
++	TP_ARGS(epfd, events, maxevents, timeout),
++	TP_STRUCT__entry(__field(int, epfd) __field_hex(struct epoll_event *, events) __field(int, maxevents) __field(int, timeout)),
++	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(events, events) tp_assign(maxevents, maxevents) tp_assign(timeout, timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timer_settime
++SC_TRACE_EVENT(sys_timer_settime,
++	TP_PROTO(timer_t timer_id, int flags, const struct itimerspec * new_setting, struct itimerspec * old_setting),
++	TP_ARGS(timer_id, flags, new_setting, old_setting),
++	TP_STRUCT__entry(__field(timer_t, timer_id) __field(int, flags) __field_hex(const struct itimerspec *, new_setting) __field_hex(struct itimerspec *, old_setting)),
++	TP_fast_assign(tp_assign(timer_id, timer_id) tp_assign(flags, flags) tp_assign(new_setting, new_setting) tp_assign(old_setting, old_setting)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_clock_nanosleep
++SC_TRACE_EVENT(sys_clock_nanosleep,
++	TP_PROTO(const clockid_t which_clock, int flags, const struct timespec * rqtp, struct timespec * rmtp),
++	TP_ARGS(which_clock, flags, rqtp, rmtp),
++	TP_STRUCT__entry(__field(const clockid_t, which_clock) __field(int, flags) __field_hex(const struct timespec *, rqtp) __field_hex(struct timespec *, rmtp)),
++	TP_fast_assign(tp_assign(which_clock, which_clock) tp_assign(flags, flags) tp_assign(rqtp, rqtp) tp_assign(rmtp, rmtp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_open
++SC_TRACE_EVENT(sys_mq_open,
++	TP_PROTO(const char * u_name, int oflag, umode_t mode, struct mq_attr * u_attr),
++	TP_ARGS(u_name, oflag, mode, u_attr),
++	TP_STRUCT__entry(__string_from_user(u_name, u_name) __field(int, oflag) __field(umode_t, mode) __field_hex(struct mq_attr *, u_attr)),
++	TP_fast_assign(tp_copy_string_from_user(u_name, u_name) tp_assign(oflag, oflag) tp_assign(mode, mode) tp_assign(u_attr, u_attr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_socketpair
++SC_TRACE_EVENT(sys_socketpair,
++	TP_PROTO(int family, int type, int protocol, int * usockvec),
++	TP_ARGS(family, type, protocol, usockvec),
++	TP_STRUCT__entry(__field(int, family) __field(int, type) __field(int, protocol) __field_hex(int *, usockvec)),
++	TP_fast_assign(tp_assign(family, family) tp_assign(type, type) tp_assign(protocol, protocol) tp_assign(usockvec, usockvec)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_send
++SC_TRACE_EVENT(sys_send,
++	TP_PROTO(int fd, void * buff, size_t len, unsigned flags),
++	TP_ARGS(fd, buff, len, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, buff) __field(size_t, len) __field(unsigned, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(buff, buff) tp_assign(len, len) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_msgsnd
++SC_TRACE_EVENT(sys_msgsnd,
++	TP_PROTO(int msqid, struct msgbuf * msgp, size_t msgsz, int msgflg),
++	TP_ARGS(msqid, msgp, msgsz, msgflg),
++	TP_STRUCT__entry(__field(int, msqid) __field_hex(struct msgbuf *, msgp) __field(size_t, msgsz) __field(int, msgflg)),
++	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(msgp, msgp) tp_assign(msgsz, msgsz) tp_assign(msgflg, msgflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_request_key
++SC_TRACE_EVENT(sys_request_key,
++	TP_PROTO(const char * _type, const char * _description, const char * _callout_info, key_serial_t destringid),
++	TP_ARGS(_type, _description, _callout_info, destringid),
++	TP_STRUCT__entry(__string_from_user(_type, _type) __field_hex(const char *, _description) __field_hex(const char *, _callout_info) __field(key_serial_t, destringid)),
++	TP_fast_assign(tp_copy_string_from_user(_type, _type) tp_assign(_description, _description) tp_assign(_callout_info, _callout_info) tp_assign(destringid, destringid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_semtimedop
++SC_TRACE_EVENT(sys_semtimedop,
++	TP_PROTO(int semid, struct sembuf * tsops, unsigned nsops, const struct timespec * timeout),
++	TP_ARGS(semid, tsops, nsops, timeout),
++	TP_STRUCT__entry(__field(int, semid) __field_hex(struct sembuf *, tsops) __field(unsigned, nsops) __field_hex(const struct timespec *, timeout)),
++	TP_fast_assign(tp_assign(semid, semid) tp_assign(tsops, tsops) tp_assign(nsops, nsops) tp_assign(timeout, timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_openat
++SC_TRACE_EVENT(sys_openat,
++	TP_PROTO(int dfd, const char * filename, int flags, umode_t mode),
++	TP_ARGS(dfd, filename, flags, mode),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(int, flags) __field(umode_t, mode)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(flags, flags) tp_assign(mode, mode)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mknodat
++SC_TRACE_EVENT(sys_mknodat,
++	TP_PROTO(int dfd, const char * filename, umode_t mode, unsigned dev),
++	TP_ARGS(dfd, filename, mode, dev),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(umode_t, mode) __field(unsigned, dev)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(mode, mode) tp_assign(dev, dev)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fstatat64
++SC_TRACE_EVENT(sys_fstatat64,
++	TP_PROTO(int dfd, const char * filename, struct stat64 * statbuf, int flag),
++	TP_ARGS(dfd, filename, statbuf, flag),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct stat64 *, statbuf) __field(int, flag)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(statbuf, statbuf) tp_assign(flag, flag)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_renameat
++SC_TRACE_EVENT(sys_renameat,
++	TP_PROTO(int olddfd, const char * oldname, int newdfd, const char * newname),
++	TP_ARGS(olddfd, oldname, newdfd, newname),
++	TP_STRUCT__entry(__field(int, olddfd) __string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname)),
++	TP_fast_assign(tp_assign(olddfd, olddfd) tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_readlinkat
++SC_TRACE_EVENT(sys_readlinkat,
++	TP_PROTO(int dfd, const char * pathname, char * buf, int bufsiz),
++	TP_ARGS(dfd, pathname, buf, bufsiz),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(pathname, pathname) __field_hex(char *, buf) __field(int, bufsiz)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(pathname, pathname) tp_assign(buf, buf) tp_assign(bufsiz, bufsiz)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_vmsplice
++SC_TRACE_EVENT(sys_vmsplice,
++	TP_PROTO(int fd, const struct iovec * iov, unsigned long nr_segs, unsigned int flags),
++	TP_ARGS(fd, iov, nr_segs, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(const struct iovec *, iov) __field(unsigned long, nr_segs) __field(unsigned int, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(iov, iov) tp_assign(nr_segs, nr_segs) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_utimensat
++SC_TRACE_EVENT(sys_utimensat,
++	TP_PROTO(int dfd, const char * filename, struct timespec * utimes, int flags),
++	TP_ARGS(dfd, filename, utimes, flags),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field_hex(struct timespec *, utimes) __field(int, flags)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(utimes, utimes) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_timerfd_settime
++SC_TRACE_EVENT(sys_timerfd_settime,
++	TP_PROTO(int ufd, int flags, const struct itimerspec * utmr, struct itimerspec * otmr),
++	TP_ARGS(ufd, flags, utmr, otmr),
++	TP_STRUCT__entry(__field(int, ufd) __field(int, flags) __field_hex(const struct itimerspec *, utmr) __field_hex(struct itimerspec *, otmr)),
++	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(flags, flags) tp_assign(utmr, utmr) tp_assign(otmr, otmr)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_signalfd4
++SC_TRACE_EVENT(sys_signalfd4,
++	TP_PROTO(int ufd, sigset_t * user_mask, size_t sizemask, int flags),
++	TP_ARGS(ufd, user_mask, sizemask, flags),
++	TP_STRUCT__entry(__field(int, ufd) __field_hex(sigset_t *, user_mask) __field(size_t, sizemask) __field(int, flags)),
++	TP_fast_assign(tp_assign(ufd, ufd) tp_assign(user_mask, user_mask) tp_assign(sizemask, sizemask) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_rt_tgsigqueueinfo
++SC_TRACE_EVENT(sys_rt_tgsigqueueinfo,
++	TP_PROTO(pid_t tgid, pid_t pid, int sig, siginfo_t * uinfo),
++	TP_ARGS(tgid, pid, sig, uinfo),
++	TP_STRUCT__entry(__field(pid_t, tgid) __field(pid_t, pid) __field(int, sig) __field_hex(siginfo_t *, uinfo)),
++	TP_fast_assign(tp_assign(tgid, tgid) tp_assign(pid, pid) tp_assign(sig, sig) tp_assign(uinfo, uinfo)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_accept4
++SC_TRACE_EVENT(sys_accept4,
++	TP_PROTO(int fd, struct sockaddr * upeer_sockaddr, int * upeer_addrlen, int flags),
++	TP_ARGS(fd, upeer_sockaddr, upeer_addrlen, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct sockaddr *, upeer_sockaddr) __field_hex(int *, upeer_addrlen) __field(int, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(upeer_sockaddr, upeer_sockaddr) tp_assign(upeer_addrlen, upeer_addrlen) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_prlimit64
++SC_TRACE_EVENT(sys_prlimit64,
++	TP_PROTO(pid_t pid, unsigned int resource, const struct rlimit64 * new_rlim, struct rlimit64 * old_rlim),
++	TP_ARGS(pid, resource, new_rlim, old_rlim),
++	TP_STRUCT__entry(__field(pid_t, pid) __field(unsigned int, resource) __field_hex(const struct rlimit64 *, new_rlim) __field_hex(struct rlimit64 *, old_rlim)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(resource, resource) tp_assign(new_rlim, new_rlim) tp_assign(old_rlim, old_rlim)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sendmmsg
++SC_TRACE_EVENT(sys_sendmmsg,
++	TP_PROTO(int fd, struct mmsghdr * mmsg, unsigned int vlen, unsigned int flags),
++	TP_ARGS(fd, mmsg, vlen, flags),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct mmsghdr *, mmsg) __field(unsigned int, vlen) __field(unsigned int, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(mmsg, mmsg) tp_assign(vlen, vlen) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mount
++SC_TRACE_EVENT(sys_mount,
++	TP_PROTO(char * dev_name, char * dir_name, char * type, unsigned long flags, void * data),
++	TP_ARGS(dev_name, dir_name, type, flags, data),
++	TP_STRUCT__entry(__string_from_user(dev_name, dev_name) __string_from_user(dir_name, dir_name) __string_from_user(type, type) __field(unsigned long, flags) __field_hex(void *, data)),
++	TP_fast_assign(tp_copy_string_from_user(dev_name, dev_name) tp_copy_string_from_user(dir_name, dir_name) tp_copy_string_from_user(type, type) tp_assign(flags, flags) tp_assign(data, data)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_llseek
++SC_TRACE_EVENT(sys_llseek,
++	TP_PROTO(unsigned int fd, unsigned long offset_high, unsigned long offset_low, loff_t * result, unsigned int origin),
++	TP_ARGS(fd, offset_high, offset_low, result, origin),
++	TP_STRUCT__entry(__field(unsigned int, fd) __field(unsigned long, offset_high) __field(unsigned long, offset_low) __field_hex(loff_t *, result) __field(unsigned int, origin)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(offset_high, offset_high) tp_assign(offset_low, offset_low) tp_assign(result, result) tp_assign(origin, origin)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_select
++SC_TRACE_EVENT(sys_select,
++	TP_PROTO(int n, fd_set * inp, fd_set * outp, fd_set * exp, struct timeval * tvp),
++	TP_ARGS(n, inp, outp, exp, tvp),
++	TP_STRUCT__entry(__field(int, n) __field_hex(fd_set *, inp) __field_hex(fd_set *, outp) __field_hex(fd_set *, exp) __field_hex(struct timeval *, tvp)),
++	TP_fast_assign(tp_assign(n, n) tp_assign(inp, inp) tp_assign(outp, outp) tp_assign(exp, exp) tp_assign(tvp, tvp)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setxattr
++SC_TRACE_EVENT(sys_setxattr,
++	TP_PROTO(const char * pathname, const char * name, const void * value, size_t size, int flags),
++	TP_ARGS(pathname, name, value, size, flags),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_lsetxattr
++SC_TRACE_EVENT(sys_lsetxattr,
++	TP_PROTO(const char * pathname, const char * name, const void * value, size_t size, int flags),
++	TP_ARGS(pathname, name, value, size, flags),
++	TP_STRUCT__entry(__string_from_user(pathname, pathname) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
++	TP_fast_assign(tp_copy_string_from_user(pathname, pathname) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fsetxattr
++SC_TRACE_EVENT(sys_fsetxattr,
++	TP_PROTO(int fd, const char * name, const void * value, size_t size, int flags),
++	TP_ARGS(fd, name, value, size, flags),
++	TP_STRUCT__entry(__field(int, fd) __string_from_user(name, name) __field_hex(const void *, value) __field(size_t, size) __field(int, flags)),
++	TP_fast_assign(tp_assign(fd, fd) tp_copy_string_from_user(name, name) tp_assign(value, value) tp_assign(size, size) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_io_getevents
++SC_TRACE_EVENT(sys_io_getevents,
++	TP_PROTO(aio_context_t ctx_id, long min_nr, long nr, struct io_event * events, struct timespec * timeout),
++	TP_ARGS(ctx_id, min_nr, nr, events, timeout),
++	TP_STRUCT__entry(__field(aio_context_t, ctx_id) __field(long, min_nr) __field(long, nr) __field_hex(struct io_event *, events) __field_hex(struct timespec *, timeout)),
++	TP_fast_assign(tp_assign(ctx_id, ctx_id) tp_assign(min_nr, min_nr) tp_assign(nr, nr) tp_assign(events, events) tp_assign(timeout, timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_timedsend
++SC_TRACE_EVENT(sys_mq_timedsend,
++	TP_PROTO(mqd_t mqdes, const char * u_msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec * u_abs_timeout),
++	TP_ARGS(mqdes, u_msg_ptr, msg_len, msg_prio, u_abs_timeout),
++	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(const char *, u_msg_ptr) __field(size_t, msg_len) __field(unsigned int, msg_prio) __field_hex(const struct timespec *, u_abs_timeout)),
++	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_msg_ptr, u_msg_ptr) tp_assign(msg_len, msg_len) tp_assign(msg_prio, msg_prio) tp_assign(u_abs_timeout, u_abs_timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_mq_timedreceive
++SC_TRACE_EVENT(sys_mq_timedreceive,
++	TP_PROTO(mqd_t mqdes, char * u_msg_ptr, size_t msg_len, unsigned int * u_msg_prio, const struct timespec * u_abs_timeout),
++	TP_ARGS(mqdes, u_msg_ptr, msg_len, u_msg_prio, u_abs_timeout),
++	TP_STRUCT__entry(__field(mqd_t, mqdes) __field_hex(char *, u_msg_ptr) __field(size_t, msg_len) __field_hex(unsigned int *, u_msg_prio) __field_hex(const struct timespec *, u_abs_timeout)),
++	TP_fast_assign(tp_assign(mqdes, mqdes) tp_assign(u_msg_ptr, u_msg_ptr) tp_assign(msg_len, msg_len) tp_assign(u_msg_prio, u_msg_prio) tp_assign(u_abs_timeout, u_abs_timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_waitid
++SC_TRACE_EVENT(sys_waitid,
++	TP_PROTO(int which, pid_t upid, struct siginfo * infop, int options, struct rusage * ru),
++	TP_ARGS(which, upid, infop, options, ru),
++	TP_STRUCT__entry(__field(int, which) __field(pid_t, upid) __field_hex(struct siginfo *, infop) __field(int, options) __field_hex(struct rusage *, ru)),
++	TP_fast_assign(tp_assign(which, which) tp_assign(upid, upid) tp_assign(infop, infop) tp_assign(options, options) tp_assign(ru, ru)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_setsockopt
++SC_TRACE_EVENT(sys_setsockopt,
++	TP_PROTO(int fd, int level, int optname, char * optval, int optlen),
++	TP_ARGS(fd, level, optname, optval, optlen),
++	TP_STRUCT__entry(__field(int, fd) __field(int, level) __field(int, optname) __field_hex(char *, optval) __field(int, optlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(level, level) tp_assign(optname, optname) tp_assign(optval, optval) tp_assign(optlen, optlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_getsockopt
++SC_TRACE_EVENT(sys_getsockopt,
++	TP_PROTO(int fd, int level, int optname, char * optval, int * optlen),
++	TP_ARGS(fd, level, optname, optval, optlen),
++	TP_STRUCT__entry(__field(int, fd) __field(int, level) __field(int, optname) __field_hex(char *, optval) __field_hex(int *, optlen)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(level, level) tp_assign(optname, optname) tp_assign(optval, optval) tp_assign(optlen, optlen)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_msgrcv
++SC_TRACE_EVENT(sys_msgrcv,
++	TP_PROTO(int msqid, struct msgbuf * msgp, size_t msgsz, long msgtyp, int msgflg),
++	TP_ARGS(msqid, msgp, msgsz, msgtyp, msgflg),
++	TP_STRUCT__entry(__field(int, msqid) __field_hex(struct msgbuf *, msgp) __field(size_t, msgsz) __field(long, msgtyp) __field(int, msgflg)),
++	TP_fast_assign(tp_assign(msqid, msqid) tp_assign(msgp, msgp) tp_assign(msgsz, msgsz) tp_assign(msgtyp, msgtyp) tp_assign(msgflg, msgflg)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_add_key
++SC_TRACE_EVENT(sys_add_key,
++	TP_PROTO(const char * _type, const char * _description, const void * _payload, size_t plen, key_serial_t ringid),
++	TP_ARGS(_type, _description, _payload, plen, ringid),
++	TP_STRUCT__entry(__string_from_user(_type, _type) __field_hex(const char *, _description) __field_hex(const void *, _payload) __field(size_t, plen) __field(key_serial_t, ringid)),
++	TP_fast_assign(tp_copy_string_from_user(_type, _type) tp_assign(_description, _description) tp_assign(_payload, _payload) tp_assign(plen, plen) tp_assign(ringid, ringid)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_fchownat
++SC_TRACE_EVENT(sys_fchownat,
++	TP_PROTO(int dfd, const char * filename, uid_t user, gid_t group, int flag),
++	TP_ARGS(dfd, filename, user, group, flag),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(filename, filename) __field(uid_t, user) __field(gid_t, group) __field(int, flag)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(filename, filename) tp_assign(user, user) tp_assign(group, group) tp_assign(flag, flag)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_linkat
++SC_TRACE_EVENT(sys_linkat,
++	TP_PROTO(int olddfd, const char * oldname, int newdfd, const char * newname, int flags),
++	TP_ARGS(olddfd, oldname, newdfd, newname, flags),
++	TP_STRUCT__entry(__field(int, olddfd) __string_from_user(oldname, oldname) __field(int, newdfd) __string_from_user(newname, newname) __field(int, flags)),
++	TP_fast_assign(tp_assign(olddfd, olddfd) tp_copy_string_from_user(oldname, oldname) tp_assign(newdfd, newdfd) tp_copy_string_from_user(newname, newname) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_ppoll
++SC_TRACE_EVENT(sys_ppoll,
++	TP_PROTO(struct pollfd * ufds, unsigned int nfds, struct timespec * tsp, const sigset_t * sigmask, size_t sigsetsize),
++	TP_ARGS(ufds, nfds, tsp, sigmask, sigsetsize),
++	TP_STRUCT__entry(__field_hex(struct pollfd *, ufds) __field(unsigned int, nfds) __field_hex(struct timespec *, tsp) __field_hex(const sigset_t *, sigmask) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(ufds, ufds) tp_assign(nfds, nfds) tp_assign(tsp, tsp) tp_assign(sigmask, sigmask) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_preadv
++SC_TRACE_EVENT(sys_preadv,
++	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen, unsigned long pos_l, unsigned long pos_h),
++	TP_ARGS(fd, vec, vlen, pos_l, pos_h),
++	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen) __field(unsigned long, pos_l) __field(unsigned long, pos_h)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen) tp_assign(pos_l, pos_l) tp_assign(pos_h, pos_h)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_pwritev
++SC_TRACE_EVENT(sys_pwritev,
++	TP_PROTO(unsigned long fd, const struct iovec * vec, unsigned long vlen, unsigned long pos_l, unsigned long pos_h),
++	TP_ARGS(fd, vec, vlen, pos_l, pos_h),
++	TP_STRUCT__entry(__field(unsigned long, fd) __field_hex(const struct iovec *, vec) __field(unsigned long, vlen) __field(unsigned long, pos_l) __field(unsigned long, pos_h)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(vec, vec) tp_assign(vlen, vlen) tp_assign(pos_l, pos_l) tp_assign(pos_h, pos_h)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_perf_event_open
++SC_TRACE_EVENT(sys_perf_event_open,
++	TP_PROTO(struct perf_event_attr * attr_uptr, pid_t pid, int cpu, int group_fd, unsigned long flags),
++	TP_ARGS(attr_uptr, pid, cpu, group_fd, flags),
++	TP_STRUCT__entry(__field_hex(struct perf_event_attr *, attr_uptr) __field(pid_t, pid) __field(int, cpu) __field(int, group_fd) __field(unsigned long, flags)),
++	TP_fast_assign(tp_assign(attr_uptr, attr_uptr) tp_assign(pid, pid) tp_assign(cpu, cpu) tp_assign(group_fd, group_fd) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_recvmmsg
++SC_TRACE_EVENT(sys_recvmmsg,
++	TP_PROTO(int fd, struct mmsghdr * mmsg, unsigned int vlen, unsigned int flags, struct timespec * timeout),
++	TP_ARGS(fd, mmsg, vlen, flags, timeout),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(struct mmsghdr *, mmsg) __field(unsigned int, vlen) __field(unsigned int, flags) __field_hex(struct timespec *, timeout)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(mmsg, mmsg) tp_assign(vlen, vlen) tp_assign(flags, flags) tp_assign(timeout, timeout)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_name_to_handle_at
++SC_TRACE_EVENT(sys_name_to_handle_at,
++	TP_PROTO(int dfd, const char * name, struct file_handle * handle, int * mnt_id, int flag),
++	TP_ARGS(dfd, name, handle, mnt_id, flag),
++	TP_STRUCT__entry(__field(int, dfd) __string_from_user(name, name) __field_hex(struct file_handle *, handle) __field_hex(int *, mnt_id) __field(int, flag)),
++	TP_fast_assign(tp_assign(dfd, dfd) tp_copy_string_from_user(name, name) tp_assign(handle, handle) tp_assign(mnt_id, mnt_id) tp_assign(flag, flag)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_futex
++SC_TRACE_EVENT(sys_futex,
++	TP_PROTO(u32 * uaddr, int op, u32 val, struct timespec * utime, u32 * uaddr2, u32 val3),
++	TP_ARGS(uaddr, op, val, utime, uaddr2, val3),
++	TP_STRUCT__entry(__field_hex(u32 *, uaddr) __field(int, op) __field(u32, val) __field_hex(struct timespec *, utime) __field_hex(u32 *, uaddr2) __field(u32, val3)),
++	TP_fast_assign(tp_assign(uaddr, uaddr) tp_assign(op, op) tp_assign(val, val) tp_assign(utime, utime) tp_assign(uaddr2, uaddr2) tp_assign(val3, val3)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_sendto
++SC_TRACE_EVENT(sys_sendto,
++	TP_PROTO(int fd, void * buff, size_t len, unsigned flags, struct sockaddr * addr, int addr_len),
++	TP_ARGS(fd, buff, len, flags, addr, addr_len),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, buff) __field(size_t, len) __field(unsigned, flags) __field_hex(struct sockaddr *, addr) __field_hex(int, addr_len)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(buff, buff) tp_assign(len, len) tp_assign(flags, flags) tp_assign(addr, addr) tp_assign(addr_len, addr_len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_recvfrom
++SC_TRACE_EVENT(sys_recvfrom,
++	TP_PROTO(int fd, void * ubuf, size_t size, unsigned flags, struct sockaddr * addr, int * addr_len),
++	TP_ARGS(fd, ubuf, size, flags, addr, addr_len),
++	TP_STRUCT__entry(__field(int, fd) __field_hex(void *, ubuf) __field(size_t, size) __field(unsigned, flags) __field_hex(struct sockaddr *, addr) __field_hex(int *, addr_len)),
++	TP_fast_assign(tp_assign(fd, fd) tp_assign(ubuf, ubuf) tp_assign(size, size) tp_assign(flags, flags) tp_assign(addr, addr) tp_assign(addr_len, addr_len)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_pselect6
++SC_TRACE_EVENT(sys_pselect6,
++	TP_PROTO(int n, fd_set * inp, fd_set * outp, fd_set * exp, struct timespec * tsp, void * sig),
++	TP_ARGS(n, inp, outp, exp, tsp, sig),
++	TP_STRUCT__entry(__field(int, n) __field_hex(fd_set *, inp) __field_hex(fd_set *, outp) __field_hex(fd_set *, exp) __field_hex(struct timespec *, tsp) __field_hex(void *, sig)),
++	TP_fast_assign(tp_assign(n, n) tp_assign(inp, inp) tp_assign(outp, outp) tp_assign(exp, exp) tp_assign(tsp, tsp) tp_assign(sig, sig)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_splice
++SC_TRACE_EVENT(sys_splice,
++	TP_PROTO(int fd_in, loff_t * off_in, int fd_out, loff_t * off_out, size_t len, unsigned int flags),
++	TP_ARGS(fd_in, off_in, fd_out, off_out, len, flags),
++	TP_STRUCT__entry(__field(int, fd_in) __field_hex(loff_t *, off_in) __field(int, fd_out) __field_hex(loff_t *, off_out) __field(size_t, len) __field(unsigned int, flags)),
++	TP_fast_assign(tp_assign(fd_in, fd_in) tp_assign(off_in, off_in) tp_assign(fd_out, fd_out) tp_assign(off_out, off_out) tp_assign(len, len) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_epoll_pwait
++SC_TRACE_EVENT(sys_epoll_pwait,
++	TP_PROTO(int epfd, struct epoll_event * events, int maxevents, int timeout, const sigset_t * sigmask, size_t sigsetsize),
++	TP_ARGS(epfd, events, maxevents, timeout, sigmask, sigsetsize),
++	TP_STRUCT__entry(__field(int, epfd) __field_hex(struct epoll_event *, events) __field(int, maxevents) __field(int, timeout) __field_hex(const sigset_t *, sigmask) __field(size_t, sigsetsize)),
++	TP_fast_assign(tp_assign(epfd, epfd) tp_assign(events, events) tp_assign(maxevents, maxevents) tp_assign(timeout, timeout) tp_assign(sigmask, sigmask) tp_assign(sigsetsize, sigsetsize)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_process_vm_readv
++SC_TRACE_EVENT(sys_process_vm_readv,
++	TP_PROTO(pid_t pid, const struct iovec * lvec, unsigned long liovcnt, const struct iovec * rvec, unsigned long riovcnt, unsigned long flags),
++	TP_ARGS(pid, lvec, liovcnt, rvec, riovcnt, flags),
++	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(const struct iovec *, lvec) __field(unsigned long, liovcnt) __field_hex(const struct iovec *, rvec) __field(unsigned long, riovcnt) __field(unsigned long, flags)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(lvec, lvec) tp_assign(liovcnt, liovcnt) tp_assign(rvec, rvec) tp_assign(riovcnt, riovcnt) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++#ifndef OVERRIDE_32_sys_process_vm_writev
++SC_TRACE_EVENT(sys_process_vm_writev,
++	TP_PROTO(pid_t pid, const struct iovec * lvec, unsigned long liovcnt, const struct iovec * rvec, unsigned long riovcnt, unsigned long flags),
++	TP_ARGS(pid, lvec, liovcnt, rvec, riovcnt, flags),
++	TP_STRUCT__entry(__field(pid_t, pid) __field_hex(const struct iovec *, lvec) __field(unsigned long, liovcnt) __field_hex(const struct iovec *, rvec) __field(unsigned long, riovcnt) __field(unsigned long, flags)),
++	TP_fast_assign(tp_assign(pid, pid) tp_assign(lvec, lvec) tp_assign(liovcnt, liovcnt) tp_assign(rvec, rvec) tp_assign(riovcnt, riovcnt) tp_assign(flags, flags)),
++	TP_printk()
++)
++#endif
++
++#endif /*  _TRACE_SYSCALLS_POINTERS_H */
++
++/* This part must be outside protection */
++#include "../../../probes/define_trace.h"
++
++#else /* CREATE_SYSCALL_TABLE */
++
++#include "arm-32-syscalls-3.4.25_pointers_override.h"
++#include "syscalls_pointers_override.h"
++
++#ifndef OVERRIDE_TABLE_32_sys_read
++TRACE_SYSCALL_TABLE(sys_read, sys_read, 3, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_write
++TRACE_SYSCALL_TABLE(sys_write, sys_write, 4, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_open
++TRACE_SYSCALL_TABLE(sys_open, sys_open, 5, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_creat
++TRACE_SYSCALL_TABLE(sys_creat, sys_creat, 8, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_link
++TRACE_SYSCALL_TABLE(sys_link, sys_link, 9, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_unlink
++TRACE_SYSCALL_TABLE(sys_unlink, sys_unlink, 10, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_chdir
++TRACE_SYSCALL_TABLE(sys_chdir, sys_chdir, 12, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mknod
++TRACE_SYSCALL_TABLE(sys_mknod, sys_mknod, 14, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_chmod
++TRACE_SYSCALL_TABLE(sys_chmod, sys_chmod, 15, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lchown16
++TRACE_SYSCALL_TABLE(sys_lchown16, sys_lchown16, 16, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mount
++TRACE_SYSCALL_TABLE(sys_mount, sys_mount, 21, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_access
++TRACE_SYSCALL_TABLE(sys_access, sys_access, 33, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rename
++TRACE_SYSCALL_TABLE(sys_rename, sys_rename, 38, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mkdir
++TRACE_SYSCALL_TABLE(sys_mkdir, sys_mkdir, 39, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rmdir
++TRACE_SYSCALL_TABLE(sys_rmdir, sys_rmdir, 40, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pipe
++TRACE_SYSCALL_TABLE(sys_pipe, sys_pipe, 42, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_times
++TRACE_SYSCALL_TABLE(sys_times, sys_times, 43, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_acct
++TRACE_SYSCALL_TABLE(sys_acct, sys_acct, 51, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_umount
++TRACE_SYSCALL_TABLE(sys_umount, sys_umount, 52, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_chroot
++TRACE_SYSCALL_TABLE(sys_chroot, sys_chroot, 61, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ustat
++TRACE_SYSCALL_TABLE(sys_ustat, sys_ustat, 62, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sigpending
++TRACE_SYSCALL_TABLE(sys_sigpending, sys_sigpending, 73, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sethostname
++TRACE_SYSCALL_TABLE(sys_sethostname, sys_sethostname, 74, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setrlimit
++TRACE_SYSCALL_TABLE(sys_setrlimit, sys_setrlimit, 75, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getrusage
++TRACE_SYSCALL_TABLE(sys_getrusage, sys_getrusage, 77, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_gettimeofday
++TRACE_SYSCALL_TABLE(sys_gettimeofday, sys_gettimeofday, 78, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_settimeofday
++TRACE_SYSCALL_TABLE(sys_settimeofday, sys_settimeofday, 79, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getgroups16
++TRACE_SYSCALL_TABLE(sys_getgroups16, sys_getgroups16, 80, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setgroups16
++TRACE_SYSCALL_TABLE(sys_setgroups16, sys_setgroups16, 81, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_symlink
++TRACE_SYSCALL_TABLE(sys_symlink, sys_symlink, 83, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_readlink
++TRACE_SYSCALL_TABLE(sys_readlink, sys_readlink, 85, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_uselib
++TRACE_SYSCALL_TABLE(sys_uselib, sys_uselib, 86, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_swapon
++TRACE_SYSCALL_TABLE(sys_swapon, sys_swapon, 87, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_reboot
++TRACE_SYSCALL_TABLE(sys_reboot, sys_reboot, 88, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_truncate
++TRACE_SYSCALL_TABLE(sys_truncate, sys_truncate, 92, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_statfs
++TRACE_SYSCALL_TABLE(sys_statfs, sys_statfs, 99, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fstatfs
++TRACE_SYSCALL_TABLE(sys_fstatfs, sys_fstatfs, 100, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_syslog
++TRACE_SYSCALL_TABLE(sys_syslog, sys_syslog, 103, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setitimer
++TRACE_SYSCALL_TABLE(sys_setitimer, sys_setitimer, 104, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getitimer
++TRACE_SYSCALL_TABLE(sys_getitimer, sys_getitimer, 105, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_newstat
++TRACE_SYSCALL_TABLE(sys_newstat, sys_newstat, 106, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_newlstat
++TRACE_SYSCALL_TABLE(sys_newlstat, sys_newlstat, 107, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_newfstat
++TRACE_SYSCALL_TABLE(sys_newfstat, sys_newfstat, 108, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_wait4
++TRACE_SYSCALL_TABLE(sys_wait4, sys_wait4, 114, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_swapoff
++TRACE_SYSCALL_TABLE(sys_swapoff, sys_swapoff, 115, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sysinfo
++TRACE_SYSCALL_TABLE(sys_sysinfo, sys_sysinfo, 116, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setdomainname
++TRACE_SYSCALL_TABLE(sys_setdomainname, sys_setdomainname, 121, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_newuname
++TRACE_SYSCALL_TABLE(sys_newuname, sys_newuname, 122, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_adjtimex
++TRACE_SYSCALL_TABLE(sys_adjtimex, sys_adjtimex, 124, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sigprocmask
++TRACE_SYSCALL_TABLE(sys_sigprocmask, sys_sigprocmask, 126, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_init_module
++TRACE_SYSCALL_TABLE(sys_init_module, sys_init_module, 128, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_delete_module
++TRACE_SYSCALL_TABLE(sys_delete_module, sys_delete_module, 129, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_quotactl
++TRACE_SYSCALL_TABLE(sys_quotactl, sys_quotactl, 131, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_llseek
++TRACE_SYSCALL_TABLE(sys_llseek, sys_llseek, 140, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getdents
++TRACE_SYSCALL_TABLE(sys_getdents, sys_getdents, 141, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_select
++TRACE_SYSCALL_TABLE(sys_select, sys_select, 142, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_readv
++TRACE_SYSCALL_TABLE(sys_readv, sys_readv, 145, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_writev
++TRACE_SYSCALL_TABLE(sys_writev, sys_writev, 146, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sysctl
++TRACE_SYSCALL_TABLE(sys_sysctl, sys_sysctl, 149, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_setparam
++TRACE_SYSCALL_TABLE(sys_sched_setparam, sys_sched_setparam, 154, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_getparam
++TRACE_SYSCALL_TABLE(sys_sched_getparam, sys_sched_getparam, 155, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_setscheduler
++TRACE_SYSCALL_TABLE(sys_sched_setscheduler, sys_sched_setscheduler, 156, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_rr_get_interval
++TRACE_SYSCALL_TABLE(sys_sched_rr_get_interval, sys_sched_rr_get_interval, 161, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_nanosleep
++TRACE_SYSCALL_TABLE(sys_nanosleep, sys_nanosleep, 162, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getresuid16
++TRACE_SYSCALL_TABLE(sys_getresuid16, sys_getresuid16, 165, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_poll
++TRACE_SYSCALL_TABLE(sys_poll, sys_poll, 168, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getresgid16
++TRACE_SYSCALL_TABLE(sys_getresgid16, sys_getresgid16, 171, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigaction
++TRACE_SYSCALL_TABLE(sys_rt_sigaction, sys_rt_sigaction, 174, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigprocmask
++TRACE_SYSCALL_TABLE(sys_rt_sigprocmask, sys_rt_sigprocmask, 175, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigpending
++TRACE_SYSCALL_TABLE(sys_rt_sigpending, sys_rt_sigpending, 176, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigtimedwait
++TRACE_SYSCALL_TABLE(sys_rt_sigtimedwait, sys_rt_sigtimedwait, 177, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigqueueinfo
++TRACE_SYSCALL_TABLE(sys_rt_sigqueueinfo, sys_rt_sigqueueinfo, 178, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_sigsuspend
++TRACE_SYSCALL_TABLE(sys_rt_sigsuspend, sys_rt_sigsuspend, 179, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_chown16
++TRACE_SYSCALL_TABLE(sys_chown16, sys_chown16, 182, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getcwd
++TRACE_SYSCALL_TABLE(sys_getcwd, sys_getcwd, 183, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sendfile
++TRACE_SYSCALL_TABLE(sys_sendfile, sys_sendfile, 187, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getrlimit
++TRACE_SYSCALL_TABLE(sys_getrlimit, sys_getrlimit, 191, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_stat64
++TRACE_SYSCALL_TABLE(sys_stat64, sys_stat64, 195, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lstat64
++TRACE_SYSCALL_TABLE(sys_lstat64, sys_lstat64, 196, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fstat64
++TRACE_SYSCALL_TABLE(sys_fstat64, sys_fstat64, 197, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lchown
++TRACE_SYSCALL_TABLE(sys_lchown, sys_lchown, 198, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getgroups
++TRACE_SYSCALL_TABLE(sys_getgroups, sys_getgroups, 205, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setgroups
++TRACE_SYSCALL_TABLE(sys_setgroups, sys_setgroups, 206, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getresuid
++TRACE_SYSCALL_TABLE(sys_getresuid, sys_getresuid, 209, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getresgid
++TRACE_SYSCALL_TABLE(sys_getresgid, sys_getresgid, 211, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_chown
++TRACE_SYSCALL_TABLE(sys_chown, sys_chown, 212, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getdents64
++TRACE_SYSCALL_TABLE(sys_getdents64, sys_getdents64, 217, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pivot_root
++TRACE_SYSCALL_TABLE(sys_pivot_root, sys_pivot_root, 218, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mincore
++TRACE_SYSCALL_TABLE(sys_mincore, sys_mincore, 219, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setxattr
++TRACE_SYSCALL_TABLE(sys_setxattr, sys_setxattr, 226, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lsetxattr
++TRACE_SYSCALL_TABLE(sys_lsetxattr, sys_lsetxattr, 227, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fsetxattr
++TRACE_SYSCALL_TABLE(sys_fsetxattr, sys_fsetxattr, 228, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getxattr
++TRACE_SYSCALL_TABLE(sys_getxattr, sys_getxattr, 229, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lgetxattr
++TRACE_SYSCALL_TABLE(sys_lgetxattr, sys_lgetxattr, 230, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fgetxattr
++TRACE_SYSCALL_TABLE(sys_fgetxattr, sys_fgetxattr, 231, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_listxattr
++TRACE_SYSCALL_TABLE(sys_listxattr, sys_listxattr, 232, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_llistxattr
++TRACE_SYSCALL_TABLE(sys_llistxattr, sys_llistxattr, 233, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_flistxattr
++TRACE_SYSCALL_TABLE(sys_flistxattr, sys_flistxattr, 234, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_removexattr
++TRACE_SYSCALL_TABLE(sys_removexattr, sys_removexattr, 235, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_lremovexattr
++TRACE_SYSCALL_TABLE(sys_lremovexattr, sys_lremovexattr, 236, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fremovexattr
++TRACE_SYSCALL_TABLE(sys_fremovexattr, sys_fremovexattr, 237, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sendfile64
++TRACE_SYSCALL_TABLE(sys_sendfile64, sys_sendfile64, 239, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_futex
++TRACE_SYSCALL_TABLE(sys_futex, sys_futex, 240, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_setaffinity
++TRACE_SYSCALL_TABLE(sys_sched_setaffinity, sys_sched_setaffinity, 241, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sched_getaffinity
++TRACE_SYSCALL_TABLE(sys_sched_getaffinity, sys_sched_getaffinity, 242, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_io_setup
++TRACE_SYSCALL_TABLE(sys_io_setup, sys_io_setup, 243, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_io_getevents
++TRACE_SYSCALL_TABLE(sys_io_getevents, sys_io_getevents, 245, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_io_submit
++TRACE_SYSCALL_TABLE(sys_io_submit, sys_io_submit, 246, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_io_cancel
++TRACE_SYSCALL_TABLE(sys_io_cancel, sys_io_cancel, 247, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_epoll_ctl
++TRACE_SYSCALL_TABLE(sys_epoll_ctl, sys_epoll_ctl, 251, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_epoll_wait
++TRACE_SYSCALL_TABLE(sys_epoll_wait, sys_epoll_wait, 252, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_set_tid_address
++TRACE_SYSCALL_TABLE(sys_set_tid_address, sys_set_tid_address, 256, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timer_create
++TRACE_SYSCALL_TABLE(sys_timer_create, sys_timer_create, 257, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timer_settime
++TRACE_SYSCALL_TABLE(sys_timer_settime, sys_timer_settime, 258, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timer_gettime
++TRACE_SYSCALL_TABLE(sys_timer_gettime, sys_timer_gettime, 259, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_clock_settime
++TRACE_SYSCALL_TABLE(sys_clock_settime, sys_clock_settime, 262, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_clock_gettime
++TRACE_SYSCALL_TABLE(sys_clock_gettime, sys_clock_gettime, 263, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_clock_getres
++TRACE_SYSCALL_TABLE(sys_clock_getres, sys_clock_getres, 264, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_clock_nanosleep
++TRACE_SYSCALL_TABLE(sys_clock_nanosleep, sys_clock_nanosleep, 265, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_utimes
++TRACE_SYSCALL_TABLE(sys_utimes, sys_utimes, 269, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_open
++TRACE_SYSCALL_TABLE(sys_mq_open, sys_mq_open, 274, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_unlink
++TRACE_SYSCALL_TABLE(sys_mq_unlink, sys_mq_unlink, 275, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_timedsend
++TRACE_SYSCALL_TABLE(sys_mq_timedsend, sys_mq_timedsend, 276, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_timedreceive
++TRACE_SYSCALL_TABLE(sys_mq_timedreceive, sys_mq_timedreceive, 277, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_notify
++TRACE_SYSCALL_TABLE(sys_mq_notify, sys_mq_notify, 278, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mq_getsetattr
++TRACE_SYSCALL_TABLE(sys_mq_getsetattr, sys_mq_getsetattr, 279, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_waitid
++TRACE_SYSCALL_TABLE(sys_waitid, sys_waitid, 280, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_bind
++TRACE_SYSCALL_TABLE(sys_bind, sys_bind, 282, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_connect
++TRACE_SYSCALL_TABLE(sys_connect, sys_connect, 283, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_accept
++TRACE_SYSCALL_TABLE(sys_accept, sys_accept, 285, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getsockname
++TRACE_SYSCALL_TABLE(sys_getsockname, sys_getsockname, 286, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getpeername
++TRACE_SYSCALL_TABLE(sys_getpeername, sys_getpeername, 287, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_socketpair
++TRACE_SYSCALL_TABLE(sys_socketpair, sys_socketpair, 288, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_send
++TRACE_SYSCALL_TABLE(sys_send, sys_send, 289, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sendto
++TRACE_SYSCALL_TABLE(sys_sendto, sys_sendto, 290, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_recvfrom
++TRACE_SYSCALL_TABLE(sys_recvfrom, sys_recvfrom, 292, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_setsockopt
++TRACE_SYSCALL_TABLE(sys_setsockopt, sys_setsockopt, 294, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getsockopt
++TRACE_SYSCALL_TABLE(sys_getsockopt, sys_getsockopt, 295, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sendmsg
++TRACE_SYSCALL_TABLE(sys_sendmsg, sys_sendmsg, 296, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_recvmsg
++TRACE_SYSCALL_TABLE(sys_recvmsg, sys_recvmsg, 297, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_semop
++TRACE_SYSCALL_TABLE(sys_semop, sys_semop, 298, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_msgsnd
++TRACE_SYSCALL_TABLE(sys_msgsnd, sys_msgsnd, 301, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_msgrcv
++TRACE_SYSCALL_TABLE(sys_msgrcv, sys_msgrcv, 302, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_msgctl
++TRACE_SYSCALL_TABLE(sys_msgctl, sys_msgctl, 304, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_shmat
++TRACE_SYSCALL_TABLE(sys_shmat, sys_shmat, 305, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_shmdt
++TRACE_SYSCALL_TABLE(sys_shmdt, sys_shmdt, 306, 1)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_shmctl
++TRACE_SYSCALL_TABLE(sys_shmctl, sys_shmctl, 308, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_add_key
++TRACE_SYSCALL_TABLE(sys_add_key, sys_add_key, 309, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_request_key
++TRACE_SYSCALL_TABLE(sys_request_key, sys_request_key, 310, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_semtimedop
++TRACE_SYSCALL_TABLE(sys_semtimedop, sys_semtimedop, 312, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_inotify_add_watch
++TRACE_SYSCALL_TABLE(sys_inotify_add_watch, sys_inotify_add_watch, 317, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_openat
++TRACE_SYSCALL_TABLE(sys_openat, sys_openat, 322, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mkdirat
++TRACE_SYSCALL_TABLE(sys_mkdirat, sys_mkdirat, 323, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_mknodat
++TRACE_SYSCALL_TABLE(sys_mknodat, sys_mknodat, 324, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchownat
++TRACE_SYSCALL_TABLE(sys_fchownat, sys_fchownat, 325, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_futimesat
++TRACE_SYSCALL_TABLE(sys_futimesat, sys_futimesat, 326, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fstatat64
++TRACE_SYSCALL_TABLE(sys_fstatat64, sys_fstatat64, 327, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_unlinkat
++TRACE_SYSCALL_TABLE(sys_unlinkat, sys_unlinkat, 328, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_renameat
++TRACE_SYSCALL_TABLE(sys_renameat, sys_renameat, 329, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_linkat
++TRACE_SYSCALL_TABLE(sys_linkat, sys_linkat, 330, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_symlinkat
++TRACE_SYSCALL_TABLE(sys_symlinkat, sys_symlinkat, 331, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_readlinkat
++TRACE_SYSCALL_TABLE(sys_readlinkat, sys_readlinkat, 332, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_fchmodat
++TRACE_SYSCALL_TABLE(sys_fchmodat, sys_fchmodat, 333, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_faccessat
++TRACE_SYSCALL_TABLE(sys_faccessat, sys_faccessat, 334, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pselect6
++TRACE_SYSCALL_TABLE(sys_pselect6, sys_pselect6, 335, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_ppoll
++TRACE_SYSCALL_TABLE(sys_ppoll, sys_ppoll, 336, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_set_robust_list
++TRACE_SYSCALL_TABLE(sys_set_robust_list, sys_set_robust_list, 338, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_get_robust_list
++TRACE_SYSCALL_TABLE(sys_get_robust_list, sys_get_robust_list, 339, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_splice
++TRACE_SYSCALL_TABLE(sys_splice, sys_splice, 340, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_vmsplice
++TRACE_SYSCALL_TABLE(sys_vmsplice, sys_vmsplice, 343, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_getcpu
++TRACE_SYSCALL_TABLE(sys_getcpu, sys_getcpu, 345, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_epoll_pwait
++TRACE_SYSCALL_TABLE(sys_epoll_pwait, sys_epoll_pwait, 346, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_utimensat
++TRACE_SYSCALL_TABLE(sys_utimensat, sys_utimensat, 348, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_signalfd
++TRACE_SYSCALL_TABLE(sys_signalfd, sys_signalfd, 349, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timerfd_settime
++TRACE_SYSCALL_TABLE(sys_timerfd_settime, sys_timerfd_settime, 353, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_timerfd_gettime
++TRACE_SYSCALL_TABLE(sys_timerfd_gettime, sys_timerfd_gettime, 354, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_signalfd4
++TRACE_SYSCALL_TABLE(sys_signalfd4, sys_signalfd4, 355, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pipe2
++TRACE_SYSCALL_TABLE(sys_pipe2, sys_pipe2, 359, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_preadv
++TRACE_SYSCALL_TABLE(sys_preadv, sys_preadv, 361, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_pwritev
++TRACE_SYSCALL_TABLE(sys_pwritev, sys_pwritev, 362, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_rt_tgsigqueueinfo
++TRACE_SYSCALL_TABLE(sys_rt_tgsigqueueinfo, sys_rt_tgsigqueueinfo, 363, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_perf_event_open
++TRACE_SYSCALL_TABLE(sys_perf_event_open, sys_perf_event_open, 364, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_recvmmsg
++TRACE_SYSCALL_TABLE(sys_recvmmsg, sys_recvmmsg, 365, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_accept4
++TRACE_SYSCALL_TABLE(sys_accept4, sys_accept4, 366, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_prlimit64
++TRACE_SYSCALL_TABLE(sys_prlimit64, sys_prlimit64, 369, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_name_to_handle_at
++TRACE_SYSCALL_TABLE(sys_name_to_handle_at, sys_name_to_handle_at, 370, 5)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_open_by_handle_at
++TRACE_SYSCALL_TABLE(sys_open_by_handle_at, sys_open_by_handle_at, 371, 3)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_clock_adjtime
++TRACE_SYSCALL_TABLE(sys_clock_adjtime, sys_clock_adjtime, 372, 2)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_sendmmsg
++TRACE_SYSCALL_TABLE(sys_sendmmsg, sys_sendmmsg, 374, 4)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_process_vm_readv
++TRACE_SYSCALL_TABLE(sys_process_vm_readv, sys_process_vm_readv, 376, 6)
++#endif
++#ifndef OVERRIDE_TABLE_32_sys_process_vm_writev
++TRACE_SYSCALL_TABLE(sys_process_vm_writev, sys_process_vm_writev, 377, 6)
++#endif
++
++#endif /* CREATE_SYSCALL_TABLE */
+diff --git a/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers_override.h b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers_override.h
+new file mode 100644
+index 0000000..65131bb
+--- /dev/null
++++ b/instrumentation/syscalls/headers/arm-32-syscalls-3.4.25_pointers_override.h
+@@ -0,0 +1,39 @@
++
++#define OVERRIDE_TABLE_32_sys_mmap2
++
++
++#ifndef CREATE_SYSCALL_TABLE
++
++SC_TRACE_EVENT(sys_mmap2,
++	TP_PROTO(void *addr, size_t len, int prot,
++                 int flags, int fd, off_t pgoff),
++	TP_ARGS(addr, len, prot, flags, fd, pgoff),
++	TP_STRUCT__entry(
++		__field_hex(void *, addr)
++		__field(size_t, len)
++		__field(int, prot)
++		__field(int, flags)
++		__field(int, fd)
++		__field(off_t, pgoff)),
++	TP_fast_assign(
++		tp_assign(addr, addr)
++		tp_assign(len, len)
++		tp_assign(prot, prot)
++		tp_assign(flags, flags)
++		tp_assign(fd, fd)
++		tp_assign(pgoff, pgoff)),
++	TP_printk()
++)
++
++#else	/* CREATE_SYSCALL_TABLE */
++
++#define OVERRIDE_TABLE_32_sys_execve
++TRACE_SYSCALL_TABLE(sys_execve, sys_execve, 11, 3)
++#define OVERRIDE_TABLE_32_sys_clone
++TRACE_SYSCALL_TABLE(sys_clone, sys_clone, 120, 5)
++#define OVERRIDE_TABLE_32_sys_mmap2
++TRACE_SYSCALL_TABLE(sys_mmap2, sys_mmap2, 192, 6)
++
++#endif /* CREATE_SYSCALL_TABLE */
++
++
+diff --git a/instrumentation/syscalls/headers/syscalls_integers.h b/instrumentation/syscalls/headers/syscalls_integers.h
+index 002130a..1ee96c5 100644
+--- a/instrumentation/syscalls/headers/syscalls_integers.h
++++ b/instrumentation/syscalls/headers/syscalls_integers.h
+@@ -7,5 +7,5 @@
+ #endif
+ 
+ #ifdef CONFIG_ARM
+-#include "arm-32-syscalls-2.6.38_integers.h"
++#include "arm-32-syscalls-3.4.25_integers.h"
+ #endif
+diff --git a/instrumentation/syscalls/headers/syscalls_pointers.h b/instrumentation/syscalls/headers/syscalls_pointers.h
+index 11b4979..44c74ed 100644
+--- a/instrumentation/syscalls/headers/syscalls_pointers.h
++++ b/instrumentation/syscalls/headers/syscalls_pointers.h
+@@ -7,5 +7,5 @@
+ #endif
+ 
+ #ifdef CONFIG_ARM
+-#include "arm-32-syscalls-2.6.38_pointers.h"
++#include "arm-32-syscalls-3.4.25_pointers.h"
+ #endif
+-- 
+1.7.10.4
+

--- a/recipes/lttng-2.0/lttng-modules_2.2.0.bbappend
+++ b/recipes/lttng-2.0/lttng-modules_2.2.0.bbappend
@@ -1,0 +1,6 @@
+PRINC := "${@int(PRINC) + 1}"
+
+FILESEXTRAPATHS := "${THISDIR}/${BPN}"
+SRC_URI += "\
+    file://0001-Update-ARM-32-bit-syscall-tracepoints-to-3.4.patch \
+"


### PR DESCRIPTION
Bring up the commit from lttng master branch to version 2.2.0.
This patch updates ARM syscalls tracepoints to kernel version 3.4.

Although the kernel version, served by this patch, is less, than our versions, it's more preferable, than even previously used instrumentation for 3.5.6, because:
- this patch is from official upstream master branch, so future updates to later lttng versions will be smoother;
- the set of syscalls in 3.5 is almost the same as in 3.4 (just minor differences in argument names and types), so this patch will work for 3.5 too;
- this 3.4 instrumentation supports even more syscalls than previous "unofficial" 3.5 one (probably some syscalls were somehow masked while automatic list extraction last time).

Kernel version 3.8 has just one additional syscall, comparing to 3.5, so this instrumentation will work sufficiently good for 3.8 too (although that additional syscall will be traced as unknown).
