### PR TITLE
consolekit: populate log directory

### DIFF
--- a/meta-mentor-staging/recipes-support/consolekit/02-consolekit.conf
+++ b/meta-mentor-staging/recipes-support/consolekit/02-consolekit.conf
@@ -1,0 +1,1 @@
+d		/var/volatile/log/ConsoleKit		-	-	-	-

--- a/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
+++ b/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
@@ -4,3 +4,13 @@ PACKAGECONFIG[polkit] = "--with-polkit,--without-polkit,polkit,"
 
 # For glib-gettextize
 DEPENDS += "glib-2.0-native"
+
+SRC_URI += " \
+    file://02-consolekit.conf \
+"
+
+do_install_append () {
+    rm -rf ${D}${localstatedir}/log ${D}${localstatedir}/run ${D}${localstatedir}/volatile
+    install -D -m 0644 ${WORKDIR}/02-consolekit.conf ${D}${sysconfdir}/tmpfiles.d/02-consolekit.conf
+    sed -i '/After=/a After=systemd-tmpfiles-setup.service' ${D}${systemd_unitdir}/system/console-kit-log-system-start.service
+}


### PR DESCRIPTION
Replace /var/log/ConsoleKit with tmpfiles.d conf because
/var/log is a simlink pointing to /var/volatile/log which is tmpfs.

Ported from:
    https://github.com/MentorEmbedded/mel-meta-atp/commit/4e90dd8d21593b7fa956153b2043d71a3aab5ffc

Signed-off-by: Drew Moseley drew_moseley@mentor.com
