### PR TITLE
wpa-supplicant: add missing build time dependency on libgcrypt

### DIFF
--- a/meta-mel/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.1.bbappend
+++ b/meta-mel/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.1.bbappend
@@ -1,5 +1,6 @@
 WPA_SUPPLICANT_TLS_LIB ?= "gnutls"
 DEPENDS := "${@DEPENDS.replace('openssl', '').replace('gnutls', '${WPA_SUPPLICANT_TLS_LIB}' if 'mel' in OVERRIDES.split(':') else 'gnutls openssl')}"
+DEPENDS += "libgcrypt"
 
 do_configure_append_mel () {
     sed -i '/CONFIG_TLS/d' wpa_supplicant/.config


### PR DESCRIPTION
Jira: SB-3222

Signed-off-by: Fahad Arslan Fahad_Arslan@mentor.com
