### PR TITLE
mel: fix IMAGE_FEATURES vardeps bug

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -235,6 +235,11 @@ BBMASK ?= "(/meta-ivi/(recipes-multimedia/pulseaudio|recipes-connectivity/(connm
 SHELL[unexport] = "1"
 BB_TERMINAL_EXPORTS += "SHELL"
 
+# Fix upstream image.bbclass vardeps bug, to ensure that changes to the image
+# features result in re-executing do_rootfs.
+FEATURE_INSTALL[vardepvalue] = "${FEATURE_INSTALL}"
+FEATURE_INSTALL_OPTIONAL[vardepvalue] = "${FEATURE_INSTALL_OPTIONAL}"
+
 # Work around vars for the target leaking into natives
 TARGET_LDFLAGS[unexport] = "1"
 TARGET_CFLAGS[unexport] = "1"


### PR DESCRIPTION
Changes to IMAGE_FEATURES or FEATURE_PACKAGE_<feature> for each feature in
IMAGE_FEATURES didn't result in a change to the do_rootfs checksum, so the
task wouldn't re-run when those variables changed. Fix by expanding the inline
python as the vardepvalue, so any change to the package list to be installed
based on image features will affect the checksum.

JIRA: SB-3056

Signed-off-by: Christopher Larson kergoth@gmail.com
