### PR TITLE
pointercal-xinput: allow package to be empty for MinnowBoard

### DIFF
--- a/meta-mel/minnow/recipes-graphics/xinput-calibrator/pointercal-xinput_%.bbappend
+++ b/meta-mel/minnow/recipes-graphics/xinput-calibrator/pointercal-xinput_%.bbappend
@@ -1,0 +1,1 @@
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Allow pointercal-xinput package to be empty so that required
ipk is generated for ade to build successfully.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3629

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
