### PR TITLE
mel.conf: drop additional SANITY_TESTED_DISTROS

### DIFF
--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -163,17 +163,6 @@ PATCHRESOLVE = "noop"
 # Defaults for meta-ti machines missing it, as some recipes require it
 MACHINE_KERNEL_PR_beagleboard ?= "r1"
 
-# Additional distros we test on
-SANITY_TESTED_DISTROS += "\
-    Ubuntu-10.04 \
-    Centos-5.4 \
-    Centos-5.5 \
-    Centos-5.6 \
-    Centos-5.7 \
-    Centos-5.8 \
-    Centos-5.9 \
-"
-
 # We aren't quite so picky as poky
 WARN_QA = "ldflags useless-rpaths rpaths staticdev libdir xorg-driver-abi \
            textrel already-stripped incompatible-license files-invalid \


### PR DESCRIPTION
These are no longer supported by us.

Signed-off-by: Christopher Larson kergoth@gmail.com
