### PR TITLE
mel: lock down weston/wayland versions

### DIFF
--- a/meta-mel/conf/distro/include/mel-versions.conf
+++ b/meta-mel/conf/distro/include/mel-versions.conf
@@ -3,3 +3,7 @@ PREFERRED_VERSION_udev_am37x-evm = "164"
 PREFERRED_VERSION_udev_dm37x-evm = "164"
 
 include conf/distro/include/qt5-versions.inc
+
+# Don't use glsdk 1.3.0 recipes
+PREFERRED_VERSION_weston ?= "1.4.0"
+PREFERRED_VERSION_wayland ?= "1.4.0"


### PR DESCRIPTION
Don't use the old 1.3.0 glsdk versions. We can drop this if/when the old 
recipes are dropped from the glsdk tracking layers.

JIRA: SB-2622

Signed-off-by: Christopher Larson kergoth@gmail.com
