### PR TITLE
Avoid duplicate configs in defconfig:

### DIFF
--- a/classes/kernel-config-fragments.bbclass
+++ b/classes/kernel-config-fragments.bbclass
@@ -15,9 +15,20 @@ append_fragments () {
 
     for fragment in ${WORKDIR}/*.cfg; do
         if [ -e $fragment ] || [ -L $fragment ]; then
-            cat $fragment >> ${KERNEL_DEFCONFIG}
+            while read line; do
+                CONFIG="${line%=*}"
+                DEF_GREP=`awk "/\<${CONFIG}\>/" "${KERNEL_DEFCONFIG}" `
+                RC=$?
+                if [ 0 = $RC ] && [ -n "${DEF_GREP}" ]; then
+                    sed -i "s/${DEF_GREP}/${line}/g" ${KERNEL_DEFCONFIG}
+                else
+                    echo ${line} >> ${KERNEL_DEFCONFIG}
+                fi
+            done < $fragment
         fi
     done
+    CONF_DIR=`dirname ${KERNEL_DEFCONFIG}`
+    rm -f ${CONF_DIR}/sed*
 }
 
 python () {


### PR DESCRIPTION
Currently we are just appending *.cfg fragments to defconfig which may cause
problem sometime. I have added extra check on fragmets in defconfig to verify
if particular config is already there then modify else append it

Signed-off-by: hmsadiq irfan_sadiq@mentor.com
