### PR TITLE
image: add SPLIT_DEBUG_FS to do_rootfs[vardeps]

### DIFF
--- a/meta-mentor-staging/classes/image.bbclass
+++ b/meta-mentor-staging/classes/image.bbclass
@@ -85,6 +85,7 @@ do_rootfs[depends] += "makedevs-native:do_populate_sysroot virtual/fakeroot-nati
 do_rootfs[depends] += "virtual/update-alternatives-native:do_populate_sysroot update-rc.d-native:do_populate_sysroot"
 do_rootfs[recrdeptask] += "do_packagedata"
 do_rootfs[vardeps] += "BAD_RECOMMENDATIONS NO_RECOMMENDATIONS"
+do_rootfs[vardeps] += "SPLIT_DEBUG_FS"
 
 do_build[depends] += "virtual/kernel:do_deploy"
 


### PR DESCRIPTION
Without this, the image won't be rebuilt when changing SPLIT_DEBUG_FS.

JIRA: SB-2716
