### PR TITLE
mel: replace suffix -emgd with -gl for MinnowBoard

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -278,6 +278,9 @@ MACHINE_HWCODECS_append = " "
 XSERVERCODECS_remove = "emgd-driver-video emgd-gst-plugins-va emgd-gst-plugins-mixvideo gst-va-intel"
 XSERVERCODECS_append = " "
 
+# Replace "-emgd" suffix with a generic "-gl" for opengl related packages for MinnowBoard
+GLSUFFIX_minnow = "-gl"
+
 # Changing a mirror shouldn't force a refetch/rebuild
 SRC_URI[vardepsexclude] += "\
     APACHE_MIRROR \


### PR DESCRIPTION
Replace "-emgd" suffix with a generic "-gl" for opengl
related packages for MinnowBoard since we are not
building emgd related stuff due to licensing concerns.

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
