### PR TITLE
Fixed PREMIRRORS in the local.conf template

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -103,7 +103,7 @@ USER_FEATURES += "~nfc"
 DL_DIR ?= "${TOPDIR}/downloads"
 
 # Continue to pull downloads from the MEL install
-PREMIRRORS =+ ".*://.*/.* file://${MELDIR}/downloads/ \n "
+PREMIRRORS_prepend = ".*://.*/.* file://${MELDIR}/downloads/ \n "
 
 # BitBake has the capability to accelerate builds based on previously built
 # output. This is done using "shared state" files which can be thought of as


### PR DESCRIPTION
"PREMIRRORS =+" does not work when own-mirrors are specified
in local.conf. "PREMIRRORS_prepend =" should be used instead

JIRA: MEIBPADIT-737

Signed-off-by: Mikhail Durnev Mikhail_Durnev@mentor.com
