### PR TITLE
console-image, core-image-sato: Add quota to rootfs

### DIFF
--- a/meta-mel/core/recipes-sato/images/core-image-sato.bbappend
+++ b/meta-mel/core/recipes-sato/images/core-image-sato.bbappend
@@ -1,1 +1,2 @@
 IMAGE_FEATURES .= "${@base_contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
+IMAGE_INSTALL += " quota"

--- a/meta-mel/recipes-core/images/console-image.bb
+++ b/meta-mel/recipes-core/images/console-image.bb
@@ -13,3 +13,4 @@ LICENSE = "MIT"
 inherit core-image
 
 IMAGE_FEATURES .= "${@base_contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
+IMAGE_INSTALL += " quota"


### PR DESCRIPTION
JIRA: SB-3746

Add quota support in the rootfs

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
