### PR TITLE
mel: support per-layer downloads and sstate

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -153,11 +153,19 @@ require conf/distro/include/kernel-link.inc
 # Default to ipk packaging
 PACKAGE_CLASSES ?= "package_ipk"
 
+# Pull in info about what layer a recipe came from
+INHERIT += "extra_layerinfo"
+
+# Support pulling downloads and sstate from inside individual layers. This
+# will let us ship self contained layers to a release without risking file
+# conflicts between them.
+PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERPATH}/downloads\n' if '${RECIPE_LAYERPATH}' != 'None' else ''}"
+SSTATE_MIRROR_SITES_prepend = "${@' '.join('file://%s/sstate-cache' % l for l in '${BBLAYERS}'.split())} "
+
 # Populate a tree of downloads organized by layer for archive-release
 ARCHIVE_RELEASE_DL_TOPDIR ?= "${DEPLOY_DIR}/release-downloads"
 DL_LICENSE_INCLUDE ?= "*"
-
-INHERIT += "archive-release-downloads extra_layerinfo"
+INHERIT += "archive-release-downloads"
 RECIPE_LAYER_BASENAME = "${@os.path.basename(get_layer_rootdir(RECIPE_LAYERPATH, d))}"
 ARCHIVE_RELEASE_DL_DIR = "${ARCHIVE_RELEASE_DL_TOPDIR}/${RECIPE_LAYER_BASENAME}"
 


### PR DESCRIPTION
This will pull downloads from <layer path>/downloads and sstate from <layer
path>/sstate-cache.

JIRA: SB-3520

Signed-off-by: Christopher Larson chris_larson@mentor.com
