### PR TITLE
conf: exclude bbappends in meta-xilinx

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -249,6 +249,9 @@ XSERVER_minnow = "xserver-xorg xf86-input-evdev xf86-input-mouse xf86-input-keyb
 # Don't include the xorg.conf that makes use of EMGD
 BBMASK .= "|/meta-minnow/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend"
 
+# Drop gdb-7.7 bbappends from meta-xilinx
+BBMASK .= "|/meta-xilinx/recipes-devtools/gdb/gdb.*_7\.7%.*\.bbappend"
+
 # Minnow has USB host, so we need vfat support for USB storage
 MACHINE_FEATURES_append_minnow = " vfat"
 


### PR DESCRIPTION
meta-xilinx contains bbappend files for three recipes we do not provide
anywhere in our tree.  Use BBMASK to automatically remove them when using
the meta-xilinx layer.

Signed-off-by: Joe MacDonald joe_macdonald@mentor.com
