### PR TITLE
archive-release: kill explicit dep on tar-replacement-native

### DIFF
--- a/recipes/meta/archive-release.bb
+++ b/recipes/meta/archive-release.bb
@@ -301,7 +301,6 @@ addtask dump_headrevs
 do_prepare_release[dirs] =+ "${DEPLOY_DIR_RELEASE} ${MELDIR} ${S}"
 do_prepare_release[cleandirs] = "${S}"
 do_prepare_release[nostamp] = "1"
-do_prepare_release[depends] += "tar-replacement-native:do_populate_sysroot"
 do_prepare_release[depends] += "${RELEASE_IMAGE}:do_rootfs"
 do_prepare_release[depends] += "${RELEASE_IMAGE}:do_build"
 do_prepare_release[recrdeptask] += "do_package_write"


### PR DESCRIPTION
Using a task dep seems to bypass ASSUME_PROVIDED, forcing it into the build,
resulting in text file races for the tar binary in the sysroot, and also, it's
unnecessary, since the up front build done by the bitbake wrapper ensures that
recent tar is available.

Signed-off-by: Christopher Larson chris_larson@mentor.com
(cherry picked from commit a16456b82dcf769fe342918ebae1378093f237f8)
