### PR TITLE
mel.conf: remove xserver dependency on emgd

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -249,3 +249,16 @@ BBMASK ?= "(/meta-fsl-arm/(recipes-graphics/mesa/mesa_9\.2\.2|qt5-layer/recipes-
 # go upstream.
 SHELL[unexport] = "1"
 BB_TERMINAL_EXPORTS += "SHELL"
+
+# Override preferred version of recipe to be used in case of MinnowBoard
+PREFERRED_VERSION_xserver-xorg_minnow = '1.14.4'
+
+# Ensure default Xorg X server is used for MinnowBoard
+XSERVER_minnow = "xserver-xorg xf86-input-evdev xf86-input-mouse xf86-input-keyboard xf86-video-fbdev"
+
+# Don't include the xorg.conf that makes use of EMGD
+BBMASK .= "|/meta-minnow/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend"
+
+# Explicitly remove the proprietary stuff
+MACHINE_HWCODECS_remove = "va-intel"
+XSERVERCODECS_remove = "emgd-driver-video emgd-gst-plugins-va emgd-gst-plugins-mixvideo gst-va-intel"

--- a/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xorg_1.9.3.bbappend
+++ b/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xorg_1.9.3.bbappend
@@ -1,0 +1,3 @@
+python () { 
+    raise bb.parse.SkipPackage("We do not support EMGD for licensing reasons") 
+}


### PR DESCRIPTION
Since the emgd-driver-bin package requires white-listing the EMGD
license, remove xserver dependency on emgd and use recipes from Poky.

Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
