### PR TITLE
mel: empty ADE_SECTIONS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -16,7 +16,7 @@ MELDIR ?= "${COREBASE}/.."
 # Application Development Environment
 ADE_PROVIDER = "Mentor Graphics Corporation"
 ADE_SITENAME = "Application Development Environment for ${DISTRO_NAME}"
-ADE_SECTIONS = "devel bootloaders kernel source sdk"
+ADE_SECTIONS = ""
 ADE_SECTIONS_EXCLUDED = "locale"
 
 # Default image for our installers


### PR DESCRIPTION
Due to how things are structured at the moment, sections which are not listed
here are not installed when the user selects the ADE for installation. We
don't want to risk missing anything at this time, so empty the variable, which
results in all package sections being installed with the ADE.

JIRA: SB-3070

Signed-off-by: Christopher Larson kergoth@gmail.com
