### PR TITLE
linux-ti-staging: Add systemd related kconfig options

### DIFF
--- a/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-ti-staging/0001-omap2plus-Enable-config-options-for-proper-systemd-o.patch
+++ b/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-ti-staging/0001-omap2plus-Enable-config-options-for-proper-systemd-o.patch
@@ -1,0 +1,44 @@
+From 6c37a195792e838302533cfb1a1da0010bc76310 Mon Sep 17 00:00:00 2001
+From: Wade Farnsworth <wade_farnsworth@mentor.com>
+Date: Mon, 21 Apr 2014 07:58:53 -0700
+Subject: [PATCH] omap2plus: Enable config options for proper systemd
+ operation
+
+CGROUPS, AUTOFS4, and FHANDLE are required for systemd to initialize
+properly.  These are missing from the omap2plus, which causes the
+boot to fail on Beaglebone and related platforms.
+
+Signed-off-by: Wade Farnsworth <wade_farnsworth@mentor.com>
+---
+ arch/arm/configs/omap2plus_defconfig |    3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm/configs/omap2plus_defconfig b/arch/arm/configs/omap2plus_defconfig
+index ff579a7..d29c89c 100644
+--- a/arch/arm/configs/omap2plus_defconfig
++++ b/arch/arm/configs/omap2plus_defconfig
+@@ -1,11 +1,13 @@
+ CONFIG_SYSVIPC=y
+ CONFIG_POSIX_MQUEUE=y
++CONFIG_FHANDLE=y
+ CONFIG_NO_HZ=y
+ CONFIG_HIGH_RES_TIMERS=y
+ CONFIG_BSD_PROCESS_ACCT=y
+ CONFIG_IKCONFIG=y
+ CONFIG_IKCONFIG_PROC=y
+ CONFIG_LOG_BUF_SHIFT=16
++CONFIG_CGROUPS=y
+ CONFIG_BLK_DEV_INITRD=y
+ CONFIG_EXPERT=y
+ CONFIG_SLAB=y
+@@ -358,6 +360,7 @@ CONFIG_EXT3_FS=y
+ CONFIG_EXT4_FS=y
+ CONFIG_QUOTA=y
+ CONFIG_QFMT_V2=y
++CONFIG_AUTOFS4_FS=y
+ CONFIG_MSDOS_FS=y
+ CONFIG_VFAT_FS=y
+ CONFIG_TMPFS=y
+-- 
+1.7.9.5
+

--- a/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-ti-staging_3.12.bbappend
+++ b/meta-mentor-staging/meta-ti/recipes-kernel/linux/linux-ti-staging_3.12.bbappend
@@ -1,1 +1,5 @@
 DEPENDS += "bc-native"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "${@base_contains('DISTRO_FEATURES', 'systemd', ' file://0001-omap2plus-Enable-config-options-for-proper-systemd-o.patch ', '', d)}"


### PR DESCRIPTION
Add missing kconfig options to linux-ti-staging kernel.  This
allows systemd to fully initialize.

Signed-off-by: Wade Farnsworth wade_farnsworth@mentor.com
