### PR TITLE
mel: unexport some TARGET_ variables

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -5,7 +5,7 @@ SDK_VENDOR = "-melsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
 
-# Override poky defaults based on our needs. Removed core-boot and ptest.
+# Override poky defaults based on our needs. Removed ptest.
 POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch wayland"
 POKY_DEFAULT_EXTRA_RDEPENDS = ""
 POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
@@ -66,6 +66,9 @@ INHERIT += "isolated-sstate-dir"
 
 # Do an up front type check to sanity check user configuration
 INHERIT += "typecheck"
+
+# Import oe.terminal to allow a type check of OE_TERMINAL
+OE_IMPORTS += "oe.terminal"
 
 # Restore any available saved headrevs
 DUMP_HEADREVS_DB ?= '${MELDIR}/${MACHINE}/saved_persist_data.db'
@@ -129,11 +132,8 @@ DISTRO_FEATURES_append = " vfat"
 PACKAGECONFIG_append_pn-busybox = " fbset"
 
 # Sane default locales for images
-GLIBC_GENERATE_LOCALES ?= "en_US"
+GLIBC_GENERATE_LOCALES ?= "en_US en_US.UTF-8"
 IMAGE_LINGUAS ?= "en-us"
-
-# Targets for qemu
-QEMU_TARGETS += "mips64 mips64el sh4"
 
 # We prefer busybox rather than tinylogin
 VIRTUAL-RUNTIME_login_manager = "busybox"
@@ -152,7 +152,6 @@ PACKAGECONFIG_remove_pn-nativesdk-opkg-utils = "update-alternatives"
 
 # We want information about image contents
 INHERIT += "buildhistory"
-BUILDHISTORY_DIR ?= "${TOPDIR}/buildhistory"
 BUILDHISTORY_COMMIT ?= "1"
 
 # Ensure our external toolchain is sane
@@ -171,9 +170,6 @@ DL_LICENSE_INCLUDE ?= "*"
 INHERIT += "archive-release-downloads extra_layerinfo"
 RECIPE_LAYER_BASENAME = "${@os.path.basename(get_layer_rootdir(RECIPE_LAYERPATH, d))}"
 ARCHIVE_RELEASE_DL_DIR = "${ARCHIVE_RELEASE_DL_TOPDIR}/${RECIPE_LAYER_BASENAME}"
-
-# Ensure we have what we need for the below type checks
-OE_IMPORTS += "oe.terminal"
 
 # Default to no automatic spawned terminals -- expicit is better than implicit
 PATCHRESOLVE = "noop"
@@ -195,11 +191,6 @@ ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la \
 # Disable reliance upon upstream URIs, as we want our customers to be able to
 # build without network connectivity
 CONNECTIVITY_CHECK_URIS = ""
-
-# Work around do_populate_lic(sstate_create_package) / do_rootfs race
-# Without this, bitbake defaults the dirs to ${B}, which do_rootfs removes due
-# to its cleandirs for recipes where ${B} == ${S}.
-sstate_create_package[dirs] = "${TOPDIR}"
 
 # Default to the Xorg X server
 XSERVER ?= "\

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -235,8 +235,8 @@ setup_builddir () {
         echo "created for you with some default values."
 
         (
-            JOBS_FACTOR="2"
-            THREADS_FACTOR="3 / 2"
+            JOBS_FACTOR="3 / 2"
+            THREADS_FACTOR="1"
             NCPU=`grep -c processor /proc/cpuinfo`
             JOBS=`expr $NCPU \* $JOBS_FACTOR`
             THREADS=`expr $NCPU \* $THREADS_FACTOR`


### PR DESCRIPTION
This prevents TARGET_{C,CPP,CXX,LD}FLAGS from leaking into native checksums, 
causing native sstates to not be shared between machines where those flags 
differ. Discovered by Mark Crowe, see the oe-core list for details.

Signed-off-by: Christopher Larson kergoth@gmail.com
