### PR TITLE
mel: set ADE_VERSION with fixed timestamp

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -18,6 +18,8 @@ ADE_PROVIDER = "Mentor Graphics Corporation"
 ADE_SITENAME = "Application Development Environment for ${DISTRO_NAME}"
 ADE_SECTIONS = ""
 ADE_SECTIONS_EXCLUDED = "locale"
+ADE_VERSION = "${@'${SDK_VERSION}'.replace('+snapshot', '')}"
+ADE_VERSION_append := ".${@str(int(time.time()))}"
 
 # Default image for our installers
 RELEASE_IMAGE ?= "core-image-base"


### PR DESCRIPTION
This ensures that the ADE_VERSION used in create-ade aligns with the
ADE_VERSION used in ade-support.

JIRA: SB-3335

Signed-off-by: Christopher Larson chris_larson@mentor.com
