### PR TITLE
mel.conf: adapt to meta-ro-rootfs switch to volatile-binds

### DIFF
--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -39,8 +39,8 @@ FETCHCMD_wget += "--auth-no-challenge"
 
 INHERIT_DISTRO ?= "debian devshell sstate license deploy-license-manifest"
 
-# Include configuration for bind mounts in r/o systemd images
-IMAGE_INSTALL_append = " ${@'ro-binds' if 'read-only-rootfs' in IMAGE_FEATURES.split() and 'systemd' in DISTRO_FEATURES.split() and 'ro-rootfs' in BBFILE_COLLECTIONS.split() else ''}"
+# Ensure / is mounted r/o in systemd images
+INHERIT += "read_only_rootfs_systemd"
 
 # Add an explicit -march to BUILD_CFLAGS. sanity.bbclass will fail on gcc
 # versions older than 4.5 without -march= in BUILD_CFLAGS.


### PR DESCRIPTION
Signed-off-by: Christopher Larson kergoth@gmail.com
