### PR TITLE
trace-cmd: Update to version 2.3.2

### DIFF
--- a/meta-mentor-staging/recipes-kernel/trace-cmd/trace-cmd_2.3.2.bb
+++ b/meta-mentor-staging/recipes-kernel/trace-cmd/trace-cmd_2.3.2.bb
@@ -1,0 +1,23 @@
+SUMMARY = "User interface to Ftrace"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe \
+"
+SRCREV = "79e08f8edb38c4c5098486caaa87ca90ba00f547"
+
+PV = "2.3.2+git${SRCPV}"
+
+inherit pkgconfig pythonnative
+
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rostedt/trace-cmd.git;protocol=git;branch=trace-cmd-stable-v2.3 \
+"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "'prefix=${prefix}' NO_PYTHON=1"
+
+FILES_${PN}-dbg += "${datadir}/trace-cmd/plugins/.debug/"
+
+do_install() {
+	oe_runmake prefix="${prefix}" DESTDIR="${D}" install
+}
+
+


### PR DESCRIPTION
Current trace-cmd version 1.2 in poky was throwing
"recorder error in splice input" error while recording
a trace on kernel version 3.10. Updated the trace-cmd
version to latest 2.3.2 to resolve this error.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
