### PR TITLE
Make systemd and sysvinit switchable

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -205,6 +205,12 @@ BB_DISKMON_DIRS = "\
 #    file:///some/local/dir \
 #"
 
+# Uncomment following lines to enable sysvinit
+#VIRTUAL-RUNTIME_init_manager = "sysvinit"
+#VIRTUAL-RUNTIME_initscripts = "initscripts"
+#DISTRO_FEATURES_BACKFILL_CONSIDERED = ""
+#DISTRO_FEATURES_remove = " systemd"
+
 # This may be used to abort the build when using an untested/unverified
 # version of the external toolchain.
 #CSL_VER_REQUIRED = "2012.03"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -103,9 +103,9 @@ UBI_VOLNAME = "rootfs"
 IMAGE_ROOTFS_EXTRA_SPACE = "40960"
 
 # Add systemd
-VIRTUAL-RUNTIME_init_manager = "systemd"
-VIRTUAL-RUNTIME_initscripts = ""
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+VIRTUAL-RUNTIME_init_manager ?= "systemd"
+VIRTUAL-RUNTIME_initscripts ?= ""
+DISTRO_FEATURES_BACKFILL_CONSIDERED ?= "sysvinit"
 DISTRO_FEATURES_append = " systemd"
 
 # Avoid pulling in alsa-state for systemd


### PR DESCRIPTION
Configurations are added to local.conf.sample in comments
to make it switchable from systemd to sysvinit. Systemd is
default startup process.
Signed-off-by: Muzaffar Mahmood muzaffar_mahmood@mentor.com
