### PR TITLE
mel: for systemd, pull in alsa-states, not alsa-state

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -108,6 +108,9 @@ VIRTUAL-RUNTIME_initscripts = ""
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 DISTRO_FEATURES_append = " systemd"
 
+# Avoid pulling in alsa-state for systemd
+VIRTUAL-RUNTIME_alsa-state = "${@'alsa-state' if 'sysvinit' in DISTRO_FEATURES.split() else 'alsa-states'}"
+
 # Add nls if we're supporting.
 DISTRO_FEATURES_append = " ${@['','nls'][bb.data.getVar('USE_NLS', d, 1) == 'yes']}"
 DISTRO_FEATURES_append = " vfat"


### PR DESCRIPTION
Fixes JIRA: SB-2016, which is a do_rootfs failure due to initscripts-functions not being available. See the commits for the details.
