### PR TITLE
Revert "linux-qoriq-sdk: lock down to a tarball for release"

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
@@ -1,21 +1,8 @@
 # Support config fragments, and configure for lttng
 inherit cml1-config kernel-config-lttng
 
-
-LOCKDOWN_SRCREV = "4b66366af2d77de68f4bd6548d07421e13d3df05"
-PV = "3.8.13-mel-fsl-qoriq-1"
-SRC_URI_remove = "git://git.freescale.com/ppc/sdk/linux.git"
-SRC_URI =+ "https://github.com/MentorEmbedded/linux-mel/archive/fsl-sdk-v1.4.tar.gz;downloadfilename=linux-mel-fsl-sdk-v1.4.tar.gz"
-SRC_URI[md5sum] = "1452b30c99629d385476105fe5169e4a"
-SRC_URI[sha256sum] = "a60e2d3450bee6f00da0535683f573737e02114531522ecbdeb3bbe777e154e5"
-S = "${WORKDIR}/linux-mel-fsl-sdk-v1.4"
-
-
 DEFCONFIG = "${KERNEL_DEFCONFIG}"
 
 python () {
     d.setVar("do_configure", 'kernel_do_configure')
-
-    if d.getVar('SRCREV', True) != d.getVar('LOCKDOWN_SRCREV', True):
-        bb.fatal("linux-qoriq-sdk SRCREV has been updated, the bbappend in meta-mentor needs updating to match.")
 }


### PR DESCRIPTION
We can update the lockdown when the next release comes around. In the 
meantime, we want to track upstream as closely as possible and with as little 
overhead as possible.

JIRA: SB-1903

This reverts commit 4cbad1aa3fa2af0f4c864bb84fe22f3288e3344e.
