### PR TITLE
Workaround allowing proper playing of audio files with different formats

### DIFF
--- a/recipes/pulseaudio/pulseaudio_4.0.bbappend
+++ b/recipes/pulseaudio/pulseaudio_4.0.bbappend
@@ -3,3 +3,7 @@ PACKAGECONFIG[gconf] = "--enable-gconf,--disable-gconf,gconf,"
 # Currently this is in PACKAGES_DYNAMIC via a regex, not PACKAGES, so bitbake
 # is unaware of its defined RDEPENDS. Add it explicitly to work around this.
 PACKAGES += "pulseaudio-module-console-kit"
+
+do_install_append() {
+        sed -i 's/; resample-method.*/resample-method \= speex-fixed-3/' ${D}/etc/pulse/daemon.conf
+}


### PR DESCRIPTION
using Pusleaudio.

*For some audio formats that required resampler to be invoked, the
default Pulseaudio resampler (speex-float-N) was not working as
desired and hence no audio was being heard. Changing resampler to
speex-fixed-N allows correct resampling and audio can be heard.
But this is just a workaround since actual issue seems to be with the
toolchain because Pulseaudio source and configuration is same as before
but toolchain has been updated.
A test case is to be developed to cofirm that this issue is related to
toolchain modifications.

Jira Issue: SB-1495, ATP2013.11: Not able to hear audio when play
audio file through pulseaudio.

Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
