### PR TITLE
ca-certificates: work around duplicate signed roots

### DIFF
--- a/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates/dup-certs-workaround.patch
+++ b/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates/dup-certs-workaround.patch
@@ -1,0 +1,24 @@
+diff --git a/mozilla/certdata2pem.py b/mozilla/certdata2pem.py
+index 5cc8f4c..0482894 100644
+--- a/mozilla/certdata2pem.py
++++ b/mozilla/certdata2pem.py
+@@ -116,12 +116,16 @@ for obj in objects:
+     if obj['CKA_CLASS'] == 'CKO_CERTIFICATE':
+         if not obj['CKA_LABEL'] in trust or not trust[obj['CKA_LABEL']]:
+             continue
+-        fname = obj['CKA_LABEL'][1:-1].replace('/', '_')\
++        bname = obj['CKA_LABEL'][1:-1].replace('/', '_')\
+                                       .replace(' ', '_')\
+                                       .replace('(', '=')\
+                                       .replace(')', '=')\
+-                                      .replace(',', '_') + '.crt'
+-        fname = fname.decode('string_escape')
++                                      .replace(',', '_')
++        bname = bname.decode('string_escape')
++        fname = bname + '.crt'
++        if os.path.exists(fname):
++            print "Found duplicate certificate name %s, renaming." % bname
++            fname = bname + '_2.crt'
+         f = open(fname, 'w')
+         f.write("-----BEGIN CERTIFICATE-----\n")
+         f.write("\n".join(textwrap.wrap(base64.b64encode(obj['CKA_VALUE']), 64)))

--- a/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates_20130610.bbappend
+++ b/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates_20130610.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://dup-certs-workaround.patch"


### PR DESCRIPTION
openssl issue where two signed roots have the same CKA_LABEL resulting in identical filenames.
Ship both versions of the same signed roots instead of overwriting first found.

Signed-off-by: Michael Powell michael_powell@mentor.com
Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
