### PR TITLE
fsl-ppc/u-boot: Add --bss-plt to LDFLAGS

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/files/0001-powerpc-add-bss-plt-to-LDFLAGS.patch
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/files/0001-powerpc-add-bss-plt-to-LDFLAGS.patch
@@ -1,0 +1,30 @@
+From 77be788d150ccb423aff44965f6ad5deda6a2281 Mon Sep 17 00:00:00 2001
+From: Wade Farnsworth <wade_farnsworth@mentor.com>
+Date: Thu, 8 May 2014 13:02:46 -0700
+Subject: [PATCH] powerpc: add --bss-plt to LDFLAGS
+
+Recent toolchains compile with a new BSS PLT and Global Offset Table
+layout.  However, u-boot.lds has not been updated to handle this.  Adding
+--bss-plt to LDFLAGS reverts to the old layout.
+
+Signed-off-by: Wade Farnsworth <wade_farnsworth@mentor.com>
+---
+ arch/powerpc/config.mk |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/powerpc/config.mk b/arch/powerpc/config.mk
+index b706281..1559985 100644
+--- a/arch/powerpc/config.mk
++++ b/arch/powerpc/config.mk
+@@ -24,7 +24,7 @@
+ CROSS_COMPILE ?= ppc_8xx-
+ 
+ CONFIG_STANDALONE_LOAD_ADDR ?= 0x40000
+-LDFLAGS_FINAL += --gc-sections
++LDFLAGS_FINAL += --gc-sections --bss-plt
+ PLATFORM_RELFLAGS += -fpic -mrelocatable -ffunction-sections -fdata-sections
+ PLATFORM_CPPFLAGS += -DCONFIG_PPC -D__powerpc__
+ PLATFORM_LDFLAGS  += -n
+-- 
+1.7.9.5
+

--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot_git.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot_git.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+            file://0001-powerpc-add-bss-plt-to-LDFLAGS.patch \
+           "


### PR DESCRIPTION
Recent toolchains compile with a new BSS PLT and Global Offset Table
layout.  However, u-boot.lds has not been updated to handle this.
Adding --bss-plt to LDFLAGS reverts to the old layout.

This was reported in SB-2736.

Signed-off-by: Wade Farnsworth wade_farnsworth@mentor.com
