### PR TITLE
alsa-utils: interrupt streaming via signal broken

### DIFF
--- a/meta-mentor-staging/recipes-multimedia/alsa/alsa-utils/alsa-utils-aplay-interrupt-signal-handling.patch
+++ b/meta-mentor-staging/recipes-multimedia/alsa/alsa-utils/alsa-utils-aplay-interrupt-signal-handling.patch
@@ -1,0 +1,75 @@
+--- a/aplay/aplay.c	2014-05-19 16:25:14.000000000 +0530
++++ b/aplay/aplay.c	2014-05-20 15:17:14.364823007 +0530
+@@ -392,14 +392,22 @@
+ 		putchar('\n');
+ 	if (!quiet_mode)
+ 		fprintf(stderr, _("Aborted by signal %s...\n"), strsignal(sig));
+-	if (handle)
++	if (stream == SND_PCM_STREAM_CAPTURE) {
++		if (fmt_rec_table[file_type].end) {
++			fmt_rec_table[file_type].end(fd);
++			fd = -1;
++		}
++		stream = -1;
++	}
++	if (fd > 1) {
++		close(fd);
++		fd = -1;
++	}
++	if (handle && sig != SIGABRT) {
+ 		snd_pcm_abort(handle);
+-	if (sig == SIGABRT) {
+-		/* do not call snd_pcm_close() and abort immediately */
+ 		handle = NULL;
+-		prg_exit(EXIT_FAILURE);
+ 	}
+-	signal(sig, signal_handler);
++	prg_exit(EXIT_FAILURE);
+ }
+ 
+ /* call on SIGUSR1 signal. */
+@@ -1921,7 +1929,7 @@
+ 		count = chunk_size;
+ 	}
+ 	data = remap_data(data, count);
+-	while (count > 0) {
++	while (count > 0 && !in_aborting) {
+ 		if (test_position)
+ 			do_test_position();
+ 		check_stdin();
+@@ -1964,7 +1972,7 @@
+ 		count = chunk_size;
+ 	}
+ 	data = remap_datav(data, count);
+-	while (count > 0) {
++	while (count > 0 && !in_aborting) {
+ 		unsigned int channel;
+ 		void *bufs[channels];
+ 		size_t offset = result;
+@@ -2013,7 +2021,7 @@
+ 		count = chunk_size;
+ 	}
+ 
+-	while (count > 0) {
++	while (count > 0 && !in_aborting) {
+ 		if (test_position)
+ 			do_test_position();
+ 		check_stdin();
+@@ -2052,7 +2060,7 @@
+ 		count = chunk_size;
+ 	}
+ 
+-	while (count > 0) {
++	while (count > 0 && !in_aborting) {
+ 		unsigned int channel;
+ 		void *bufs[channels];
+ 		size_t offset = result;
+@@ -2096,7 +2104,7 @@
+ 	ssize_t result = count, r;
+ 	size_t size;
+ 
+-	while (count > 0) {
++	while (count > 0 && !in_aborting) {
+ 		size = count;
+ 		if (size > chunk_bytes - buffer_pos)
+ 			size = chunk_bytes - buffer_pos;

--- a/meta-mentor-staging/recipes-multimedia/alsa/alsa-utils_1.0.27.2.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/alsa/alsa-utils_1.0.27.2.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://alsa-utils-aplay-interrupt-signal-handling.patch"


### PR DESCRIPTION
aplay/arecord (alsa-utils v1.0.27.2) cannot interrupt streaming
via CTRL-C. Fixed the issue by reverting buggy patches and
properly handling 'in_aborting' flag in appropriate functions.

Signed-off-by: Anant Agrawal Anant_Agrawal@mentor.com
Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
