### PR TITLE
linux-qoriq-sdk-headers: recipe already deleted so removing bbappend

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers.bbappend
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers.bbappend
@@ -1,6 +1,0 @@
-PV = "3.8.13-mel-fsl-qoriq-1"
-SRC_URI_remove = "git://git.freescale.com/ppc/sdk/linux.git"
-SRC_URI =+ "https://github.com/MentorEmbedded/linux-mel/archive/fsl-sdk-v1.4.tar.gz;downloadfilename=linux-mel-fsl-sdk-v1.4.tar.gz"
-SRC_URI[md5sum] = "1452b30c99629d385476105fe5169e4a"
-SRC_URI[sha256sum] = "a60e2d3450bee6f00da0535683f573737e02114531522ecbdeb3bbe777e154e5"
-S = "${WORKDIR}/linux-mel-fsl-sdk-v1.4"


### PR DESCRIPTION
Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
