### PR TITLE
canutils: add iproute2 to configure CAN interface

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-extended/socketcan/canutils_4.0.6.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/socketcan/canutils_4.0.6.bbappend
@@ -1,0 +1,2 @@
+#add iproute2 to configure CAN interface
+RDEPENDS_${PN} += "iproute2"


### PR DESCRIPTION
Previously ip tool from busybox was failing to configure
CAN interface. Added iproute2 in RDEPENDS so that it
can be used to configure CAN interface.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-3667

Signed-off-by: Yasir-Khan yasir_khan@mentor.com
