### PR TITLE
curl: Add ca-certificates in RRECOMMENDS

### DIFF
--- a/recipes/curl/curl_7.32.0.bbappend
+++ b/recipes/curl/curl_7.32.0.bbappend
@@ -3,3 +3,5 @@ CURLGNUTLS_class-nativesdk += "--without-gnutls --with-ssl"
 
 #EXTRA_OECONF += "--with-ca-path=${sysconfdir}/ssl/certs"
 EXTRA_OECONF += "--with-ca-bundle=${sysconfdir}/ssl/certs/ca-certificates.crt"
+
+RRECOMMENDS_${PN} += "ca-certificates"


### PR DESCRIPTION
curl requires ca-certificates along with openssl to fetch remote
contents securely. We have tried to push this upstream but this need
some more brain storming that how to handle this in the most
appropriate way.

Please see following threads on OE-Core mailing list:
http://patches.openembedded.org/patch/58369/
http://lists.openembedded.org/pipermail/openembedded-core/2013-September/083974.html

Signed-off-by: Muhammad Shakeel muhammad_shakeel@mentor.com
