### PR TITLE
Disable prelink by default

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -150,7 +150,7 @@ SDKMACHINE ?= "i686"
 #   - 'image-prelink' in order to prelink the filesystem image
 #   - 'image-swab' to perform host system intrusion detection
 # NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
-USER_CLASSES ?= "buildstats buildstats-summary image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats buildstats-summary image-mklibs"
 
 # To use mklibs, it must also be explicitly enabled for a given image. Note
 # that images built with mklibs will only run the binaries installed at image


### PR DESCRIPTION
While we're in that area of the code, also fix the reference to local.conf.extended.

JIRA: SB-2991, SB-3113
