### PR TITLE
alsa-state: remove the init.d for non-sysvinit distros

### DIFF
--- a/meta-mel/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/meta-mel/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,10 @@
+# This recipe doesn't inherit systemd, so that doesn't remove the startup
+# script, which makes sense, but if this ships its init script
+# unconditionally, it ends up depending on initscripts-functions, which
+# doesn't exist in the case where sysvinit isn't in DISTRO_FEATURES.
+
+do_install_append () {
+    if ${@'true' if 'sysvinit' not in DISTRO_FEATURES.split() else 'false'}; then
+        rm -rf "${D}${sysconfdir}/init.d"
+    fi
+}


### PR DESCRIPTION
- For non-sysvinit distros, even when sysvinit compatibility is enabled in
  sysvinit, we still don't want this init.d script, as alsa-utils-alsactl
  provides its own systemd services to handle saving/loading alsa state. The
  ideal fix for this is to move the startup script from alsa-state into
  alsa-utils-alsactl where the systemd services live, so systemd.bbclass can
  automatically kill the sysvinit scripts when appropriate.
- Including it will lead to an initscript-functions dependency at this time,
  but it isn't produced for non-sysvinit compatible distros, unless
  initscripts gets built somehow. I think ideally we need to alter update-rc.d
  to not just add an rdepends on initscripts-functions, but also a DEPENDS on
  initscripts when sysvinit is in DISTRO_FEATURES, to ensure it's always built
  so the runtime dependency can be satisfied.

JIRA: SB-2052

Signed-off-by: Christopher Larson kergoth@gmail.com
