### PR TITLE
binutils: quiet alternatives warnings

### DIFF
--- a/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
+++ b/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
@@ -42,3 +42,6 @@ do_configure () {
 do_install_append () {
 	rm -rf ${D}${prefix}/${TARGET_SYS}/lib
 }
+
+# This version doesn't provide these
+USE_ALTERNATIVES_FOR := "${@oe_filter_out('ld.bfd|elfedit', USE_ALTERNATIVES_FOR, d)}"


### PR DESCRIPTION
This recipe doesn't install ld.bfd or elfedit, so disable creation of 
alternatives for these, to quiet build warnings.

JIRA: SB-2748

Signed-off-by: Christopher Larson kergoth@gmail.com
