### PR TITLE
mozjs: apply powerpc build fix patch

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-extended/mozjs/mozjs/powerpc_va_list.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/mozjs/mozjs/powerpc_va_list.patch
@@ -1,0 +1,31 @@
+Upstream-Status: Inappropriate [configuration]
+
+diff -ur src/jsapi.cpp src/jsapi.cpp
+--- src/jsapi.cpp	2012-02-15 23:40:35.000000000 -0700
++++ src/jsapi.cpp	2012-03-01 17:01:41.716770994 -0700
+@@ -108,6 +108,10 @@
+ #include "jsxml.h"
+ #endif
+ 
++#if defined(__powerpc__)
++#define HAVE_VA_LIST_AS_ARRAY
++#endif
++
+ using namespace js;
+ using namespace js::gc;
+ using namespace js::types;
+
+diff -ur src/jsprf.cpp src/jsprf.cpp
+--- src/jsprf.cpp	2012-02-15 23:40:35.000000000 -0700
++++ src/jsprf.cpp	2012-03-01 17:01:41.348769842 -0700
+@@ -57,6 +57,10 @@
+ ** Note: on some platforms va_list is defined as an array,
+ ** and requires array notation.
+ */
++#if defined(__powerpc__)
++#define HAVE_VA_LIST_AS_ARRAY
++#endif
++
+ #ifdef HAVE_VA_COPY
+ #define VARARGS_ASSIGN(foo, bar)        VA_COPY(foo,bar)
+ #elif defined(HAVE_VA_LIST_AS_ARRAY)

--- a/meta-mentor-staging/openembedded-layer/recipes-extended/mozjs/mozjs_17.0.0.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/mozjs/mozjs_17.0.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://powerpc_va_list.patch"

--- a/meta-mentor-staging/recipes-support/postgresql/ecpg-parallel-make-fix.patch
+++ b/meta-mentor-staging/recipes-support/postgresql/ecpg-parallel-make-fix.patch
@@ -1,4 +1,4 @@
-Upstream-status: backport
+Upstream-Status: backport
 
 From 602070f9cce790debd8d1469254e7726ab499ae7 Mon Sep 17 00:00:00 2001
 From: Peter Eisentraut <peter_e@gmx.net>


### PR DESCRIPTION
Patch is from the firefox recipe in meta-browser, to fix va_list issues with 
the powerpc build. This could use a bit further investigation, as the 
configure macro is supposed to sort out this define for us.

JIRA: SB-2120

Signed-off-by: Christopher Larson kergoth@gmail.com
