### PR TITLE
mel: don't use BB_HASHBASE_WHITELIST_append

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -13,9 +13,6 @@ POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 # Paths
 MELDIR ?= "${COREBASE}/.."
 
-# Ensure the path to the mel install isn't hardcoded into any signatures
-BB_HASHBASE_WHITELIST_append = " MELDIR"
-
 # Application Development Environment
 ADE_PROVIDER = "Mentor Graphics Corporation"
 ADE_SITENAME = "Application Development Environment for ${DISTRO_NAME}"

--- a/meta-mel/conf/distro/include/sstate.inc
+++ b/meta-mel/conf/distro/include/sstate.inc
@@ -1,3 +1,10 @@
+# Ensure the path to the mel install doesn't affect checksums
+python sstate_config_handler () {
+    e.data.appendVar('BB_HASHBASE_WHITELIST', ' MELDIR')
+}
+sstate_config_handler[eventmask] = "bb.event.ConfigParsed"
+addhandler sstate_config_handler
+
 INHERIT += "sstate-mirror-sites"
 
 # We know RHEL 6 is the oldest distro we support, and that binaries built


### PR DESCRIPTION
Currently, bitbake isn't always using the finalized configuration metadata to
get the value of this variable, so the _append isn't always applied.

JIRA: MEIBPADIT-811
