### PR TITLE
libunique: Added missing dependency on dbus-glib

### DIFF
--- a/gnome-layer/recipes-gnome/libunique/libunique_1.1.6.bbappend
+++ b/gnome-layer/recipes-gnome/libunique/libunique_1.1.6.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "dbus-glib"


### PR DESCRIPTION
Signed-off-by: Mikhail Durnev Mikhail_Durnev@mentor.com
