### PR TITLE
e2fsprogs: Fix gettext issue

### DIFF
--- a/meta-mentor-staging/recipes-devtools/e2fsprogs/e2fsprogs_1.42.9.bbappend
+++ b/meta-mentor-staging/recipes-devtools/e2fsprogs/e2fsprogs_1.42.9.bbappend
@@ -1,0 +1,3 @@
+do_configure_append() {
+    sed -i '/@$(CHECK_MACRO_VERSION)/d' ${WORKDIR}/build/po/Makefile
+}


### PR DESCRIPTION
Ignoring the macro version check in the Makefile. So that
it doesn't break compilation for MEL.

JIRA: SB-2251

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
