### PR TITLE
Revert "connman: Remove connman.service file"

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/connman/connman_1.22.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_1.22.bbappend
@@ -4,3 +4,10 @@ PACKAGECONFIG[wifi] = "--enable-wifi, --disable-wifi,,wpa-supplicant"
 PACKAGECONFIG[bluetooth] = "--enable-bluetooth, --disable-bluetooth,,bluez4"
 PACKAGECONFIG[3g] = "--enable-ofono, --disable-ofono,,ofono"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://connman.service \
+            "
+do_install_append() {
+    cp -f ${WORKDIR}/connman.service ${D}${systemd_unitdir}/system/
+}

--- a/meta-mentor-staging/recipes-connectivity/connman/files/connman.service
+++ b/meta-mentor-staging/recipes-connectivity/connman/files/connman.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Connection service
+After=syslog.target
+
+[Service]
+Type=dbus
+BusName=net.connman
+Restart=on-failure
+EnvironmentFile=-/tmp/connman.env
+ExecStartPre=/bin/sh -c "if grep 'nfsroot\|ip=' /proc/cmdline; then ETH_IFACE=$(ip addr | grep 'eth[0-9]:' | grep 'UP' | sed -e 's,\(eth[0-9]\)\(.*\),\1,' -e 's,^.*: ,,' ); NET_ADDR=$(cat /proc/cmdline | sed -ne 's/^.*ip=\([^ :]*\).*$/\1/p'); echo -e 'OPT=-I '$ETH_IFACE'\nOPT2='$ETH_IFACE'\nNET_ADDR='$NET_ADDR' ' > /tmp/connman.env; fi "
+ExecStart=/usr/sbin/connmand -n $OPT
+ExecStartPost=/bin/sh -c "if [ ! -z \"$OPT\" ] && [ \"$NET_ADDR\" = \"dhcp\" ]; then /sbin/udhcpc -i $OPT2; fi"
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Removing the service file breaks the nfs-boot functionality, hence reverting

This reverts commit 6b3707197b5f021973ee79dac03dd4dc22e6d6d7.
