### PR TITLE
python-native: disable user site support

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python-native_2.7.3.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python-native_2.7.3.bbappend
@@ -1,0 +1,5 @@
+# We don't want modules in ~/.local being used in preference to those
+# installed in the native sysroot, so disable user site support.
+do_install_append () {
+    sed -i -e 's,^\(ENABLE_USER_SITE = \).*,\1False,' ${D}${libdir}/python${PYTHON_MAJMIN}/site.py
+}


### PR DESCRIPTION
The user site-packages gets inserted into sys.path ahead of the system site 
directories, so a site package installed there will be used in preference to 
what's in our sysroot, causing less deterministic builds, and potential build 
breakage, depending on what the user has installed there. Disable it for our 
native python, so they don't affect our builds.

JIRA: SB-2579

Related to SB-2073.

Signed-off-by: Christopher Larson kergoth@gmail.com
