### PR TITLE
make: Remove "Disables MAKEINFO due to texinfo 5.x compat issue with mak...

### DIFF
--- a/meta-mentor-staging/recipes-devtools/make/make_3.81.bbappend
+++ b/meta-mentor-staging/recipes-devtools/make/make_3.81.bbappend
@@ -1,3 +1,0 @@
-# Newer texinfo versions lose compatibility with make.texi, and lacking
-# expertise with texinfo, we'll disable makeinfo use.
-EXTRA_OEMAKE += "'MAKEINFO=true'"


### PR DESCRIPTION
...e.texi:

Poky has a proper fix for this issue. This bbappend can be removed
Reverts : 6132aec9eec95a17f3774759773baf1ffc18ea4a

Signed-off-by: Abhijit Potnis Abhijit_Potnis@mentor.com
