### PR TITLE
sstate: reduce 32/64bit host sstate reuse problems

### DIFF
--- a/meta-mel/classes/add_build_arch.bbclass
+++ b/meta-mel/classes/add_build_arch.bbclass
@@ -12,10 +12,11 @@ python add_build_march () {
     if '-march' not in build_cflags and build_arch in arch_args:
         d.setVar("BUILD_MARCH", "-march={0}".format(arch_args[build_arch]))
         d.appendVar("BUILD_CFLAGS", " ${BUILD_MARCH}")
+
+        # This is needed to ensure that a change to the BUILD_ARCH won't cause
+        # target signatures to change, which is needed to allow sstate reuse
+        # for target recipes across 32/64 bit hosts.
+        d.appendVarFlag("BUILD_CFLAGS", "vardepsexclude", "BUILD_MARCH")
 }
 add_build_march[eventmask] = "bb.event.ConfigParsed"
 addhandler add_build_march
-
-# We don't want our BUILD_MARCH getting into the signatures for our target
-# recipe tasks, otherwise they end up bound to the host.
-BUILD_CFLAGS[vardepsexclude] += "${@'BUILD_MARCH' if 'class-target' in OVERRIDES.split(':') else ''}"

--- a/meta-mel/conf/distro/include/sstate.inc
+++ b/meta-mel/conf/distro/include/sstate.inc
@@ -1,6 +1,14 @@
-# Ensure the path to the mel install doesn't affect checksums
 python sstate_config_handler () {
-    e.data.appendVar('BB_HASHBASE_WHITELIST', ' MELDIR')
+    d = e.data
+
+    # Ensure the path to the mel install doesn't affect checksums
+    d.appendVar('BB_HASHBASE_WHITELIST', ' MELDIR')
+
+    # These vars shouldn't change except for when BUILD_ARCH does, and that's
+    # already captured via the sstate archive filename. Excluding them should
+    # let us reuse target sstates even if the BUILD_ARCH of the natives
+    # changes (e.g. reuse target between 32 and 64 bit build hosts).
+    d.appendVar("BB_HASHBASE_WHITELIST", " SITEINFO_ENDIANNESS SITEINFO_BITS SIZEOF_POINTER")
 }
 sstate_config_handler[eventmask] = "bb.event.ConfigParsed"
 addhandler sstate_config_handler


### PR DESCRIPTION
BUILD_MARCH, SITEINFO_ENDIANNESS, and SITEINFO_BITS affected native
signatures, and now changes to native signatures also affect target recipes
that depend upon them. Interestingly, changes to BUILD_ARCH will cause natives
to rebuild, but not the target recipes that depend upon them, as BUILD_ARCH is
dynamically produced with ${@}, and its unexpanded form is what goes into
signatures, but the expanded version ends up in the sstate filename. Since the
other variables should only change for native recipes when BUILD_ARCH does, it
should be safe to exclude them from the signatures, and hopefully restore the
ability to reuse target sstate archives between 32 and 64 bit build hosts.

JIRA: SB-2976

Signed-off-by: Christopher Larson chris_larson@mentor.com
