### PR TITLE
linux-qoriq-sdk: enable autofs kernel config

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk_3.8.13-rt9-fsl.bb
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk_3.8.13-rt9-fsl.bb
@@ -15,6 +15,7 @@ COMPATIBLE_MACHINE = "(p1010rdb|p4080ds)$"
 KERNEL_SRC_URI ?= "http://s3.amazonaws.com/portal.mentor.com/sources/ATP-2014.05/linux-qoriq-sdk-${PV}.tar.xz"
 SRC_URI = "${KERNEL_SRC_URI} \
            file://nbd.cfg \
+           file://autofs.cfg \
           "
 
 SRC_URI[md5sum] = "c9262f6b2f847e1b9019322797bb5205"


### PR DESCRIPTION
Autofs is required by proc-sys-fs-binfmt_misc.automount service which is
currently failing for PPC targets.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3245

Signed-off-by: Fahad Usman fahad_usman@mentor.com
