### PR TITLE
disable ptest default and add info to local.conf

### DIFF
--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -5,9 +5,10 @@ SDK_VENDOR = "-melsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
 
-# We don't want to force task-core-boot
-DISTRO_EXTRA_RDEPENDS = ""
-DISTRO_EXTRA_RRECOMMENDS = ""
+# Override poky defaults based on our needs. Removed core-boot and ptest.
+POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch wayland"
+POKY_DEFAULT_EXTRA_RDEPENDS = ""
+POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 
 # Paths
 MELDIR ?= "${COREBASE}/.."

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -56,6 +56,11 @@ CORE_IMAGE_EXTRA_INSTALL = "oprofile"
 
 EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-openssh codebench-debug tools-profile"
 
+# Uncomment to enable runtime testing with ptest
+#USER_FEATURES += "ptest"
+#EXTRA_IMAGE_FEATURES += "ptest-pkgs"
+#CORE_IMAGE_EXTRA_INSTALL += "ptest-runner"
+
 # Uncomment this to enable inclusion of gdbserver in the codebench-debug
 # packagegroup / image feature even when GPLv3 is in INCOMPATIBLE_LICENSE, or
 # using a distro which sets it that way (atp).


### PR DESCRIPTION
We are restricting the ptest default distro feature
and adding the ptest related info in local.conf.sample
to use ptest.

Signed-off-by: Shrikant Bobade Shrikant_Bobade@mentor.com
