### PR TITLE
latencytop: Remove gtk+ dependency and configuration option.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -123,6 +123,12 @@ DISTRO_FEATURES_append = " vfat"
 # Ensure fbset is in busybox configuration, and fbset-modes is included
 PACKAGECONFIG_append_pn-busybox = " fbset"
 
+# Ensure that we are not getting GUI for latencytop.
+PACKAGECONFIG_pn-latencytop = ""
+
+# Ensure that we are not getting GUI for sysprof.
+PACKAGECONFIG_pn-sysprof = ""
+
 # Sane default locales for images
 GLIBC_GENERATE_LOCALES ?= "en_US en_US.UTF-8"
 IMAGE_LINGUAS ?= "en-us"

--- a/meta-mentor-staging/recipes-kernel/latencytop/latencytop_0.5.bbappend
+++ b/meta-mentor-staging/recipes-kernel/latencytop/latencytop_0.5.bbappend
@@ -1,0 +1,6 @@
+DEPENDS := "${@oe_filter_out('gtk+', '${DEPENDS}', d)}"
+
+PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}"
+PACKAGECONFIG[x11] = ",,gtk+"
+
+EXTRA_OEMAKE_X = "${@bb.utils.contains('PACKAGECONFIG', 'x11', 'HAS_GTK_GUI=1', '', d)}"

--- a/meta-mentor-staging/recipes-kernel/sysprof/sysprof_git.bbappend
+++ b/meta-mentor-staging/recipes-kernel/sysprof/sysprof_git.bbappend
@@ -1,0 +1,6 @@
+DEPENDS := "${@oe_filter_out('gtk\+|libglade', '${DEPENDS}', d)}"
+
+
+PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)}"
+PACKAGECONFIG[x11] = ",,gtk+ libglade"
+


### PR DESCRIPTION
- Latencytop is bringing graphical recipes in our console image. We dont need
  graphical view of latencytop at this time even for sato image so removing it.

Signed-off-by: Noor Ahsan noor_ahsan@mentor.com
