### PR TITLE
bluez5: Update the bluetooth.conf

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/bluez/bluez5_5.15.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/bluez/bluez5_5.15.bbappend
@@ -1,0 +1,4 @@
+do_configure_append () {
+        sed -i 's/org.bluez.Agent"/org.bluez.Agent1"/' ${WORKDIR}/bluetooth.conf
+}
+


### PR DESCRIPTION
In bluez5, Agent interface has been renamed from org.bluez.Agent
to org.bluez.Agent1. Reflect this change in bluetooth.conf to
allow sending of dbus messages to agent interface.

*Resolves no PIN prompt bug while pairing
JIRA: http://jira.alm.mentorg.com:8080/browse/SB-2041

*Resolves bluetooth keyboard connection problem.
JIRA: http://jira.alm.mentorg.com:8080/browse/SB-2180

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
