### PR TITLE
systemd: Check for HAVE_POSIX_FALLOCATE

### DIFF
--- a/meta-mentor-staging/recipes-core/systemd/systemd/systemd-pam-fix-fallocate.patch
+++ b/meta-mentor-staging/recipes-core/systemd/systemd/systemd-pam-fix-fallocate.patch
@@ -1,0 +1,84 @@
+Upstream-Status: Denied [no desire for uclibc support]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: systemd-209/src/journal/journal-file.c
+===================================================================
+--- systemd-209.orig/src/journal/journal-file.c	2014-02-12 18:42:33.000000000 -0800
++++ systemd-209/src/journal/journal-file.c	2014-02-19 23:23:19.464631643 -0800
+@@ -38,6 +38,8 @@
+ #include "compress.h"
+ #include "fsprg.h"
+ 
++#include "config.h"
++
+ #define DEFAULT_DATA_HASH_TABLE_SIZE (2047ULL*sizeof(HashItem))
+ #define DEFAULT_FIELD_HASH_TABLE_SIZE (333ULL*sizeof(HashItem))
+ 
+@@ -316,7 +318,7 @@
+ 
+ static int journal_file_allocate(JournalFile *f, uint64_t offset, uint64_t size) {
+         uint64_t old_size, new_size;
+-        int r;
++        int r = 0;
+ 
+         assert(f);
+ 
+@@ -364,9 +366,24 @@
+         /* Note that the glibc fallocate() fallback is very
+            inefficient, hence we try to minimize the allocation area
+            as we can. */
++#ifdef HAVE_POSIX_FALLOCATE
+         r = posix_fallocate(f->fd, old_size, new_size - old_size);
+         if (r != 0)
+                 return -r;
++#else
++       /* Use good old method to write zeros into the journal file
++          perhaps very inefficient yet working. */
++       if(new_size > old_size) {
++               char *buf = alloca(new_size - old_size);
++               off_t oldpos = lseek(f->fd, 0, SEEK_CUR);
++               bzero(buf, new_size - old_size);
++               lseek(f->fd, old_size, SEEK_SET);
++               r = write(f->fd, buf, new_size - old_size);
++               lseek(f->fd, oldpos, SEEK_SET);
++       }
++       if (r < 0)
++               return -errno;
++#endif /* HAVE_POSIX_FALLOCATE */
+ 
+         if (fstat(f->fd, &f->last_stat) < 0)
+                 return -errno;
+Index: systemd-209/src/journal/journald-kmsg.c
+===================================================================
+--- systemd-209.orig/src/journal/journald-kmsg.c	2014-02-19 15:03:09.000000000 -0800
++++ systemd-209/src/journal/journald-kmsg.c	2014-02-19 23:22:14.396630422 -0800
+@@ -441,6 +441,7 @@
+ 
+ int server_open_kernel_seqnum(Server *s) {
+         int fd;
++	int r = 0;
+         uint64_t *p;
+ 
+         assert(s);
+@@ -454,8 +455,19 @@
+                 log_error("Failed to open /run/systemd/journal/kernel-seqnum, ignoring: %m");
+                 return 0;
+         }
+-
+-        if (posix_fallocate(fd, 0, sizeof(uint64_t)) < 0) {
++#ifdef HAVE_POSIX_FALLOCATE
++        r = posix_fallocate(fd, 0, sizeof(uint64_t));
++#else
++	/* Use good old method to write zeros into the journal file
++	   perhaps very inefficient yet working. */
++	char *buf = alloca(sizeof(uint64_t));
++	off_t oldpos = lseek(fd, 0, SEEK_CUR);
++	bzero(buf, sizeof(uint64_t));
++	lseek(fd, 0, SEEK_SET);
++	r = write(fd, buf, sizeof(uint64_t));
++	lseek(fd, oldpos, SEEK_SET);
++#endif /* HAVE_POSIX_FALLOCATE */
++	if (r < 0) {
+                 log_error("Failed to allocate sequential number file, ignoring: %m");
+                 close_nointr_nofail(fd);
+                 return 0;

--- a/meta-mentor-staging/recipes-core/systemd/systemd_211.bbappend
+++ b/meta-mentor-staging/recipes-core/systemd/systemd_211.bbappend
@@ -1,1 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 RRECOMMENDS_${PN} += "os-release"


### PR DESCRIPTION
The check for the config variable is using the wrong define
resulting in the #else always being used.

Submitted upstream here:
    http://lists.openembedded.org/pipermail/openembedded-core/2014-April/092000.html

Signed-off-by: Drew Moseley drew_moseley@mentor.com
