### PR TITLE
mel.conf: update SANITY_TESTED_DISTROS

### DIFF
--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -24,6 +24,16 @@ ADE_SECTIONS_EXCLUDED = "locale"
 require conf/distro/include/mel-providers.conf
 require conf/distro/include/mel-vardeps.conf
 
+# Currently, we do not support CentOS 6 due to its lack of the needed python
+# 2.7. We also do not support Debian, SUSE, or openSUSE at this time.
+SANITY_TESTED_DISTROS = "\
+    Ubuntu-12.04 \n\
+    Ubuntu-12.10 \n\
+    Ubuntu-13.04 \n\
+    Fedora-18 \n\
+    Fedora-19 \n\
+"
+
 # Ensure we can fetch from private github repositories with https
 FETCHCMD_wget += "--auth-no-challenge"
 


### PR DESCRIPTION
Currently, we do not support CentOS 6 due to its lack of the needed python 
2.7. We also do not support Debian, SUSE, or openSUSE at this time.

JIRA: SB-1262

Signed-off-by: Christopher Larson kergoth@gmail.com
