### PR TITLE
archive-release: for minnow, drop ${RELEASE_IMAGE}.iso

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -66,6 +66,7 @@ DEPLOY_IMAGES[doc] = "List of files from DEPLOY_DIR_IMAGE which will be archived
 # Use IMAGE_EXTENSION_xxx to map image type 'xxx' with real image file
 # extension name(s)
 IMAGE_EXTENSION_live = "hddimg iso"
+IMAGE_EXTENSION_live_minnow = "hddimg"
 
 # Exclude certain image types from the packaged build.
 # This allows us to build in the automated environment for regression,


### PR DESCRIPTION
We only care about the hard disk image (hddimg), not the iso, so don't bother
shipping it. This frees up some space in our release artifacts.

JIRA: SB-2976

Signed-off-by: Christopher Larson kergoth@gmail.com
