### PR TITLE
mel.conf: Removing BBMASK for qtbase

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -230,12 +230,10 @@ require conf/blocks/bluetooth.conf
 require conf/blocks/speech-synthesis.conf
 require conf/blocks/speech-recognition.conf
 
-# Temperorily mask mesa and qtbase from meta-fsl-arm until
-# gpu-viv gets tested and work properly.
 # Mask out meta-ivi's connman append, as it makes it impossible to add
 # bluetooth to its PACKAGECONFIG, so we need to undo the damage.
 # Mask out meta-ivi's libpcap for the same reason.
-BBMASK ?= "(/meta-ivi/recipes-connectivity/(connman|ofono|libpcap)/|/meta-fsl-arm/(qt5-layer/recipes-qt/qt5/qtbase_%)\.bbappend|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
+BBMASK ?= "(/meta-ivi/recipes-connectivity/(connman|ofono|libpcap)/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
 
 # The user's shell shouldn't be allowed to affect the build (and it can break
 # the flock command, if the user's shell isn't POSIX compliant). This should


### PR DESCRIPTION
Removing BBMASK for qtbase as we have got qtbase working
with gpu-viv changes.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
