### PR TITLE
sysprof: add missing dependency on glib-2.0

### DIFF
--- a/meta-mentor-staging/recipes-kernel/sysprof/sysprof_git.bbappend
+++ b/meta-mentor-staging/recipes-kernel/sysprof/sysprof_git.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://gui-argument.patch"
 
 DEPENDS := "${@oe_filter_out('gtk\+|libglade$', '${DEPENDS}', d)}"
+DEPENDS += "glib-2.0"
 
 PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gui', '', d)}"
 PACKAGECONFIG[gui] = "--enable-gui,--disable-gui,gtk+ libglade"


### PR DESCRIPTION
Adds dependency on glib-2.0 to resolve the below build error

| checking for CORE_DEP... no
| configure: error: sysprof dependencies not satisfied

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
