### PR TITLE
setup-mel-builddir: Enable LTTNG in MEL-Lite

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -295,7 +295,6 @@ if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$MEL_DISTRO\'/" $BUILDDIR/conf/local.conf
     if [ "$MEL_DISTRO" == "mel-lite" ]; then
         sed -i -e 's@\(CORE_IMAGE_EXTRA_INSTALL.*\)oprofile\(.*\)@\1\2@' \
-               -e 's@\(EXTRA_IMAGE_FEATURES.*\)tools-profile\(.*\)@\1\2@' \
                 $BUILDDIR/conf/local.conf
     fi
 fi


### PR DESCRIPTION
Signed-off-by: Drew Moseley drew_moseley@mentor.com
