### PR TITLE
setup-mel-builddir: Remove bash-specific syntax.

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -293,7 +293,7 @@ setup_builddir "$@" || exit $?
 MEL_DISTRO="${MEL_DISTRO:-mel}"
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$MEL_DISTRO\'/" $BUILDDIR/conf/local.conf
-    if [ "$MEL_DISTRO" == "mel-lite" ]; then
+    if [ "$MEL_DISTRO" = "mel-lite" ]; then
         sed -i -e 's@\(CORE_IMAGE_EXTRA_INSTALL.*\)oprofile\(.*\)@\1\2@' \
                 $BUILDDIR/conf/local.conf
     fi


### PR DESCRIPTION
Remove the bash-specific test to ensure that this will work if
the system default shell is dash which is the default on new
Ubuntu installs.

Signed-off-by: Drew Moseley drew_moseley@mentor.com
