### PR TITLE
mel: remove *_MIRROR from SRC_URI vardeps

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -251,3 +251,19 @@ MACHINE_HWCODECS_remove = "va-intel"
 MACHINE_HWCODECS_append = " "
 XSERVERCODECS_remove = "emgd-driver-video emgd-gst-plugins-va emgd-gst-plugins-mixvideo gst-va-intel"
 XSERVERCODECS_append = " "
+
+# Changing a mirror shouldn't force a refetch/rebuild
+SRC_URI[vardepsexclude] += "\
+    APACHE_MIRROR \
+    DEBIAN_MIRROR \
+    E_MIRROR \
+    GENTOO_MIRROR \
+    GNOME_GIT \
+    GNOME_MIRROR \
+    GNU_MIRROR \
+    GPE_MIRROR \
+    KERNELORG_MIRROR \
+    SOURCEFORGE_MIRROR \
+    XLIBS_MIRROR \
+    XORG_MIRROR \
+"


### PR DESCRIPTION
Changing one of the _MIRROR variables (e.g. APACHE_MIRROR) only changes where 
we're downloading something from, not what we're downloading. We don't want
to force a refetch/rebuild when the mirror variables change, so exclude it
from the SRC_URI vardeps.

JIRA: SB-2728

Signed-off-by: Christopher Larson kergoth@gmail.com
(cherry picked from commit efc648cd3d8151f393cdfa79cdbb750224c40c9a)
