### PR TITLE
linux-qoriq-sdk: disable config for network block device support

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/files/nbd.cfg
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/files/nbd.cfg
@@ -1,0 +1,1 @@
+CONFIG_BLK_DEV_NBD=n

--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk.bbappend
@@ -6,3 +6,6 @@ DEFCONFIG = "${KERNEL_DEFCONFIG}"
 python () {
     d.setVar("do_configure", 'kernel_do_configure')
 }
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://nbd.cfg"


### PR DESCRIPTION
Jira: SB-3065

Signed-off-by: Fahad Arslan Fahad_Arslan@mentor.com
