### PR TITLE
ruby-native: Workaround parallel make race

### DIFF
--- a/recipes/ruby/ruby_1.9.3-p194.bbappend
+++ b/recipes/ruby/ruby_1.9.3-p194.bbappend
@@ -1,0 +1,2 @@
+PRINC := "${@int(PRINC) + 1}"
+PARALLEL_MAKE = ""


### PR DESCRIPTION
There is a race condition in the ruby-native package that does not
appear to be resolved upstream.

http://marc.info/?t=123428742700005&r=1&w=2

Work-around it by disabling parallel make for ruby.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
