### PR TITLE
bridge-utils: use update-alternatives bbclass

### DIFF
--- a/networking-layer/recipes-support/bridge-utils/bridge-utils_1.5.bbappend
+++ b/networking-layer/recipes-support/bridge-utils/bridge-utils_1.5.bbappend
@@ -1,0 +1,11 @@
+pkg_postinst_${PN} () {
+}
+
+pkg_prerm_${PN} () {
+}
+
+inherit update-alternatives
+
+ALTERNATIVE_PRIORITY = "75"
+ALTERNATIVE_${PN} = "brctl"
+ALTERNATIVE_LINK_NAME[brctl] = "${sbindir}/brctl"


### PR DESCRIPTION
This fixes a read-only-rootfs bug, as the manual update-alternatives command 
being run didn't utilize ${D}, so failed at do_rootfs time.

Signed-off-by: Christopher Larson kergoth@gmail.com
