### PR TITLE
libxkbcommon: Add missing dependency on xkeyboard-config

### DIFF
--- a/meta-mentor-staging/recipes-graphics/xorg-lib/libxkbcommon_0.4.0.bbappend
+++ b/meta-mentor-staging/recipes-graphics/xorg-lib/libxkbcommon_0.4.0.bbappend
@@ -1,0 +1,3 @@
+DEPENDS += "${@base_contains('DISTRO_FEATURES', 'x11', 'xkeyboard-config', '', d)}"
+
+EXTRA_OECONF += "${@base_contains('DISTRO_FEATURES', 'x11', '', '--disable-x11', d)}"


### PR DESCRIPTION
libxkbcommon depends on xkeyboard-config

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
