### PR TITLE
connman: handle ip=off in connman.service file

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/connman/files/connman.service
+++ b/meta-mentor-staging/recipes-connectivity/connman/files/connman.service
@@ -8,7 +8,7 @@ BusName=net.connman
 Restart=on-failure
 EnvironmentFile=-/tmp/connman.env
 ExecStartPre=/bin/sh -c "if grep 'nfsroot\|ip=' /proc/cmdline; then ETH_IFACE=$(ip addr | grep 'eth[0-9]:' | grep 'UP' | sed -e 's,\(eth[0-9]\)\(.*\),\1,' -e 's,^.*: ,,' ); NET_ADDR=$(cat /proc/cmdline | sed -ne 's/^.*ip=\([^ :]*\).*$/\1/p'); echo -e 'OPT=-I '$ETH_IFACE'\nOPT2='$ETH_IFACE'\nNET_ADDR='$NET_ADDR' ' > /tmp/connman.env; fi "
-ExecStart=/usr/sbin/connmand -n $OPT
+ExecStart=/bin/sh -c "if [ \"$NET_ADDR\" = \"off\" ]; then /usr/sbin/connmand -n; else /usr/sbin/connmand -n $OPT; fi"
 ExecStartPost=/bin/sh -c "if [ ! -z \"$OPT\" ] && [ \"$NET_ADDR\" = \"dhcp\" ]; then /sbin/udhcpc -i $OPT2; fi"
 StandardOutput=null
 


### PR DESCRIPTION
connmand was not being invoked with correct arguments when ip=off is specified in kernel command-line, added a condition to handle this case
