### PR TITLE
node-startup-controller, node-state-manager: fixed configure.ac

### DIFF
--- a/meta-mentor-staging/ivi/recipes-extended/node-startup-controller/node-startup-controller/use-libsystemd.patch
+++ b/meta-mentor-staging/ivi/recipes-extended/node-startup-controller/node-startup-controller/use-libsystemd.patch
@@ -1,0 +1,14 @@
+diff -Naur old/configure.ac new/configure.ac
+--- old/configure.ac	2014-03-25 01:53:26.000000000 -0500
++++ new/configure.ac	2014-03-25 01:55:24.699469386 -0500
+@@ -86,7 +86,9 @@
+ PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.30.0])
+ PKG_CHECK_MODULES([GIO], [gio-2.0 >= 2.30.0])
+ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0 >= 2.30.0])
+-PKG_CHECK_MODULES([SYSTEMD_DAEMON], [libsystemd-daemon >= 183])
++PKG_CHECK_MODULES([SYSTEMD_DAEMON], [libsystemd-daemon >= 183],, [
++    PKG_CHECK_MODULES([SYSTEMD_DAEMON], [libsystemd >= 209])
++])
+ PKG_CHECK_MODULES([DLT], [automotive-dlt >= 2.2.0])
+ 
+ dnl *********************************************

--- a/meta-mentor-staging/ivi/recipes-extended/node-startup-controller/node-startup-controller_1.0.2.bbappend
+++ b/meta-mentor-staging/ivi/recipes-extended/node-startup-controller/node-startup-controller_1.0.2.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://use-libsystemd.patch"

--- a/meta-mentor-staging/ivi/recipes-extended/node-state-manager/node-state-manager/use-libsystemd.patch
+++ b/meta-mentor-staging/ivi/recipes-extended/node-state-manager/node-state-manager/use-libsystemd.patch
@@ -1,0 +1,14 @@
+diff -Naur old/configure.ac new/configure.ac
+--- old/configure.ac	2014-03-24 19:12:37.000000000 -0500
++++ new/configure.ac	2014-03-25 01:49:16.323473836 -0500
+@@ -44,7 +44,9 @@
+ PKG_CHECK_MODULES([GLIB],     [glib-2.0                   >= 2.30.0])
+ PKG_CHECK_MODULES([GOBJECT],  [gobject-2.0                >= 2.30.0])
+ PKG_CHECK_MODULES([DBUS],     [dbus-1                     >= 1.4.10])
+-PKG_CHECK_MODULES([SYSTEMD],  [libsystemd-daemon          >= 37    ])
++PKG_CHECK_MODULES([SYSTEMD],  [libsystemd-daemon          >= 37    ],, [
++    PKG_CHECK_MODULES([SYSTEMD],  [libsystemd                 >= 209   ])
++])
+ PKG_CHECK_MODULES([PCL],      [persistence_client_library >= 0.6.0 ])
+ 
+ # Derive path for storing systemd service files (e. g. /lib/systemd/system)

--- a/meta-mentor-staging/ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bbappend
+++ b/meta-mentor-staging/ivi/recipes-extended/node-state-manager/node-state-manager_2.0.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "file://use-libsystemd.patch"


### PR DESCRIPTION
In systemd 209 libsystemd-journal.so, libsystemd-id128.so,
libsystemd-login and libsystemd-daemon were merged into
a single libsystemd.so. Dependencies on the old libs must
be replaced with dependency on libsystemd.so

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
