### PR TITLE
packagegroups: LIC_FILES_CHKSUM not needed for PGs

### DIFF
--- a/meta-mentor-staging/recipes-core/packagegroups/packagegroup-core-qt.bbappend
+++ b/meta-mentor-staging/recipes-core/packagegroups/packagegroup-core-qt.bbappend
@@ -1,2 +1,0 @@
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mentor-staging/recipes-core/packagegroups/packagegroup-core-ssh-openssh.bbappend
+++ b/meta-mentor-staging/recipes-core/packagegroups/packagegroup-core-ssh-openssh.bbappend
@@ -1,2 +1,0 @@
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"


### PR DESCRIPTION
Defining LIC_FILES_CHKSUM is not required for packagegroups anymore.

Signed-off-by: Fahad Usman fahad_usman@mentor.com
