### PR TITLE
Modification to include dtb files as well in machine images tarball.

### DIFF
--- a/recipes/meta/archive-release.bb
+++ b/recipes/meta/archive-release.bb
@@ -43,7 +43,7 @@ DEPLOY_IMAGES = "\
     ${@' '.join('${RELEASE_IMAGE}-${MACHINE}.%s' % ext for ext in IMAGE_EXTENSIONS.split())} \
     ${RELEASE_IMAGE}-${MACHINE}.license_manifest \
     ${RELEASE_IMAGE}-${MACHINE}.license_manifest.csv \
-    ${KERNEL_IMAGETYPE}*${MACHINE}* \
+    ${KERNEL_IMAGETYPE}* \
 "
 DEPLOY_IMAGES[doc] = "List of files from DEPLOY_DIR_IMAGE which will be archived"
 


### PR DESCRIPTION
- Selection criteria was using machine-name alongwith other patterns
  to pick the file. Since some dtb file names didn't contain exact
  machine-name they were left out. Removed ${MACHINE}\* so that such
  necessary files are also included in the tar.

Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
