### PR TITLE
mel: mask out old bbappend in meta-virtualization

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -230,7 +230,7 @@ include conf/distro/include/qt5-mel.conf
 # Mask out meta-ivi's connman, libpcap, and pulseaudio appends, as it makes it
 # impossible to add bluetooth to its PACKAGECONFIG, so we need to undo the
 # damage.
-BBMASK ?= "(/meta-ivi/(recipes-multimedia/pulseaudio|recipes-connectivity/(connman|ofono|libpcap))/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/)"
+BBMASK ?= "(/meta-ivi/(recipes-multimedia/pulseaudio|recipes-connectivity/(connman|ofono|libpcap))/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/|/meta-virtualization/recipes-kernel/linux/linux-yocto_3\.4)"
 
 # The user's shell shouldn't be allowed to affect the build (and it can break
 # the flock command, if the user's shell isn't POSIX compliant). This should


### PR DESCRIPTION
linux-yocto 3.4 is no longer upstream.

Signed-off-by: Christopher Larson chris_larson@mentor.com
