### PR TITLE
Added handling for customer repos, hotfixes, etc.

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -29,9 +29,43 @@ else
         esac
     done
 
+    OPTIONALLAYERS="$OPTIONALLAYERS"
+
+    # Customer directory layers handling (e.g. adit-custom, conti-custom, etc.)
+    if [ -e "$layerdir/../customer.conf" ] ; then
+        for CUSTOMER in $(cat $layerdir/../customer.conf) ; do
+            if [ -d "$CUSTOMER-custom" ] ; then
+                if [ -e "$CUSTOMER-custom/custom.conf" ] ; then
+                    CUSTOMERLAYERS=`cat $CUSTOMER-custom/custom.conf | sed -e '/^[ 	]*#/d'`
+                    CUSTOMERLAYERS=`echo $CUSTOMERLAYERS | sed -e 's/\n//g'`
+                    OPTIONALLAYERS="$OPTIONALLAYERS $CUSTOMERLAYERS"
+                    unset CUSTOMERLAYERS
+                fi
+            fi
+        done
+        unset CUSTOMER
+    fi
+
+    # Hotfix layers handling
+    if [ -e "$layerdir/../hotfixes/hotfix.conf" ] ; then
+        HOTFIXES=`cat $layerdir/../hotfixes/hotfix.conf | sed -e '/^[ 	]*#/d'`
+        HOTFIXES=`echo $HOTFIXES | sed -e 's/\n//g'`
+        OPTIONALLAYERS="$OPTIONALLAYERS $HOTFIXES"
+        unset HOTFIXES
+    fi
+
+    # Extra layers handling
+    if [ -e "$layerdir/../xlayers.conf" ] ; then
+        EXTRALAYERS=`cat $layerdir/../xlayers.conf | sed -e '/^[ 	]*#/d'`
+        EXTRALAYERS=`echo $EXTRALAYERS | sed -e 's/\n//g'`
+        OPTIONALLAYERS="$OPTIONALLAYERS $EXTRALAYERS"
+        unset EXTRALAYERS
+    fi
+
     OPTIONALLAYERS="$OPTIONALLAYERS" EXTRAMELLAYERS="$EXTRAMELLAYERS" $layerdir/scripts/setup-mel-builddir "$@" && \
         [ -n "$BUILDDIR" ] && [ -e "$BUILDDIR" ] && \
         . $BUILDDIR/setup-environment
+    unset EXTRAMELLAYERS
     unset OPTIONALLAYERS
     unset layerdir
 fi


### PR DESCRIPTION
Added three sections to parse the following options config files
for additional layers to add to the config:

```
mel/customer.conf
mel/xlayers.conf
mel/hotfixes/hotfix.conf
```

All three are optional.  customer.conf must contain the customer name
and will pull in the custom configuration for "adit-custom" repo, for
example when "adit" is listed in customer.conf

hotfixes/hotfix.conf lists the layer names for all desired hotfixes
to be included in the build.  It does not automatically add all hotfixes
in order to pull out problematic hotfixes, and more importantly to allow
cooperative work on hotfixes.  That is, incomplete hotfixes can be merged
in without worry of mangling the nightly build until they are ready and
added to hotfix.conf.

xlayers.conf is intended to be used as an easy way for a developer to
add a particular layer to the build configuration without having to
go and modify OPTIONALLAYERS inside setup-environment.  This can't be
done within local.conf because bblayers.conf is created before local.conf
is ever created/parsed.
