### PR TITLE
mel.conf: include qt5-mel.conf

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -128,10 +128,6 @@ DISTRO_FEATURES_append = " vfat"
 # Ensure fbset is in busybox configuration, and fbset-modes is included
 PACKAGECONFIG_append_pn-busybox = " fbset"
 
-# Ensure that qtwebkit uses gstreamer 0.10, not 1.0, as we have both machine
-# specifics (e.g. glsdk bits) and tracepoints (meta-tracing) for 0.10.
-PACKAGECONFIG_pn-qtwebkit ?= "gstreamer010 qtlocation qtmultimedia qtsensors"
-
 # Sane default locales for images
 GLIBC_GENERATE_LOCALES ?= "en_US en_US.UTF-8"
 IMAGE_LINGUAS ?= "en-us"
@@ -224,6 +220,9 @@ INHERIT += "blacklist"
 require conf/blocks/bluetooth.conf
 require conf/blocks/speech-synthesis.conf
 require conf/blocks/speech-recognition.conf
+
+# Handle Qt5 changes
+include conf/distro/include/qt5-mel.conf
 
 # Mask out meta-ivi's connman, libpcap, and pulseaudio appends, as it makes it
 # impossible to add bluetooth to its PACKAGECONFIG, so we need to undo the


### PR DESCRIPTION
Include qt5-mel.conf to mel.conf and remove the qtwebkit
PACKAGECONFIG changes to qt5-mel.conf.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
