### PR TITLE
consolekit: avoid shipping directory to /var/log

### DIFF
--- a/meta-mentor-staging/recipes-support/consolekit/consolekit/02-consolekit.conf
+++ b/meta-mentor-staging/recipes-support/consolekit/consolekit/02-consolekit.conf
@@ -1,0 +1,1 @@
+d		/var/volatile/log/ConsoleKit		-	-	-	-

--- a/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
+++ b/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://02-consolekit.conf \
+"
+
+do_install_append () {
+    rm -rf ${D}${localstatedir}/log ${D}${localstatedir}/run ${D}${localstatedir}/volatile
+    install -D -m 0644 ${WORKDIR}/02-consolekit.conf ${D}${sysconfdir}/tmpfiles.d/02-consolekit.conf
+    sed -i '/After=/a After=systemd-tmpfiles-setup.service' ${D}${base_libdir}/systemd/system/console-kit-log-system-start.service
+}


### PR DESCRIPTION
Replace /var/log/ConsoleKit with tmpfiles.d conf because
/var/log is a simlink pointing to /var/volatile/log  which
is tmpfs.

From meta-atp rev 4e90dd8d21593b7fa956153b2043d71a3aab5ffc.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3630

Signed-off-by: Sergey Ignatov sergey_ignatov@mentor.com
Signed-off-by: Yasir-Khan yasir_khan@mentor.com
