### PR TITLE
make: disable makeinfo exec due to texinfo 5.x compat issue

### DIFF
--- a/recipes/make/make_3.81.bbappend
+++ b/recipes/make/make_3.81.bbappend
@@ -1,0 +1,3 @@
+# Newer texinfo versions lose compatibility with make.texi, and lacking
+# expertise with texinfo, we'll disable makeinfo use.
+EXTRA_OEMAKE += "'MAKEINFO=true'"


### PR DESCRIPTION
Newer texinfo versions lose compatibility with make.texi, and lacking
expertise with texinfo, we'll disable makeinfo use, otherwise we can get build
failures.

Signed-off-by: Christopher Larson kergoth@gmail.com
