### PR TITLE
tofrodos-native: Add recipe file

### DIFF
--- a/recipes/tofrodos/tofrodos-native/Make-OE-friendly.patch
+++ b/recipes/tofrodos/tofrodos-native/Make-OE-friendly.patch
@@ -1,0 +1,32 @@
+Upstream-Status: Inappropriate [open-embedded]
+
+Signed-off-by: Muhammad Shakeel <muhammad_shakeel@mentor.com>
+
+--- src/Makefile	2012-09-30 22:15:32.000000000 +0500
++++ src/Makefile	2013-09-17 13:18:53.073698834 +0500
+@@ -30,7 +30,7 @@
+ RM = rm -f
+ 
+ # flags
+-CFLAGS = $(DEFINES) $(TFLAG) $(CDEBUG) -c -Wall
++CCFLAGS = $(DEFINES) $(TFLAG) $(CDEBUG) -c -Wall
+ GZIPFLAGS = -9
+ INSTALLBINFLAGS = -m 755
+ INSTALLDATAFLAGS = -m 644
+@@ -58,7 +58,7 @@
+ 
+ # implicit rules
+ .c.o:
+-	$(CC) $(CFLAGS) $<
++	$(CC) $(CCFLAGS) $(CFLAGS) $<
+ 
+ # user visible rules
+ all: $(FROMDOS) $(TODOS)
+@@ -69,7 +69,7 @@
+ clobber: clean
+ 	$(RM) $(FROMDOS) $(TODOS)
+ 
+-install: installman
++install:
+ 	$(INSTALL) $(INSTALLBINFLAGS) $(FROMDOS) $(BINDIR)
+ 	($(CD) $(BINDIR) ; $(LN) $(LNFLAGS) fromdos todos)

--- a/recipes/tofrodos/tofrodos-native_1.7.12a.bb
+++ b/recipes/tofrodos/tofrodos-native_1.7.12a.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Tofrodos is a text file conversion utility that converts ASCII files between the MSDOS and unix format"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://../COPYING;md5=8ca43cbc842c2336e835926c2166c28b"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "http://tofrodos.sourceforge.net/download/tofrodos-${PV}.tar.gz \
+           file://Make-OE-friendly.patch \
+          "
+
+SRC_URI[md5sum] = "219c03d7c58975b335cdb5201338125a"
+SRC_URI[sha256sum] = "3098af78325486b99116c65c9f9bbbbfb3dfbeab1ab1e63a8da79550a5af6a08"
+
+S = "${WORKDIR}/tofrodos/src"
+
+inherit native
+
+do_install(){
+	mkdir -p ${D}/${bindir}/
+	oe_runmake 'BINDIR=${D}${bindir}' install
+}


### PR DESCRIPTION
This recipe will add 'fromdos' and 'todos' tools for host
environment. These utilities are required by the packages which
have source files edited in MS Windows environment, i.e. omapdrm-pvr
present in from meta-ti-glsdk layer. 'fromdos' will replace MS-DOS
line-endings with Unix style line-endings.

Signed-off-by: Muhammad Shakeel muhammad_shakeel@mentor.com
