### PR TITLE
Migrate last remaining bits from meta-ro-rootfs

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -232,6 +232,13 @@ include conf/distro/include/mel-security.conf
 # damage.
 BBMASK ?= "(/meta-ivi/(recipes-multimedia/pulseaudio|recipes-connectivity/(connman|ofono|libpcap))/|/meta-ivi/recipes-multimedia/libtiff/|/meta-ivi/recipes-core-ivi/eglibc/|/meta-virtualization/recipes-kernel/linux/linux-yocto_3\.4)"
 
+# Ensure we have the writable paths we need in a read-only rootfs
+VOLATILE_BINDS_append = "\
+    /var/volatile/root-home ${ROOT_HOME}\n\
+    /var/volatile/media /media\n\
+    /var/volatile/resolv.conf /etc/resolv.conf\n\
+"
+
 # The user's shell shouldn't be allowed to affect the build (and it can break
 # the flock command, if the user's shell isn't POSIX compliant). This should
 # go upstream.

--- a/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
@@ -1,0 +1,6 @@
+# Ensure that an empty resolv.conf exists before connman writes to it. This
+# way we have it in place in the read-only /, and we can bind mount over it.
+do_install_append () {
+    install -d ${D}${sysconfdir}
+    touch ${D}${sysconfdir}/resolv.conf
+}


### PR DESCRIPTION
volatile-binds and associated bits were submitted and merged upstream, so
meta-ro-rootfs is no longer necessary. That said, we had different
configuration than upstream now has, so adjust mel.conf appropriately.
