### PR TITLE
connman: Install service script to systemd_unitdir.

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/connman/connman_1.21.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_1.21.bbappend
@@ -4,6 +4,6 @@ SRC_URI += "file://fix-stoping-interfaces-at-start.patch \
             file://connman.service \
             "
 do_install_append() {
-    cp -f ${WORKDIR}/connman.service ${D}${base_libdir}/systemd/system/
+    cp -f ${WORKDIR}/connman.service ${D}${systemd_unitdir}/system/
 }
 


### PR DESCRIPTION
This will allow better functioning with multilib builds.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
