### PR TITLE
Qt5: Fixes for building Qt5 on master

### DIFF
--- a/conf/distro/include/mel-versions.conf
+++ b/conf/distro/include/mel-versions.conf
@@ -6,8 +6,5 @@ PREFERRED_VERSION_gettext-native ?= "0.18.3.1"
 PREFERRED_VERSION_binutils        ?= "2.23.2"
 PREFERRED_VERSION_binutils-native ?= "2.23.2"
 
-QT5_VERSION ?= "5.0.2"
 include conf/distro/include/qt5-versions.inc
 
-# No 5.0.2 recipe available
-PREFERRED_VERSION_qtsensors = "5.1.0"

--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -80,7 +80,7 @@ MULTILIBS ?= ""
 require conf/multilib.conf
 
 # Mask out poky's broken external-sourcery-toolchain, which interferes with ours
-BBMASK ?= "/meta/recipes-core/meta/external-sourcery-toolchain\.bb"
+BBMASK ?= "/meta/recipes-core/meta/external-sourcery-toolchain\.bb|/meta-fsl-arm/recipes-graphics/mesa/mesa_9.2.2.bbappend|/meta-fsl-arm/qt5-layer/recipes-qt/qt5/qtbase_5.1.1.bbappend"
 
 # Lower the priority of meta-oe, as we prefer oe-core when recipes are duped
 BBFILE_PRIORITY_openembedded-layer = "1"


### PR DESCRIPTION
Removing the version preference in the conf files.
Adding BBMASK for mesa and qtbase from meta-fsl-arm.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
