### PR TITLE
debianutils: Convert to update-alternatives.bbclass

### DIFF
--- a/meta-mentor-staging/recipes-support/debianutils/debianutils_2.30.bb
+++ b/meta-mentor-staging/recipes-support/debianutils/debianutils_2.30.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Miscellaneous utilities specific to Debian"
+SECTION = "base"
+LICENSE = "GPLv2 & BSD & SMAIL_GPL"
+LIC_FILES_CHKSUM = "file://debian/copyright;md5=b948675029f79c64840e78881e91e1d4"
+
+PR = "r1"
+
+SRC_URI = "${DEBIAN_MIRROR}/main/d/${BPN}/${BPN}_${PV}.tar.gz"
+SRC_URI[md5sum] = "7fdd5f8395162d8728d4b79e97b9819e"
+SRC_URI[sha256sum] = "d62e98fee5b1a758d83b62eed8d8bdec473677ff782fed89fc4ae3ba3f381401"
+
+inherit autotools update-alternatives
+
+do_configure_prepend() {
+    sed -i -e 's:tempfile.1 which.1:which.1:g' Makefile.am
+}
+
+do_install_append() {
+    if [ "${base_bindir}" != "${bindir}" ]; then
+        # Debian places some utils into ${base_bindir} as does busybox
+        install -d ${D}${base_bindir}
+        for app in run-parts tempfile; do
+            mv ${D}${bindir}/$app ${D}${base_bindir}/$app
+        done
+    fi
+}
+
+ALTERNATIVE_PRIORITY="100"
+ALTERNATIVE_${PN} = "add-shell installkernel remove-shell run-parts savelog tempfile which"
+
+ALTERNATIVE_LINK_NAME[add-shell]="${sbindir}/add-shell"
+ALTERNATIVE_LINK_NAME[installkernel]="${sbindir}/installkernel"
+ALTERNATIVE_LINK_NAME[remove-shell]="${sbindir}/remove-shell"
+ALTERNATIVE_LINK_NAME[run-parts]="${base_bindir}/run-parts"
+ALTERNATIVE_LINK_NAME[savelog]="${bindir}/savelog"
+ALTERNATIVE_LINK_NAME[tempfile]="${base_bindir}/tempfile"
+ALTERNATIVE_LINK_NAME[which]="${bindir}/which"


### PR DESCRIPTION
This causes the configuration to be done at build time
rather than on first boot.  It also fixes errors in the
postinstall scripts that were not getting caught.

Submitted for upstream review and merge here:
    http://lists.openembedded.org/pipermail/openembedded-devel/2014-June/096576.html
    http://lists.openembedded.org/pipermail/openembedded-devel/2014-June/096577.html

Signed-off-by: Drew Moseley drew_moseley@mentor.com
