### PR TITLE
trace-cmd: fix target paths

### DIFF
--- a/meta-mentor-staging/recipes-kernel/trace-cmd/trace-cmd_2.3.2.bb
+++ b/meta-mentor-staging/recipes-kernel/trace-cmd/trace-cmd_2.3.2.bb
@@ -6,18 +6,27 @@ SRCREV = "79e08f8edb38c4c5098486caaa87ca90ba00f547"
 
 PV = "2.3.2+git${SRCPV}"
 
-inherit pkgconfig pythonnative
-
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rostedt/trace-cmd.git;protocol=git;branch=trace-cmd-stable-v2.3 \
 "
 S = "${WORKDIR}/git"
 
-EXTRA_OEMAKE = "'prefix=${prefix}' NO_PYTHON=1"
+inherit pkgconfig pythonnative
 
-FILES_${PN}-dbg += "${datadir}/trace-cmd/plugins/.debug/"
+EXTRA_OEMAKE = "\
+    'prefix=${prefix}' \
+    'bindir=${bindir}' \
+    'man_dir=${mandir}' \
+    'html_install=${datadir}/kernelshark/html' \
+    'img_install=${datadir}/kernelshark/html/images' \
+    \
+    'bindir_relative=${@oe.path.relative(prefix, bindir)}' \
+    'libdir=${@oe.path.relative(prefix, libdir)}' \
+    \
+    NO_PYTHON=1 \
+"
 
 do_install() {
-	oe_runmake prefix="${prefix}" DESTDIR="${D}" install
+	oe_runmake DESTDIR="${D}" install
 }
 
-
+FILES_${PN}-dbg += "${libdir}/trace-cmd/plugins/.debug"


### PR DESCRIPTION
It was incorrectly picking up our absolute 'libdir', but in the trace-cmd 
makefile, 'libdir' is just the relative path from prefix, 'lib'. As a result, 
we ended up with plugins in /usr/usr/lib/trace-cmd/plugins. Pass that in as a
correct relative path, and while we're at it, ensure it obeys our paths for 
mandir, bindir, etc.

JIRA: SB-2580

Signed-off-by: Christopher Larson kergoth@gmail.com
