### PR TITLE
python-native: drop changes merged upstream

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python-native_2.7.3.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python-native_2.7.3.bbappend
@@ -1,5 +1,0 @@
-# We don't want modules in ~/.local being used in preference to those
-# installed in the native sysroot, so disable user site support.
-do_install_append () {
-    sed -i -e 's,^\(ENABLE_USER_SITE = \).*,\1False,' ${D}${libdir}/python${PYTHON_MAJMIN}/site.py
-}


### PR DESCRIPTION
Drop changes available in upstream poky as of commit
id 77369679efb68ef89141fff914ccac93c836853e.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
