### PR TITLE
syslinux: use cross toolchain in do_install()

### DIFF
--- a/recipes/syslinux/syslinux_6.01.bbappend
+++ b/recipes/syslinux/syslinux_6.01.bbappend
@@ -1,0 +1,7 @@
+do_install() {
+	oe_runmake CC="${CC} ${CFLAGS}" LD="${LD} ${LDFLAGS}" INSTALLROOT="${D}" firmware="bios" install
+
+	install -d ${D}${datadir}/syslinux/
+	install -m 644 ${S}/bios/core/ldlinux.sys ${D}${datadir}/syslinux/
+	install -m 644 ${S}/bios/core/ldlinux.bss ${D}${datadir}/syslinux/
+}


### PR DESCRIPTION
Signed-off-by: Mikhail Durnev Mikhail_Durnev@mentor.com
