### PR TITLE
pulseaudio: fix work around for meta-ivi bluez5

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -230,10 +230,10 @@ require conf/blocks/bluetooth.conf
 require conf/blocks/speech-synthesis.conf
 require conf/blocks/speech-recognition.conf
 
-# Mask out meta-ivi's connman append, as it makes it impossible to add
-# bluetooth to its PACKAGECONFIG, so we need to undo the damage.
-# Mask out meta-ivi's libpcap for the same reason.
-BBMASK ?= "(/meta-ivi/recipes-connectivity/(connman|ofono|libpcap)/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
+# Mask out meta-ivi's connman, libpcap, and pulseaudio appends, as it makes it
+# impossible to add bluetooth to its PACKAGECONFIG, so we need to undo the
+# damage.
+BBMASK ?= "(/meta-ivi/(recipes-multimedia/pulseaudio|recipes-connectivity/(connman|ofono|libpcap))/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
 
 # The user's shell shouldn't be allowed to affect the build (and it can break
 # the flock command, if the user's shell isn't POSIX compliant). This should

--- a/meta-mel/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
+++ b/meta-mel/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
@@ -1,5 +1,3 @@
-PACKAGECONFIG_remove = "bluez5"
-
 do_install_append_mel () {
         sed -i 's/; resample-method.*/resample-method \= speex-fixed-3/' ${D}/etc/pulse/daemon.conf
 }

--- a/meta-mentor-staging/ivi/recipes-multimedia/pulseaudio/pulseaudio/pulseaudio.service
+++ b/meta-mentor-staging/ivi/recipes-multimedia/pulseaudio/pulseaudio/pulseaudio.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=pulseaudio server
+Requires=dbus.service
+After=dbus.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/pulseaudio --log-level=0
+Restart=always
+RestartSec=5
+TimeoutSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mentor-staging/ivi/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
+++ b/meta-mentor-staging/ivi/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
@@ -1,0 +1,38 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " file://pulseaudio.service"
+
+PR = "r1"
+
+inherit systemd
+
+SYSTEMD_PACKAGES = "${PN}-server"
+SYSTEMD_SERVICE = "pulseaudio.service"
+
+PACKAGECONFIG := "${@PACKAGECONFIG.replace('bluez4', 'bluez5')}"
+
+RDEPENDS_pulseaudio-module-systemd-login =+ "systemd"
+RDEPENDS_pulseaudio-server += "\
+        ${@base_contains('DISTRO_FEATURES', 'x11', 'pulseaudio-module-systemd-login', '', d)}"
+
+python __anonymous () {
+    '''
+    If DISTRO_FEATURES include systemd use pulseaudio-module-systemd-login as a
+    replacer for pulseaudio-module-console-kit.
+    '''
+    distro_features = d.getVar('DISTRO_FEATURES', True).split()
+    if 'systemd' in distro_features:
+        new_rdeps = []
+        old_rdeps = d.getVar('RDEPENDS_pulseaudio-server', True).split()
+        for rdep in old_rdeps:
+            if rdep != 'pulseaudio-module-console-kit':
+                new_rdeps.append(rdep)
+        d.setVar('RDEPENDS_pulseaudio-server', ' '.join(new_rdeps))
+}
+
+do_install_append() {
+    if ${@base_contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system/
+        install -m 0644 ${WORKDIR}/pulseaudio.service ${D}${systemd_unitdir}/system
+    fi
+}


### PR DESCRIPTION
Unfortunately, the meta-ivi append does more than just adjust packageconfig 
for bluez5, so we needed to copy their append bits into meta-mentor-staging 
and alter them to not use _remove, so we're able to undo their change, and 
mask out the original upstream append.

Signed-off-by: Christopher Larson kergoth@gmail.com
