### PR TITLE
ca-certificates: fix installation for target.

### DIFF
--- a/recipes/ca-certificates/ca-certificates_20130610.bb
+++ b/recipes/ca-certificates/ca-certificates_20130610.bb
@@ -46,7 +46,7 @@ do_install () {
     } >${D}${sysconfdir}/ca-certificates.conf
 }
 
-do_install_class-target () {
+do_install_append_class-target () {
     sed -i -e 's,/etc/,${sysconfdir}/,' \
            -e 's,/usr/share/,${datadir}/,' \
            -e 's,/usr/local,${prefix}/local,' \


### PR DESCRIPTION
Target installation step should be appended rather than overriding
the whole installation step otherwise this would fail for target
installations becuase the corresponding files are not available.

Signed-off-by: Awais Belal awais_belal@mentor.com
