### PR TITLE
linuxi-qoriq-sdk: add p1010rdb and p2020rdb to compatible machines

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers_3.8.13-rt9-fsl.bb
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk-headers_3.8.13-rt9-fsl.bb
@@ -12,7 +12,7 @@ RRECOMMENDS_${PN}-dbg = "linux-libc-headers-dev (= ${EXTENDPKGV})"
 
 UPSTREAM_PR = "1"
 PV = "3.8.13-rt9-fsl-${UPSTREAM_PR}"
-COMPATIBLE_MACHINE = "(p1010rdb|p4080ds)$"
+COMPATIBLE_MACHINE = "(p1010rdb|p4080ds|p2020rdb|p1020rdb)$"
 
 KERNEL_SRC_URI ?= "http://s3.amazonaws.com/portal.mentor.com/sources/ATP-2014.05/linux-qoriq-sdk-${PV}.tar.xz"
 SRC_URI = "${KERNEL_SRC_URI}"

--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk_3.8.13-rt9-fsl.bb
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq-sdk_3.8.13-rt9-fsl.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qoriq-sdk.inc
 DEPENDS += "lzop-native bc-native libgcc"
 UPSTREAM_PR = "1"
 PV = "3.8.13-rt9-fsl-${UPSTREAM_PR}"
-COMPATIBLE_MACHINE = "(p1010rdb|p4080ds)$"
+COMPATIBLE_MACHINE = "(p1010rdb|p4080ds|p2020rdb|p1020rdb)$"
 
 KERNEL_SRC_URI ?= "http://s3.amazonaws.com/portal.mentor.com/sources/ATP-2014.05/linux-qoriq-sdk-${PV}.tar.xz"
 SRC_URI = "${KERNEL_SRC_URI} \


### PR DESCRIPTION
lockdown kernel sources to tarball version for p2020rdb and p1010rdb by
adding them to compatible machines of kernel and kernel headers recipe.

Signed-off-by: Fahad Usman fahad_usman@mentor.com
