### PR TITLE
gettext: kill target m4 macros from sysroot

### DIFF
--- a/meta-mentor-staging/recipes-core/gettext/gettext_0.16.1.bbappend
+++ b/meta-mentor-staging/recipes-core/gettext/gettext_0.16.1.bbappend
@@ -1,0 +1,10 @@
+# Anyone inheriting gettext will have both gettext-native and gettext
+# available, and we don't want to use older macros from the target gettext in
+# a non-gplv3 build, so kill them and let dependent recipes rely on
+# gettext-native.
+
+SYSROOT_PREPROCESS_FUNCS += "remove_sysroot_m4_macros"
+
+remove_sysroot_m4_macros () {
+    rm -r "${SYSROOT_DESTDIR}${datadir}/aclocal"
+}


### PR DESCRIPTION
Ever since the change to how aclocal files are copied (based on dependencies), 
target m4 macros seem to more reliably be used in preference to native (which 
they should), but in a non-gplv3 build, gettext is 0.16 while gettext-native
is 0.18, causing a 0.16 po.m4 to be used with our 0.18 po/Makefile.in.in
files, causing at least some failed builds, including e2fsprogs.

Anyone inheriting gettext will have both gettext-native and gettext available, 
and we don't want to use older macros from the target gettext in a non-gplv3 
build, so kill them and let dependent recipes rely on gettext-native.

Signed-off-by: Christopher Larson kergoth@gmail.com
