### PR TITLE
mel: use gstreamer 0.10, not 1.0, for qtwebkit

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -123,6 +123,10 @@ DISTRO_FEATURES_append = " vfat"
 # Ensure fbset is in busybox configuration, and fbset-modes is included
 PACKAGECONFIG_append_pn-busybox = " fbset"
 
+# Ensure that qtwebkit uses gstreamer 0.10, not 1.0, as we have both machine
+# specifics (e.g. glsdk bits) and tracepoints (meta-tracing) for 0.10.
+PACKAGECONFIG_pn-qtwebkit ?= "gstreamer010 qtlocation qtmultimedia qtsensors"
+
 # Sane default locales for images
 GLIBC_GENERATE_LOCALES ?= "en_US en_US.UTF-8"
 IMAGE_LINGUAS ?= "en-us"


### PR DESCRIPTION
Without this, all our builds including qt5 components resulted in building 
both gstreamer versions, which caused sysroot and shlibs provider conflicts, 
as well as slowing down our builds.

JIRA: SB-2713
