### PR TITLE
firmware-wireless: use https clone

### DIFF
--- a/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
+++ b/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
@@ -36,7 +36,7 @@ LIC_FILES_CHKSUM = "\
 SRCREV = "c2c3df64df50d826d7649e03fbbe84ea99e5dbc8"
 PV = "0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/MentorEmbedded/firmware-wireless"
+SRC_URI = "git://github.com/MentorEmbedded/firmware-wireless;protocol=https"
 S = "${WORKDIR}/git"
 
 inherit allarch update-alternatives


### PR DESCRIPTION
This is currently a private repository, so we need to use a protocol that
supports authentication.

This should fix our jenkins fetch failures.

Signed-off-by: Christopher Larson kergoth@gmail.com
