### PR TITLE
libvirt: set path to pkcheck

### DIFF
--- a/meta-mentor-staging/virtualization-layer/recipes-extended/libvirt/libvirt_1.2.2.bbappend
+++ b/meta-mentor-staging/virtualization-layer/recipes-extended/libvirt/libvirt_1.2.2.bbappend
@@ -1,0 +1,3 @@
+# Ensure that libvirt uses polkit rather than policykit, whether the host has
+# pkcheck installed or not, and ensure the path is correct per our config.
+CACHED_CONFIGUREVARS += "ac_cv_path_PKCHECK_PATH=${bindir}/pkcheck"


### PR DESCRIPTION
The libvirt build would fail whenever x11 was in DISTRO_FEATURES, and the
host didn't have polkit installed (either no polkit/policykit at all, or just
old policykit).

Ensure that libvirt uses polkit rather than policykit, whether the host has
pkcheck installed or not, and ensure the path is correct per our config.

JIRA: SB-3053

Signed-off-by: Christopher Larson kergoth@gmail.com
