### PR TITLE
[RFC] Remove profile tools from default config

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -23,7 +23,7 @@ MACHINE ??= "qemux86"
 # The CORE_IMAGE_EXTRA_INSTALL variable allows extra individual packages to be
 # added to any of the "core" images (e.g. core-image-base,
 # core-image-minimal).
-CORE_IMAGE_EXTRA_INSTALL = "oprofile"
+#CORE_IMAGE_EXTRA_INSTALL = ""
 
 # The EXTRA_IMAGE_FEATURES variable allows groups of packages to be added to
 # the generated images. Some of these options are added to certain image types
@@ -54,7 +54,7 @@ CORE_IMAGE_EXTRA_INSTALL = "oprofile"
 # meta/classes/image.bbclass and meta/classes/core-image.bbclass for more
 # details.
 
-EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-openssh codebench-debug tools-profile"
+EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-openssh codebench-debug"
 
 # Uncomment to enable runtime testing with ptest
 #USER_FEATURES += "ptest"


### PR DESCRIPTION
I suspect this will break existing MEL configs that rely on profiling to be enabled by default but I wonder if there may be a better way to enable these options for configs that need it.  I'm trying to build MEL Lite which does _not_ officially support profiling but there is no easy way for me to override this file.

It looks like the env variable TEMPLATECONF may have been intended for that but there's no way to enforce that the user enter it.  And the current logic in setup-melbuilddir clears that variable before processing anyway.
