### PR TITLE
mel.conf: remove xserver dependency on emgd

### DIFF
--- a/conf/distro/include/mel.conf
+++ b/conf/distro/include/mel.conf
@@ -243,3 +243,16 @@ do_package[vardeps] += "${@' '.join('LICENSE_EXCLUSION-%s' % p for p in PACKAGES
 
 # Sanely handle the GPLv3 gdbserver coming from external-sourcery-toolchain
 require conf/distro/include/gdbserver-gplv3.inc
+
+# Override preferred version of recipe to be used in case of MinnowBoard 
+PREFERRED_VERSION_xserver-xorg_minnow = '1.14.0'
+
+# Ensure default Xorg X server is used for MinnowBoard
+XSERVER_minnow = "xserver-xorg xf86-input-evdev xf86-input-mouse xf86-input-keyboard xf86-video-fbdev"
+
+# Don't include the xorg.conf that makes use of EMGD
+BBMASK .= "|/meta-minnow/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend"
+
+# Explicitly remove the proprietary stuff
+MACHINE_HWCODECS_remove = "va-intel"
+XSERVERCODECS_remove = "emgd-driver-video emgd-gst-plugins-va emgd-gst-plugins-mixvideo gst-va-intel"

--- a/intel/recipes-graphics/xorg-xserver/xserver-xorg_1.9.3.bbappend
+++ b/intel/recipes-graphics/xorg-xserver/xserver-xorg_1.9.3.bbappend
@@ -1,0 +1,3 @@
+python () {
+    raise bb.parse.SkipPackage("We do not support EMGD for licensing reasons")
+}


### PR DESCRIPTION
Since the emgd-driver-bin package requires white-listing the EMGD
license, remove xserver dependency on emgd and use recipes from Poky.

Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
