### PR TITLE
mel-security: add security related changes to mel.conf

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -227,6 +227,9 @@ require conf/blocks/speech-recognition.conf
 # Handle Qt5 changes
 include conf/distro/include/qt5-mel.conf
 
+# SELinux Security Changes 
+include conf/distro/include/mel-security.conf
+
 # Mask out meta-ivi's connman, libpcap, and pulseaudio appends, as it makes it
 # impossible to add bluetooth to its PACKAGECONFIG, so we need to undo the
 # damage.


### PR DESCRIPTION
This patch is to include the security layer related
changes to mel.conf

JIRA: SB-3615 

Signed-off-by: Shrikant Bobade Shrikant_Bobade@mentor.com
