### PR TITLE
linux-yocto: link kgdboc after the driver for UART

### DIFF
--- a/meta-mel/minnow/recipes-kernel/linux/linux-yocto/0001-kgdboc-change-the-linking-order-of-kgdboc.patch
+++ b/meta-mel/minnow/recipes-kernel/linux/linux-yocto/0001-kgdboc-change-the-linking-order-of-kgdboc.patch
@@ -1,0 +1,39 @@
+
+Upstream-Status: pending
+
+From c5af146543a87d46d967102fb101e29477716410 Mon Sep 17 00:00:00 2001
+From: Yasir-Khan <yasir_khan@mentor.com>
+Date: Mon, 29 Sep 2014 16:25:42 +0500
+Subject: [PATCH] kgdboc: change the linking order of kgdboc
+
+On MinnowBoard, when kgdboc and pch_uart are statically compiled,
+kgdboc executes prior to pch_uart getting registerd. As a result,
+kgdboc is unable to find serial console and kgdb mode is not
+entered during boot. Changed the order of linking so that
+pch_uart initialization takes place before kgdboc module is run.
+
+Signed-off-by: Yasir-Khan <yasir_khan@mentor.com>
+---
+ drivers/tty/serial/Makefile |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/tty/serial/Makefile b/drivers/tty/serial/Makefile
+index eedfec4..9bea43d 100644
+--- a/drivers/tty/serial/Makefile
++++ b/drivers/tty/serial/Makefile
+@@ -65,7 +65,6 @@ obj-$(CONFIG_SERIAL_KGDB_NMI) += kgdb_nmi.o
+ obj-$(CONFIG_SERIAL_KS8695) += serial_ks8695.o
+ obj-$(CONFIG_SERIAL_OMAP) += omap-serial.o
+ obj-$(CONFIG_SERIAL_ALTERA_UART) += altera_uart.o
+-obj-$(CONFIG_KGDB_SERIAL_CONSOLE) += kgdboc.o
+ obj-$(CONFIG_SERIAL_QE) += ucc_uart.o
+ obj-$(CONFIG_SERIAL_TIMBERDALE)	+= timbuart.o
+ obj-$(CONFIG_SERIAL_GRLIB_GAISLER_APBUART) += apbuart.o
+@@ -85,3 +84,4 @@ obj-$(CONFIG_SERIAL_AR933X)   += ar933x_uart.o
+ obj-$(CONFIG_SERIAL_EFM32_UART) += efm32-uart.o
+ obj-$(CONFIG_SERIAL_ARC)	+= arc_uart.o
+ obj-$(CONFIG_SERIAL_RP2)	+= rp2.o
++obj-$(CONFIG_KGDB_SERIAL_CONSOLE) += kgdboc.o
+-- 
+1.7.9.5
+

--- a/meta-mel/minnow/recipes-kernel/linux/linux-yocto_3.10.bbappend
+++ b/meta-mel/minnow/recipes-kernel/linux/linux-yocto_3.10.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI_append_minnow = " file://0001-kgdboc-change-the-linking-order-of-kgdboc.patch \
+"


### PR DESCRIPTION
On MinnowBoard, when kgdboc and pch_uart are statically compiled,
kgdboc executes prior to pch_uart getting registerd. As a result,
kgdboc is unable to find serial console and kgdb mode is not
entered during boot. Changed the order of linking so that
pch_uart initialization takes place before kgdboc module is run.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3632

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
