### PR TITLE
connman: Fix NFS boot hang if connman is NETWORK_MANAGER

### DIFF
--- a/recipes/connman/connman_1.17.bbappend
+++ b/recipes/connman/connman_1.17.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://fix-stoping-interfaces-at-start.patch"

--- a/recipes/connman/files/fix-stoping-interfaces-at-start.patch
+++ b/recipes/connman/files/fix-stoping-interfaces-at-start.patch
@@ -1,0 +1,15 @@
+Index: connman-1.4/src/device.c
+===================================================================
+--- connman-1.4.orig/src/device.c
++++ connman-1.4/src/device.c
+@@ -1247,7 +1247,10 @@ int __connman_device_init(const char *de
+ 	if (nodevice != NULL)
+ 		nodevice_filter = g_strsplit(nodevice, ",", -1);
+ 
++        /* Disable cleanup devices for machines booting via NFS */
++	#if 0        
+ 	cleanup_devices();
++	#endif 
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
NFS booting hangs since connman forces the the interface to be
brought down before it will bring it up.

Signed-off-by: Muhammad Shakeel muhammad_shakeel@mentor.com
