### PR TITLE
dnsmasq: fix parallel make failure

### DIFF
--- a/meta-mentor-staging/networking-layer/recipes-support/dnsmasq/dnsmasq/parallel-make.patch
+++ b/meta-mentor-staging/networking-layer/recipes-support/dnsmasq/dnsmasq/parallel-make.patch
@@ -1,0 +1,19 @@
+The dnsmasq target depends on .configured and $(objs). .configured does an rm
+-f *.o. Yet the only thing telling make to build the .configured target before
+the $(objs) target was the order of the dependencies of the dnsmasq target. We
+can't rely on that order when doing a paralllel make build, so add an explicit
+rule to enforce that order.
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+Upstream-status: Pending
+
+--- dnsmasq-2.68.orig/Makefile
++++ dnsmasq-2.68/Makefile
+@@ -139,6 +139,8 @@ bloatcheck : $(BUILDDIR)/dnsmasq_baselin
+	@rm -f *.o
+	@touch $@
+
++$(objs): .configured
++
+ $(objs:.o=.c) $(hdrs):
+	ln -s $(top)/$(SRC)/$@ .

--- a/meta-mentor-staging/networking-layer/recipes-support/dnsmasq/dnsmasq_2.68.bbappend
+++ b/meta-mentor-staging/networking-layer/recipes-support/dnsmasq/dnsmasq_2.68.bbappend
@@ -1,3 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://parallel-make.patch"
+
 EXTRA_OEMAKE += "\
     'CFLAGS=${CFLAGS}' \
     'LDFLAGS=${LDFLAGS}' \


### PR DESCRIPTION
The dnsmasq target depends on .configured and $(objs). .configured does an rm
-f *.o. Yet the only thing telling make to build the .configured target
before the $(objs) target was the order of the dependencies of the dnsmasq
target. We can't rely on that order when doing a paralllel make build, so add
an explicit rule to enforce that order.

JIRA: SB-2767

Signed-off-by: Christopher Larson kergoth@gmail.com
