### PR TITLE
curl: fix the nativesdk ssl enable

### DIFF
--- a/meta-mel/recipes-support/curl/curl_7.35.0.bbappend
+++ b/meta-mel/recipes-support/curl/curl_7.35.0.bbappend
@@ -1,2 +1,2 @@
-DEPENDS_class-nativesdk_append_mel = " nativesdk-openssl"
-CURLGNUTLS_class-nativesdk_append_mel = " --without-gnutls --with-ssl"
+DEPENDS_append_class-nativesdk_mel = " nativesdk-openssl"
+CURLGNUTLS_class-nativesdk_mel = " --without-gnutls --with-ssl"


### PR DESCRIPTION
The particular interaction of the double override wasn't working for us (we 
need these vars adjusted for class-nativesdk+mel, not just one or the other), 
so reworked to use a full double override operation, rather than a
conditional append to an override var.

Signed-off-by: Christopher Larson kergoth@gmail.com
