### PR TITLE
pigz: Add dependency on zlib-native for pigz-native

### DIFF
--- a/meta-mentor-staging/recipes-extended/pigz/pigz_2.3.1.bbappend
+++ b/meta-mentor-staging/recipes-extended/pigz/pigz_2.3.1.bbappend
@@ -1,0 +1,3 @@
+PIGZ_SYSROOT_DEPS = ""
+PIGZ_SYSROOT_DEPS_class-native = "zlib-native:do_populate_sysroot_setscene"
+do_populate_sysroot_setscene[depends] += "${PIGZ_SYSROOT_DEPS}"


### PR DESCRIPTION
When pigz-native and zlib-native are coming from sstate the setscenes might
not necessarily run in the expected order. The problem happens when setscene
for pigz-native runs before setscene for zlib-native. To fix the issue
do_populate_sysroot_setscene[depends] should be properly set for pigz-native.

Signed-off-by: Mikhail Durnev mikhail_durnev@mentor.com
