### PR TITLE
Fix the pandaboard linux-omap4 build failure(s)

### DIFF
--- a/meta-mentor-staging/meta-ti/recipes-kernel/linux/files/parallel-firmware-install.patch
+++ b/meta-mentor-staging/meta-ti/recipes-kernel/linux/files/parallel-firmware-install.patch
@@ -1,0 +1,13 @@
+Upstream-Status: Pending
+
+--- git.orig/scripts/Makefile.fwinst
++++ git/scripts/Makefile.fwinst
+@@ -27,7 +27,7 @@ endif
+ installed-mod-fw := $(addprefix $(INSTALL_FW_PATH)/,$(mod-fw))
+ 
+ installed-fw := $(addprefix $(INSTALL_FW_PATH)/,$(fw-shipped-all))
+-installed-fw-dirs := $(sort $(dir $(installed-fw))) $(INSTALL_FW_PATH)/.
++installed-fw-dirs := $(sort $(dir $(installed-fw))) $(INSTALL_FW_PATH)/./
+ 
+ # Workaround for make < 3.81, where .SECONDEXPANSION doesn't work.
+ PHONY += $(INSTALL_FW_PATH)/$$(%) install-all-dirs

--- a/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-omap4_3.4.bbappend
+++ b/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-omap4_3.4.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://parallel-firmware-install.patch"


### PR DESCRIPTION
Should resolve our jenkins build failures with pandaboard.
