### PR TITLE
mel.conf: remove wayland from distro features

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -6,7 +6,7 @@ SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
 
 # Override poky defaults based on our needs. Removed ptest.
-POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch wayland"
+POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch"
 POKY_DEFAULT_EXTRA_RDEPENDS = ""
 POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 


### PR DESCRIPTION
We do not want wayland to be included in distro features of mel by default. It
is needed in atp, where it is already being added in atp.conf

Signed-off-by: Fahad Usman fahad_usman@mentor.com
