### PR TITLE
openssh: Add dependency on libbsd.

### DIFF
--- a/recipes/openssh/openssh_6.0p1.bbappend
+++ b/recipes/openssh/openssh_6.0p1.bbappend
@@ -1,4 +1,4 @@
-PRINC := "${@int(PRINC) + 1}"
+PRINC := "${@int(PRINC) + 2}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}:"
 PARALLEL_MAKEINST = ""
@@ -12,3 +12,5 @@ do_debug_sed() {
                -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' ${WORKDIR}/sshd_config
     fi
 }
+
+DEPENDS += "libbsd"


### PR DESCRIPTION
There is a race condition when libbsd and openssh are included
in a configuration.  The libbsd recipe will eventually stage
a libutil.h file to the sysroot.  The openssh configure step
checks the existence of that file and if it exists will use it.
There are cases where the file will exist during the configure
step but have been cleaned up during the compile step, presumably
depending on libbsd being rebuilt.  It can be arbitrarily made
to happen by the following steps:

```
$ bitbake -c cleansstate libbsd openssh
$ bitbake libbsd
$ bitbake -c configure openssh
$ bitbake -c clean libbsd
$ bitbake -c compile openssh
```

Adding an explicit dependency ensure this cannot happen.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
