### PR TITLE
autogen-native: inherit pkgconfig to fix a build failure

### DIFF
--- a/meta-mentor-staging/recipes-devtools/autogen/autogen-native_5.18.2.bbappend
+++ b/meta-mentor-staging/recipes-devtools/autogen/autogen-native_5.18.2.bbappend
@@ -1,0 +1,1 @@
+inherit pkgconfig


### PR DESCRIPTION
Signed-off-by: Christopher Larson kergoth@gmail.com
