### PR TITLE
netbase: Add hostname to the hosts file

### DIFF
--- a/meta-mentor-staging/recipes-core/netbase/netbase_%.bbappend
+++ b/meta-mentor-staging/recipes-core/netbase/netbase_%.bbappend
@@ -1,0 +1,3 @@
+do_install_append() {
+   echo ${MACHINE} "		"127.0.1.1 >> ${D}${sysconfdir}/hosts
+}


### PR DESCRIPTION
Adding this to the hosts file will help the rpcinfo
command work with hostname.

JIRA: SB-3004

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
