### PR TITLE
wayland/weston: do not set preferred version, as v1.5.0 is built

### DIFF
--- a/meta-mel/conf/distro/include/mel-versions.conf
+++ b/meta-mel/conf/distro/include/mel-versions.conf
@@ -3,7 +3,3 @@ PREFERRED_VERSION_udev_am37x-evm = "164"
 PREFERRED_VERSION_udev_dm37x-evm = "164"
 
 include conf/distro/include/qt5-versions.inc
-
-# Don't use glsdk 1.3.0 recipes
-PREFERRED_VERSION_weston ?= "1.4.0"
-PREFERRED_VERSION_wayland ?= "1.4.0"


### PR DESCRIPTION
Since there is no wayland/weston 1.4 is available from poky, do
not set un-available version which throws warning during parse:

WARNING:
NOTE: preferred version 1.4.0 of wayland not available (for item wayland)
NOTE: versions of wayland available: 1.5.0
NOTE: preferred version 1.4.0 of weston not available (for item weston)
NOTE: versions of weston available: 1.5.0

Signed-off-by: Srikanth Krishnakar Srikanth_Krishnakar@mentor.com
