### PR TITLE
sanity_tested_distro: Add Ubuntu-14.04 and remove other unsupported hosts

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -34,10 +34,7 @@ require conf/distro/include/mel-vardeps.conf
 # 2.7. We also do not support Debian, SUSE, or openSUSE at this time.
 SANITY_TESTED_DISTROS = "\
     Ubuntu-12.04 \n\
-    Ubuntu-12.10 \n\
-    Ubuntu-13.04 \n\
-    Fedora-18 \n\
-    Fedora-19 \n\
+    Ubuntu-14.04 \n\
 "
 
 # Forcibly silence PRINC warnings by killing PRINC


### PR DESCRIPTION
JIRA: SB-3254

We currently support ubuntu-12.04 LTS and ubuntu-14.04 LTS distros.
Removed EOL (ubuntu-12.10, ubuntu-13.04 & Fedora 18,19) OS's from list

Signed-off-by: Srikanth Krishnakar Srikanth_Krishnakar@mentor.com
