### PR TITLE
gnupg: Added dependency on curl

### DIFF
--- a/meta-mentor-staging/recipes-support/gnupg/gnupg_1.4.7.bbappend
+++ b/meta-mentor-staging/recipes-support/gnupg/gnupg_1.4.7.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[curl] = "--with-libcurl=${STAGING_LIBDIR},--without-libcurl,curl"


### PR DESCRIPTION
meta-ivi adds curl to the rootfs image but does not add it to dependencies for gnupg.
This leads to build failures in some rare cases (when both curl and gnupg are rebuilt
for some reason).

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
