### PR TITLE
Remove iso

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -360,3 +360,9 @@ do_package_write_rpm[noexec] = "1"
 
 IMAGE_EXTENSION_live_baldeagle := "${@oe_filter_out('iso', '${IMAGE_EXTENSION_live}', d)}"
 IMAGE_EXTENSION_live_steppeeagle := "${@oe_filter_out('iso', '${IMAGE_EXTENSION_live}', d)}"
+prepare_templates_append_baldeagle() {
+    sed -i 's,^\(EXTERNAL_TOOLCHAIN ?= \"\$\)\({MELDIR}/../..\)",\1\2/codebench-lite",' local.conf.sample
+}
+prepare_templates_append_steppeeagle() {
+    sed -i 's,^\(EXTERNAL_TOOLCHAIN ?= \"\$\)\({MELDIR}/../..\)",\1\2/codebench-lite",' local.conf.sample
+}


### PR DESCRIPTION
These are a few changes we need for BE/SE support.  The prepare_templates bits will move into a different location once we implement a proper "mel-lite" distro in the next few weeks but in the meantime we need to store them somewhere.  We can't have them in our layer since it needs to be independent of meta-mentor and open builds will fail due to no corresponding bb file.

The stripping of ISO images may be of interest to other platforms as I'm not convinced they are terribly useful in an embedded context but for now I have them suffixed with my board names.
