### PR TITLE
bluez5: Allow method calls over dbus for bluetooth daemon

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/bluez/bluez5_5.15.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/bluez/bluez5_5.15.bbappend
@@ -1,4 +1,5 @@
 do_configure_append () {
         sed -i 's/org.bluez.Agent"/org.bluez.Agent1"/' ${WORKDIR}/bluetooth.conf
+	sed -i '/<\/policy>/i\ \ \ \ <allow send_type="method_call"\/>' ${WORKDIR}/bluetooth.conf
 }
 


### PR DESCRIPTION
This patch changes the dbus policy settings in order to allow
calling methods over dbus. bluez5 and pulseaudio rely on this
mechanism to configure media end points. Previously bluetoothd
was failing to configure the media end points with error
org.freedesktop.DBus.Error.AccessDenied, due to which bluetooth
headset and smartphone were unable to connect in A2DP mode.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3135

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
