### PR TITLE
fix curl security issue cve-2014-0138

### DIFF
--- a/meta-mentor-staging/recipes-support/curl/curl_7.35.0.bbappend
+++ b/meta-mentor-staging/recipes-support/curl/curl_7.35.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}:"
+SRC_URI += "file://libcurl-cve-2014-0138.patch"

--- a/meta-mentor-staging/recipes-support/curl/libcurl-cve-2014-0138.patch
+++ b/meta-mentor-staging/recipes-support/curl/libcurl-cve-2014-0138.patch
@@ -1,0 +1,46 @@
+diff -Naur curl-7.35.0-old/lib/http.c curl-7.35.0/lib/http.c
+--- curl-7.35.0-old/lib/http.c	2014-04-23 14:52:30.833351045 +0530
++++ curl-7.35.0/lib/http.c	2014-04-23 14:46:46.937357585 +0530
+@@ -145,8 +145,8 @@
+   ZERO_NULL,                            /* readwrite */
+   PORT_HTTPS,                           /* defport */
+   CURLPROTO_HTTP | CURLPROTO_HTTPS,     /* protocol */
+-  PROTOPT_SSL                           /* flags */
+-};
++  PROTOPT_SSL | PROTOPT_CREDSPERREQUEST /* flags */
++};
+ #endif
+
+
+diff -Naur curl-7.35.0-old/lib/url.c curl-7.35.0/lib/url.c
+--- curl-7.35.0-old/lib/url.c	2014-04-23 14:52:30.833351045 +0530
++++ curl-7.35.0/lib/url.c	2014-04-23 14:46:46.909357584 +0530
+@@ -3040,11 +3040,11 @@
+            strcmp(check->localdev, needle->localdev))
+           continue;
+       }
++       if((!(needle->handler->flags & PROTOPT_CREDSPERREQUEST)) ||
++         wantNTLM) {
++        /* This protocol requires credentials per connection or is HTTP+NTLM,
++           so verify that we're using the same name and password as well */
+
+-      if((needle->handler->protocol & CURLPROTO_FTP) ||
+-         ((needle->handler->protocol & CURLPROTO_HTTP) && wantNTLM)) {
+-         /* This is FTP or HTTP+NTLM, verify that we're using the same name
+-            and password as well */
+          if(!strequal(needle->user, check->user) ||
+             !strequal(needle->passwd, check->passwd)) {
+             /* one of them was different */
+diff -Naur curl-7.35.0-old/lib/urldata.h curl-7.35.0/lib/urldata.h
+--- curl-7.35.0-old/lib/urldata.h	2014-04-23 14:52:30.809351047 +0530
++++ curl-7.35.0/lib/urldata.h	2014-04-23 14:46:46.841357587 +0530
+@@ -785,7 +785,8 @@
+                                       gets a default */
+ #define PROTOPT_NOURLQUERY (1<<6)   /* protocol can't handle
+                                         url query strings (?foo=bar) ! */
+-
++#define PROTOPT_CREDSPERREQUEST (1<<7) /* requires login creditials per request
++                                          as opposed to per connection */
+
+ /* return the count of bytes sent, or -1 on error */
+ typedef ssize_t (Curl_send)(struct connectdata *conn, /* connection data */


### PR DESCRIPTION
Jira:  SB-2650
Integrate community fix for the issue cve-2014-0138
Fixed connection re-use when using different log-in credentials.
In addition to FTP, other connection based protocols such as IMAP, POP3,
SMTP, SCP, SFTP and LDAP require a new connection when different log-in
credentials are specified. Fixed the detection logic to include these
other protocols.
Upstream-Status: Backported

Signed-off-by: Priyanka Shobhan priyanka_shobhan@mentor.com
