### PR TITLE
glib-2.0: Do not use readlink when cross compiling.

### DIFF
--- a/meta-mentor-staging/recipes-core/glib-2.0/glib-2.0/0001-configure.ac-Do-not-use-readlink-when-cross-compilin.patch
+++ b/meta-mentor-staging/recipes-core/glib-2.0/glib-2.0/0001-configure.ac-Do-not-use-readlink-when-cross-compilin.patch
@@ -1,0 +1,32 @@
+commit 9b38d507ec37b3d7d4df6095fa7ed16b47d399f7
+Author: Drew Moseley <drew_moseley@mentor.com>
+Date:   Sat Mar 29 21:10:43 2014 -0400
+
+    configure.ac: Do not use readlink when cross compiling.
+
+    Do not use readlink to set ABS_GLIB_RUNTIME_LIBDIR when cross
+    compiling.  Doing so causes host paths to potentially pollute
+    the target.
+
+    Note that in this case the path is not converted to absolute if
+    it contains any ".." references so it's not completely correct.
+
+    Upstream-Status: Pending
+
+    Signed-off-by: Drew Moseley <drew_moseley@mentor.com>
+
+diff -rub glib-2.38.2.orig/configure.ac glib-2.38.2/configure.ac
+--- glib-2.38.2.orig/configure.ac	2014-04-03 20:17:13.035567143 -0400
++++ glib-2.38.2/configure.ac	2014-04-03 20:19:07.071566057 -0400
+@@ -275,7 +275,11 @@
+            [],
+ 	   [with_runtime_libdir=""])
+ GLIB_RUNTIME_LIBDIR="$with_runtime_libdir"
++AS_IF([ test $cross_compiling = yes ], [
++ABS_GLIB_RUNTIME_LIBDIR="$libdir/$with_runtime_libdir"
++], [
+ ABS_GLIB_RUNTIME_LIBDIR="`readlink -m $libdir/$with_runtime_libdir`"
++])
+ AC_SUBST(GLIB_RUNTIME_LIBDIR)
+ AC_SUBST(ABS_GLIB_RUNTIME_LIBDIR)
+ AM_CONDITIONAL(HAVE_GLIB_RUNTIME_LIBDIR, [test "x$with_runtime_libdir" != "x"])

--- a/meta-mentor-staging/recipes-core/glib-2.0/glib-2.0_2.38.2.bbappend
+++ b/meta-mentor-staging/recipes-core/glib-2.0/glib-2.0_2.38.2.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += " \
+           file://0001-configure.ac-Do-not-use-readlink-when-cross-compilin.patch \
+          "


### PR DESCRIPTION
When configuring glib, the configure.ac script uses readlink
to convert a relative path to an absolute path.  In my particular
build system, /usr/lib64 is a symlink to /usr/lib so the files
get packaged in the wrong location resulting in the following:

```
WARNING: QA Issue: glib-2.0-dbg: found library in wrong location: /usr/share/gdb/auto-load/usr/lib/libgobject-2.0.so.0.3800.2-gdb.py
glib-2.0-dbg: found library in wrong location: /usr/share/gdb/auto-load/usr/lib/libglib-2.0.so.0.3800.2-gdb.py
```

This patches configure.ac to simply use the path unmodified.
In the default configuration it is not a relative path so
there is no issue with it needing to be converted.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
