### PR TITLE
connman: Remove PACKAGECONFIG bits

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/connman/connman_1.21.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_1.21.bbappend
@@ -3,9 +3,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://fix-stoping-interfaces-at-start.patch \
             file://connman.service \
             "
-
-PACKAGECONFIG_append_pn-connman = " bluetooth wifi 3g"
-
 do_install_append() {
     cp -f ${WORKDIR}/connman.service ${D}${base_libdir}/systemd/system/
 }


### PR DESCRIPTION
- It is not required for MEL

Signed-off-by: Muzaffar Mahmood muzaffar_mahmood@mentor.com
