### PR TITLE
gdk-pixbuf-native: add setscene dep on jpeg-native

### DIFF
--- a/meta-mentor-staging/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.30.3.bbappend
+++ b/meta-mentor-staging/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.30.3.bbappend
@@ -1,0 +1,1 @@
+PIXBUFCACHE_SYSROOT_DEPS_class-native += "jpeg-native:do_populate_sysroot_setscene"


### PR DESCRIPTION
Without this, we can get setscene postinst failure due to libjpeg being 
unavailable.

Signed-off-by: Christopher Larson kergoth@gmail.com
