### PR TITLE
dhcp: Get rid of ifconfig/route in dhclient-script

### DIFF
--- a/recipes/dhcp/dhcp/replace-ifconfig-route.patch
+++ b/recipes/dhcp/dhcp/replace-ifconfig-route.patch
@@ -1,0 +1,176 @@
+Found this patch here:
+https://lists.isc.org/pipermail/dhcp-users/2011-January/012910.html
+
+and made some adjustments/updates to make it work with this version.
+Wasn't able to find that why this patch was not accepted by ISC DHCP developers.
+
+Upstream-Status: Pending
+
+Signed-off-by: Muhammad Shakeel <muhammad_shakeel@mentor.com>
+
+--- dhcp-4.2.5-P1/client/scripts/linux.orig	2013-09-04 12:22:55.000000000 +0500
++++ dhcp-4.2.5-P1/client/scripts/linux	2013-09-04 12:52:19.068761518 +0500
+@@ -103,17 +103,11 @@
+ if [ x$old_broadcast_address != x ]; then
+   old_broadcast_arg="broadcast $old_broadcast_address"
+ fi
+-if [ x$new_subnet_mask != x ]; then
+-  new_subnet_arg="netmask $new_subnet_mask"
+-fi
+-if [ x$old_subnet_mask != x ]; then
+-  old_subnet_arg="netmask $old_subnet_mask"
+-fi
+-if [ x$alias_subnet_mask != x ]; then
+-  alias_subnet_arg="netmask $alias_subnet_mask"
++if [ -n "$new_subnet_mask" ]; then
++    new_mask="/$new_subnet_mask"
+ fi
+-if [ x$new_interface_mtu != x ]; then
+-  mtu_arg="mtu $new_interface_mtu"
++if [ -n "$alias_subnet_mask" ]; then
++    alias_mask="/$alias_subnet_mask"
+ fi
+ if [ x$IF_METRIC != x ]; then
+   metric_arg="metric $IF_METRIC"
+@@ -127,9 +121,9 @@
+ if [ x$reason = xPREINIT ]; then
+   if [ x$alias_ip_address != x ]; then
+     # Bring down alias interface. Its routes will disappear too.
+-    ifconfig $interface:0- inet 0
++    ${ip} -4 addr flush dev ${interface} label ${interface}:0
+   fi
+-  ifconfig $interface 0 up
++  ${ip} link set dev ${interface} up
+ 
+   # We need to give the kernel some time to get the interface up.
+   sleep 1
+@@ -156,25 +150,30 @@
+   if [ x$old_ip_address != x ] && [ x$alias_ip_address != x ] && \
+ 		[ x$alias_ip_address != x$old_ip_address ]; then
+     # Possible new alias. Remove old alias.
+-    ifconfig $interface:0- inet 0
++    ${ip} -4 addr flush dev ${interface} label ${interface}:0
+   fi
+   if [ x$old_ip_address != x ] && [ x$old_ip_address != x$new_ip_address ]; then
+     # IP address changed. Bringing down the interface will delete all routes,
+     # and clear the ARP cache.
+-    ifconfig $interface inet 0 down
++    ${ip} -4 addr flush dev ${interface} label ${interface}
+ 
+   fi
+   if [ x$old_ip_address = x ] || [ x$old_ip_address != x$new_ip_address ] || \
+      [ x$reason = xBOUND ] || [ x$reason = xREBOOT ]; then
+ 
+-    ifconfig $interface inet $new_ip_address $new_subnet_arg \
+-					$new_broadcast_arg $mtu_arg
++    ${ip} -4 addr add ${new_ip_address}${new_mask} ${new_broadcast_arg} \
++                dev ${interface} label ${interface}
++    if [ -n "$new_interface_mtu" ]; then
++      # set MTU
++      ${ip} link set dev ${interface} mtu ${new_interface_mtu}
++    fi
+     # Add a network route to the computed network address.
+     for router in $new_routers; do
+       if [ "x$new_subnet_mask" = "x255.255.255.255" ] ; then
+-	route add -host $router dev $interface
++        ${ip} -4 route add ${router} dev $interface >/dev/null 2>&1
+       fi
+-      route add default gw $router $metric_arg dev $interface
++      ${ip} -4 route add default via ${router} dev ${interface} \
++        ${metric_arg} >/dev/null 2>&1
+     done
+   else
+     # we haven't changed the address, have we changed other options           
+@@ -182,21 +181,23 @@
+     if [ x$new_routers != x ] && [ x$new_routers != x$old_routers ] ; then
+       # if we've changed routers delete the old and add the new.
+       for router in $old_routers; do
+-        route del default gw $router
++        ${ip} -4 route delete default via ${router}
+       done
+       for router in $new_routers; do
+         if [ "x$new_subnet_mask" = "x255.255.255.255" ] ; then
+-	  route add -host $router dev $interface
+-	fi
+-	route add default gw $router $metric_arg dev $interface
++	      ${ip} -4 route add ${router} dev $interface >/dev/null 2>&1
++	    fi
++        ${ip} -4 route add default via ${router} dev ${interface} \
++          ${metric_arg} >/dev/null 2>&1
+       done
+     fi
+   fi
+   if [ x$new_ip_address != x$alias_ip_address ] && [ x$alias_ip_address != x ];
+    then
+-    ifconfig $interface:0- inet 0
+-    ifconfig $interface:0 inet $alias_ip_address $alias_subnet_arg
+-    route add -host $alias_ip_address $interface:0
++    ${ip} -4 addr flush dev ${interface} label ${interface}:0
++    ${ip} -4 addr add ${alias_ip_address}${alias_mask} \
++        dev ${interface} label ${interface}:0
++    ${ip} -4 route add ${alias_ip_address} dev ${interface} >/dev/null 2>&1
+   fi
+   make_resolv_conf
+   exit_with_hooks 0
+@@ -206,42 +207,49 @@
+    || [ x$reason = xSTOP ]; then
+   if [ x$alias_ip_address != x ]; then
+     # Turn off alias interface.
+-    ifconfig $interface:0- inet 0
++    ${ip} -4 addr flush dev ${interface} label ${interface}:0
+   fi
+   if [ x$old_ip_address != x ]; then
+     # Shut down interface, which will delete routes and clear arp cache.
+-    ifconfig $interface inet 0 down
++    ${ip} -4 addr flush dev ${interface} label ${interface}
+   fi
+   if [ x$alias_ip_address != x ]; then
+-    ifconfig $interface:0 inet $alias_ip_address $alias_subnet_arg
+-    route add -host $alias_ip_address $interface:0
++    ${ip} -4 addr add ${alias_ip_address}${alias_network_arg} \
++        dev ${interface} label ${interface}:0
++    ${ip} -4 route add ${alias_ip_address} dev ${interface} >/dev/null 2>&1
+   fi
+   exit_with_hooks 0
+ fi
+ 
+ if [ x$reason = xTIMEOUT ]; then
+   if [ x$alias_ip_address != x ]; then
+-    ifconfig $interface:0- inet 0
++    ${ip} -4 addr flush dev ${interface} label ${interface}:0
++  fi
++  ${ip} -4 addr add ${new_ip_address}${new_mask} ${new_broadcast_arg} \
++            dev ${interface} label ${interface}
++  if [ -n "$new_interface_mtu" ]; then
++    # set MTU
++    ip link set dev ${interface} mtu ${new_interface_mtu}
+   fi
+-  ifconfig $interface inet $new_ip_address $new_subnet_arg \
+-					$new_broadcast_arg $mtu_arg
+   set $new_routers
+   if ping -q -c 1 $1; then
+     if [ x$new_ip_address != x$alias_ip_address ] && \
+ 			[ x$alias_ip_address != x ]; then
+-      ifconfig $interface:0 inet $alias_ip_address $alias_subnet_arg
+-      route add -host $alias_ip_address dev $interface:0
++      ${ip} -4 addr add ${alias_ip_address}${alias_mask} \
++            dev ${interface} label ${interface}:0
++      ${ip} -4 route add ${alias_ip_address} dev ${interface} >/dev/null 2>&1
+     fi
+     for router in $new_routers; do
+       if [ "x$new_subnet_mask" = "x255.255.255.255" ] ; then
+-	route add -host $router dev $interface
++	    ${ip} -4 route add ${router} dev $interface >/dev/null 2>&1
+       fi
+-      route add default gw $router $metric_arg dev $interface
++      ${ip} -4 route add default via ${router} dev ${interface} \
++        ${metric_arg} >/dev/null 2>&1
+     done
+     make_resolv_conf
+     exit_with_hooks 0
+   fi
+-  ifconfig $interface inet 0 down
++  ${ip} -4 addr flush dev ${interface}
+   exit_with_hooks 1
+ fi
+ 

--- a/recipes/dhcp/dhcp_4.2.5-P1.bbappend
+++ b/recipes/dhcp/dhcp_4.2.5-P1.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/dhcp:"
+SRC_URI += "file://replace-ifconfig-route.patch \
+           "


### PR DESCRIPTION
Copying: https://lists.isc.org/pipermail/dhcp-users/2011-January/012910.html

```

---
ISC DHCP's dhclient-script for Linux still uses the legacy commands
"ifconfig" & "route" to manage IPv4 network addresses & routes,
while it uses iproute2's new "ip" command to manage IPv6 network data.

This requires users & distributions to have both types of commands installed.

The attached patch tries to improve the situation by replacing the
old "ifconfig" resp. "route" commands with their "ip" counterparts.

It even improves the logic a bit by only flushing the IPv4 addresses
instead of taking down the whole interface, which may still have active IPv6
connections.

---
```

Signed-off-by: Muhammad Shakeel muhammad_shakeel@mentor.com
