### PR TITLE
deploy-license-manifest: fix deploy_license_manifest failure

### DIFF
--- a/meta-mel/classes/deploy-license-manifest.bbclass
+++ b/meta-mel/classes/deploy-license-manifest.bbclass
@@ -1,5 +1,5 @@
-deploy_license_manifest () {
-    cp $LICENSE_MANIFEST ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest
+license_create_manifest_append () {
+    cp ${LICENSE_MANIFEST} ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest
     rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest
     ln -s ${IMAGE_NAME}.license_manifest ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest
 
@@ -8,5 +8,3 @@ deploy_license_manifest () {
     rm -f ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest.csv
     ln -s ${IMAGE_NAME}.license_manifest.csv ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest.csv
 }
-
-IMAGE_POSTPROCESS_COMMAND += " deploy_license_manifest; "


### PR DESCRIPTION
Rather than assuming we know where this logic needs to go (manually adding it 
to the image postprocess commands), append directly to the license.bbclass 
function which produces the manifest.

Signed-off-by: Christopher Larson kergoth@gmail.com
