### PR TITLE
qtbase,qtwebkit,meta-toolchain-qt5: Removing from meta-mentor

### DIFF
--- a/meta-mentor-staging/qt5-layer/recipes-qt/meta/meta-toolchain-qt5.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/meta/meta-toolchain-qt5.bbappend
@@ -1,2 +1,0 @@
-FEATURE_PACKAGES_qtcreator-debug := "${PACKAGE_GROUP_qtcreator-debug}"
-PACKAGE_GROUP_qtcreator-debug = ""

--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_5.2.1.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_5.2.1.bbappend
@@ -1,3 +1,0 @@
-# Add missing libxi to DEPENDS for xinput packageconfigs
-PACKAGECONFIG[xinput] = "-xinput,-no-xinput,libxi"
-PACKAGECONFIG[xinput2] = "-xinput2,-no-xinput2,libxi"

--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtwebkit_%.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtwebkit_%.bbappend
@@ -1,2 +1,0 @@
-# remove default ${PN}-examples-dbg ${PN}-examples set in qt5.inc, because it conflicts with ${PN} from separate webkit-examples recipe
-PACKAGES = "${PN}-dbg ${PN}-staticdev ${PN}-dev ${PN}-doc ${PN}-locale ${PACKAGE_BEFORE_PN} ${PN} ${PN}-qmlplugins-dbg ${PN}-tools-dbg ${PN}-plugins-dbg ${PN}-qmlplugins ${PN}-tools ${PN}-plugins ${PN}-mkspecs "


### PR DESCRIPTION
Removing qtbase,qtwebkit,meta-toolchain-qt5 and adding these
changes to meta-qt5-mel.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
