### PR TITLE
os-release: New line required for each key,value in file

### DIFF
--- a/meta-mentor-staging/recipes-core/os-release/os-release.bb
+++ b/meta-mentor-staging/recipes-core/os-release/os-release.bb
@@ -26,7 +26,7 @@ python do_compile () {
         for field in d.getVar('OS_RELEASE_FIELDS', True).split():
             value = d.getVar(field, True)
             if value:
-                f.write('{0}={1}'.format(field, value))
+                f.write('{0}={1}\n'.format(field, value))
 }
 do_compile[vardeps] += "${OS_RELEASE_FIELDS}"
 


### PR DESCRIPTION
New line's is required in os-release file. Every key, value
pair should be sperated by a new line.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
