### PR TITLE
linux-qoriq-sdk-headers: add new recipe (copied from FSL SDK v1.5)

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers.bb
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers.bb
@@ -1,0 +1,34 @@
+DESCRIPTION = "Linux kernel headers for Freescale platforms"
+SECTION = "devel"
+LICENSE = "GPLv2"
+
+PR = "${INC_PR}.1"
+
+INHIBIT_DEFAULT_DEPS = "1"
+PROVIDES = "linux-libc-headers ${PN}"
+RPROVIDES_${PN}-dev += "linux-libc-headers-dev"
+RPROVIDES_${PN}-dbg += "linux-libc-headers-dbg"
+RDEPENDS_${PN}-dev = ""
+RRECOMMENDS_${PN}-dbg = "linux-libc-headers-dev (= ${EXTENDPKGV})"
+
+require recipes-kernel/linux/linux-qoriq-sdk.inc
+
+SRC_URI_append += " file://scripts-Makefile.headersinst-install-headers-from-sc.patch"
+
+inherit kernel-arch
+
+do_configure() {
+        oe_runmake allnoconfig
+}
+
+do_compile () {
+}
+
+do_install() {
+        oe_runmake headers_install INSTALL_HDR_PATH=${D}${exec_prefix}
+        # Kernel should not be exporting this header
+        rm -f ${D}${exec_prefix}/include/scsi/scsi.h
+
+        # The ..install.cmd conflicts between various configure runs
+        find ${D}${includedir} -name ..install.cmd | xargs rm -f
+}

--- a/meta-mel/fsl-ppc/recipes-kernel/linux/scripts-Makefile.headersinst-install-headers-from-sc.patch
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/scripts-Makefile.headersinst-install-headers-from-sc.patch
@@ -1,0 +1,46 @@
+From e60cc1b011bf0f1acdb7e5168b7bed4ebb78c91f Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@windriver.com>
+Date: Wed, 9 Jan 2013 16:24:39 -0500
+Subject: [PATCH] scripts/Makefile.headersinst: install headers from scratch file
+
+If headers_install is executed from a deep/long directory structure, the
+shell's maximum argument length can be execeeded, which breaks the operation
+with:
+
+| make[2]: execvp: /bin/sh: Argument list too long
+| make[2]: ***
+
+By dumping the input files to a scratch file and using xargs to read the
+input list from the scratch file, we can avoid blowing out the maximum
+argument size and install headers in a long path name environment.
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+---
+ scripts/Makefile.headersinst |    4 +++-
+ 1 files changed, 3 insertions(+), 1 deletions(-)
+
+diff --git a/scripts/Makefile.headersinst b/scripts/Makefile.headersinst
+index 06ba4a7..536d722 100644
+--- a/scripts/Makefile.headersinst
++++ b/scripts/Makefile.headersinst
+@@ -71,7 +71,7 @@ printdir = $(patsubst $(INSTALL_HDR_PATH)/%/,%,$(dir $@))
+ quiet_cmd_install = INSTALL $(printdir) ($(words $(all-files))\
+                             file$(if $(word 2, $(all-files)),s))
+       cmd_install = \
+-        $(PERL) $< $(installdir) $(SRCARCH) $(input-files); \
++        xargs $(PERL) $< $(installdir) $(SRCARCH) < $(INSTALL_HDR_PATH)/.input-files; \
+         for F in $(wrapper-files); do                                   \
+                 echo "\#include <asm-generic/$$F>" > $(installdir)/$$F;    \
+         done;                                                           \
+@@ -100,7 +100,9 @@ targets += $(install-file)
+ $(install-file): scripts/headers_install.pl $(input-files) FORCE
+ 	$(if $(unwanted),$(call cmd,remove),)
+ 	$(if $(wildcard $(dir $@)),,$(shell mkdir -p $(dir $@)))
++	@echo $(input-files) > $(INSTALL_HDR_PATH)/.input-files
+ 	$(call if_changed,install)
++	@rm $(INSTALL_HDR_PATH)/.input-files
+ 
+ else
+ __headerscheck: $(subdirs) $(check-file)
+-- 
+1.7.0.4


### PR DESCRIPTION
Some Freescale SoC specific applications e.g. skmm-ep require header
files that are only available through linux-qoriq-sdk-headers. So
adding this recipe to allow successful compilation of such
applications.

Signed-off-by: Fahad Arslan fahad_arslan@mentor.com
