### PR TITLE
setup-environment: Handle EXCLUDEDLAYERS.

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -69,6 +69,8 @@ def process_arguments(cmdline_args):
             help='base layers to include. space separated. default="{0}"'.format(layers_default))
     parser.add_option('-o', '--optional-layers', default='',
             help='optional layers to include. space separated.')
+    parser.add_option('-x', '--excluded-layers', default='',
+            help='explicit layers to excluded. space separated.')
     parser.add_option('-g', '--globs', default=glob_default,
             help='wildcard patterns to locate layers. colon separated. default="{0}"'.format(glob_default))
     parser.add_option('-p', '--paths',
@@ -79,6 +81,7 @@ def process_arguments(cmdline_args):
 
     opts.layers = opts.layers.split()
     opts.optional_layers = opts.optional_layers.split()
+    opts.excluded_layers = opts.excluded_layers.split()
 
     new_globs = []
     for pattern in opts.globs.split(':'):
@@ -266,6 +269,8 @@ def print_layers(cmdline_opts):
                 sys.exit(str(exc))
             else:
                 all_layers |= set(layers)
+
+    all_layers = set(filter(lambda layer:layer.name not in opts.excluded_layers, all_layers))
 
     for layer in all_layers:
         priority_override = priority_overrides.get(layer.name)

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -88,7 +88,7 @@ configure_for_machine () {
 
     echo 'BBLAYERS = "\' >> $1/bblayers.conf
     layersfile=$(mktemp setup-mel-builddir.XXXXXX)
-    $layerdir/scripts/bb-determine-layers -g "*:*/*:$MELDIR/*:$MELDIR/*/*" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" $MACHINE >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "*:*/*:$MELDIR/*:$MELDIR/*/*" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -x "$EXCLUDEDLAYERS" $MACHINE >$layersfile
     if [ $? -ne 0 ]; then
         rm -f $layersfile
         echo >&2 "Error in execution of bb-determine-layers, aborting"

--- a/setup-environment
+++ b/setup-environment
@@ -30,6 +30,7 @@ else
     done
 
     OPTIONALLAYERS="$OPTIONALLAYERS"
+    EXCLUDEDLAYERS="$EXCLUDEDLAYERS"
 
     # Customer directory layers handling (e.g. <customername>-custom)
     if [ -e "$layerdir/../customer.conf" ] ; then
@@ -67,5 +68,6 @@ else
         . $BUILDDIR/setup-environment
     unset EXTRAMELLAYERS
     unset OPTIONALLAYERS
+    unset EXCLUDEDLAYERS
     unset layerdir
 fi


### PR DESCRIPTION
Some layers may be explicitly excluded (notably hotfixes) so
make sure that globbing does not accidentally include them.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
