### PR TITLE
sysvinit-inittab: Fix getting tty device name from SERIAL_CONSOLES entries

### DIFF
--- a/recipes/sysvinit/sysvinit-inittab_2.88dsf.bbappend
+++ b/recipes/sysvinit/sysvinit-inittab_2.88dsf.bbappend
@@ -1,0 +1,7 @@
+# sysvinit-inittab: Fix getting tty device name from SERIAL_CONSOLES entries
+
+python () {
+    do_install = d.getVar('do_install', False)
+    d.setVar('do_install', do_install.replace("label=`echo ${i} | sed -e 's/^.*;tty//'`",
+                                              "label=`echo ${i} | sed -e 's/^.*;tty//' -e 's/;.*//'`"))
+}


### PR DESCRIPTION
Applied as a bbappend.

Signed-off-by: Christopher Larson kergoth@gmail.com
