### PR TITLE
libsdl: Removed dependency on libglu

### DIFF
--- a/meta-mel/recipes-graphics/libsdl/libsdl_1.2.15.bbappend
+++ b/meta-mel/recipes-graphics/libsdl/libsdl_1.2.15.bbappend
@@ -1,4 +1,5 @@
 PR = "r1"
 DEPENDS := "${@oe_filter_out('virtual/libgl', '${DEPENDS}', d)}"
+DEPENDS := "${@oe_filter_out('libglu', '${DEPENDS}', d)}"
 
 EXTRA_OECONF += "--disable-video-opengl"


### PR DESCRIPTION
libglu requires libGL. If we do not support virtual/libgl
then we have to remove libglu as well.
x86-pcsim builds fail if dependency on libglu is not removed.

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
