### PR TITLE
mel: neard: obey VIRTUAL-RUNTIME_bluetooth-stack

### DIFF
--- a/meta-mel/recipes-connectivity/neard/neard_0.14.bbappend
+++ b/meta-mel/recipes-connectivity/neard/neard_0.14.bbappend
@@ -1,0 +1,6 @@
+python () {
+    if 'mel' in d.getVar('OVERRIDES', True).split(':'):
+        rrecs = d.getVar('RRECOMMENDS_neard', False)
+        rrecs = rrecs.replace('bluez4', '${VIRTUAL-RUNTIME_bluetooth-stack}')
+        d.setVar('RRECOMMENDS_neard', rrecs)
+}


### PR DESCRIPTION
neard supports either bluez4 or bluez5.

JIRA: SB-2726

Signed-off-by: Christopher Larson kergoth@gmail.com
