### PR TITLE
sysklogd: fix packaging issue

### DIFF
--- a/meta-mentor-staging/recipes-extended/sysklogd/sysklogd_1.5.bbappend
+++ b/meta-mentor-staging/recipes-extended/sysklogd/sysklogd_1.5.bbappend
@@ -1,0 +1,4 @@
+python __anonymous() {
+    if not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d):
+        d.setVar("INHIBIT_UPDATERCD_BBCLASS", "1")
+}


### PR DESCRIPTION
sysklogd inherits update-rc.d, but not from systemd.bbclass, so we need to
set INHIBIT_UPDATERCD_BBCLASS to "1" if 'sysvinit' is not in
DISTRO_FEATURES so that it does not add any un-necessary package
dependencies

http://jira.alm.mentorg.com:8080/browse/SB-3428

Signed-off-by: Fahad Usman fahad_usman@mentor.com
