### PR TITLE
linux-qoriq-sdk: Applied patch to enable CGROUPS

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/files/p4080-config.patch
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/files/p4080-config.patch
@@ -1,0 +1,9 @@
+diff --git a/arch/powerpc/configs/corenet32_smp_defconfig b/arch/powerpc/configs/corenet32_smp_defconfig
+index 255914d..070ca03 100644
+--- a/arch/powerpc/configs/corenet32_smp_defconfig
++++ b/arch/powerpc/configs/corenet32_smp_defconfig
+@@ -189,3 +189,4 @@ CONFIG_CRYPTO_SHA256=y
+ CONFIG_CRYPTO_SHA512=y
+ # CONFIG_CRYPTO_ANSI_CPRNG is not set
+ CONFIG_CRYPTO_DEV_FSL_CAAM=y
++CONFIG_CGROUPS=y

--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
@@ -3,6 +3,10 @@ inherit cml1-config kernel-config-lttng
 
 DEFCONFIG = "${KERNEL_DEFCONFIG}"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files"
+
+SRC_URI_append_p4080ds += "file://p4080-config.patch"
+
 python () {
     d.setVar("do_configure", 'kernel_do_configure')
 }


### PR DESCRIPTION
Systemd requires CGROUPS.

Signed-off-by: Muzaffar Mahmood muzaffar_mahmood@mentor.com
