### PR TITLE
connman: rdep on virtual/libbluetooth

### DIFF
--- a/meta-mel/recipes-connectivity/connman/connman_1.24.bbappend
+++ b/meta-mel/recipes-connectivity/connman/connman_1.24.bbappend
@@ -1,4 +1,5 @@
 python () {
     if 'mel' in d.getVar('OVERRIDES', True).split(':'):
         d.setVarFlag('PACKAGECONFIG', 'bluetooth', d.getVarFlag('PACKAGECONFIG', 'bluetooth', True).replace('bluez4', '${VIRTUAL-RUNTIME_bluetooth-stack}'))
+        d.setVar('RDEPENDS_connman', d.getVar('RDEPENDS_connman', True).replace('bluez4', '${PREFERRED_PROVIDER_virtual/libbluetooth}'))
 }


### PR DESCRIPTION
Replace bluez4 in RDEPENDS for connman with bluetooth block
implementation.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
