### PR TITLE
u-boot-qoriq: add 'u-boot' to RPROVIDES

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bbappend
@@ -3,3 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
             file://0001-powerpc-add-bss-plt-to-LDFLAGS.patch \
            "
+
+RPROVIDES_${PN} += "u-boot"


### PR DESCRIPTION
the name of u-boot recipe has been changed in latest up-stream master of
meta-fsl-ppl, so we need to explicitly add 'u-boot' to its RPROVIDES as the
image has a runtime dependency on u-boot

http://jira.alm.mentorg.com:8080/browse/SB-3426

Signed-off-by: Fahad Usman fahad_usman@mentor.com
