### PR TITLE
mel.conf: Fix the qtbase bbappend mask.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -251,7 +251,7 @@ require conf/blocks/speech-recognition.conf
 
 # Temperorily mask mesa and qtbase from meta-fsl-arm until
 # gpu-viv gets tested and work properly.
-BBMASK ?= "(/meta-fsl-arm/(recipes-graphics/mesa/mesa_|qt5-layer/recipes-qt/qt5/qtbase_)\.bbappend|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
+BBMASK ?= "(/meta-fsl-arm/(recipes-graphics/mesa/mesa_|qt5-layer/recipes-qt/qt5/qtbase_%)\.bbappend|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
 
 # The user's shell shouldn't be allowed to affect the build (and it can break
 # the flock command, if the user's shell isn't POSIX compliant). This should


### PR DESCRIPTION
The bbappend file name of qtbase in meta-fsl-arm is changed.
Hence this patch fixes the issue of qtbase compilation issue
of -lGAL.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com

```
conf/0001-Qt5-Fixes-for-building-Qt5-on-master.patch
```
