### PR TITLE
mel: add vfat to minnow MACHINE_FEATURES

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -252,6 +252,9 @@ XSERVER_minnow = "xserver-xorg xf86-input-evdev xf86-input-mouse xf86-input-keyb
 # Don't include the xorg.conf that makes use of EMGD
 BBMASK .= "|/meta-minnow/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend"
 
+# Minnow has USB host, so we need vfat support for USB storage
+MACHINE_FEATURES_append_minnow = " vfat"
+
 # Override minnow's inclusion of linux-firmware in favor of a minimal subset
 # which holds just the wireless firmware
 MACHINE_EXTRA_RRECOMMENDS_remove_minnow = "linux-firmware"


### PR DESCRIPTION
Minnow has USB host, so we need vfat support for USB storage.

JIRA: SB-3161

Signed-off-by: Christopher Larson kergoth@gmail.com
