### PR TITLE
mel: add STAMPCLEAN to BB_HASHBASE_WHITELIST

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -13,8 +13,11 @@ POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 # Paths
 MELDIR ?= "${COREBASE}/.."
 
-# Ensure the path to the mel install isn't hardcoded into any signatures
+# Ensure the path to the mel install isn't hardcoded into any checksums
 BB_HASHBASE_WHITELIST_append = " MELDIR"
+
+# Ensure STAMPS_DIR doesn't leak into the do_configure checksum
+BB_HASHBASE_WHITELIST_append = " STAMPCLEAN"
 
 # Application Development Environment
 ADE_PROVIDER = "Mentor Graphics Corporation"


### PR DESCRIPTION
This keeps STAMPS_DIR from leaking into the do_configure checksum, which 
disrupts the ability to use bitbake -S or bitbake-whatchanged to examine 
checksum differences, at a minimum. This is going upstream, courtesy Robert 
Yang, but let's work around it in the meantime. Drop when we update our 
upstream layers again.

JIRA: SB-2044

Signed-off-by: Christopher Larson kergoth@gmail.com
