### PR TITLE
qtwebkit: remove examples packages

### DIFF
--- a/qt5-layer/recipes-qt/qt5/qtwebkit_5.0.2.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtwebkit_5.0.2.bbappend
@@ -1,0 +1,2 @@
+# remove default ${PN}-examples-dbg ${PN}-examples set in qt5.inc, because it conflicts with ${PN} from separate webkit-examples recipe
+PACKAGES = "${PN}-dbg ${PN}-staticdev ${PN}-dev ${PN}-doc ${PN}-locale ${PACKAGE_BEFORE_PN} ${PN} ${PN}-qmlplugins-dbg ${PN}-tools-dbg ${PN}-plugins-dbg ${PN}-qmlplugins ${PN}-tools ${PN}-plugins ${PN}-mkspecs "

--- a/qt5-layer/recipes-qt/qt5/qtwebkit_5.1.0.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtwebkit_5.1.0.bbappend
@@ -1,0 +1,2 @@
+# remove default ${PN}-examples-dbg ${PN}-examples set in qt5.inc, because it conflicts with ${PN} from separate webkit-examples recipe
+PACKAGES = "${PN}-dbg ${PN}-staticdev ${PN}-dev ${PN}-doc ${PN}-locale ${PACKAGE_BEFORE_PN} ${PN} ${PN}-qmlplugins-dbg ${PN}-tools-dbg ${PN}-plugins-dbg ${PN}-qmlplugins ${PN}-tools ${PN}-plugins ${PN}-mkspecs "

--- a/qt5-layer/recipes-qt/qt5/qtwebkit_git.bbappend
+++ b/qt5-layer/recipes-qt/qt5/qtwebkit_git.bbappend
@@ -1,0 +1,2 @@
+# remove default ${PN}-examples-dbg ${PN}-examples set in qt5.inc, because it conflicts with ${PN} from separate webkit-examples recipe
+PACKAGES = "${PN}-dbg ${PN}-staticdev ${PN}-dev ${PN}-doc ${PN}-locale ${PACKAGE_BEFORE_PN} ${PN} ${PN}-qmlplugins-dbg ${PN}-tools-dbg ${PN}-plugins-dbg ${PN}-qmlplugins ${PN}-tools ${PN}-plugins ${PN}-mkspecs "


### PR DESCRIPTION
- fixes:
  NOTE: multiple providers are available for runtime qtwebkit-examples (qtwebkit-examples, qtwebkit)
  NOTE: consider defining a PREFERRED_PROVIDER entry to match qtwebkit-examples
  NOTE: multiple providers are available for runtime qtwebkit-examples-dev (qtwebkit, qtwebkit-examples)
  NOTE: consider defining a PREFERRED_PROVIDER entry to match qtwebkit-examples-dev

Backported from meta-qt5 rev. 284020d9344b6fbd88d9c6d5ff6fbaef430a775b
Author: Martin Jansa Martin.Jansa@gmail.com

JIRA: MEIP-356

Signed-off-by: Mikhail Durnev Mikhail_Durnev@mentor.com
