### PR TITLE
rootfs.py: merge changes from updated rootfs.py upstream

### DIFF
--- a/meta-mentor-staging/lib/oe/rootfs.py
+++ b/meta-mentor-staging/lib/oe/rootfs.py
@@ -1,9 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from oe.utils import execute_pre_post_process
-from oe.utils import contains as base_contains
 from oe.package_manager import *
 from oe.manifest import *
-import oe.types
 import oe.path
 import filecmp
 import shutil
@@ -44,7 +42,7 @@ class Rootfs(object):
         pass
 
     def _insert_feed_uris(self):
-        if base_contains("IMAGE_FEATURES", "package-management",
+        if bb.utils.contains("IMAGE_FEATURES", "package-management",
                          True, False, self.d):
             self.pm.insert_feeds_uris()
 
@@ -110,7 +108,7 @@ class Rootfs(object):
 
         execute_pre_post_process(self.d, post_process_cmds)
 
-        if base_contains("IMAGE_FEATURES", "read-only-rootfs",
+        if bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs",
                          True, False, self.d):
             delayed_postinsts = self._get_delayed_postinsts()
             if delayed_postinsts is not None:
@@ -132,7 +130,7 @@ class Rootfs(object):
         self._cleanup()
 
     def _uninstall_uneeded(self):
-        if base_contains("IMAGE_FEATURES", "package-management",
+        if bb.utils.contains("IMAGE_FEATURES", "package-management",
                          True, False, self.d):
             return
 


### PR DESCRIPTION
While building with updated poky layer, I noticed this build failure during do_rootfs task because the upstream version of rootfs.py has been recently updated and our local copy of rootfs.py needed those changes as well. This fix will be required after the next layer update.
