### PR TITLE
multi-machine: fix failure with /bin/sh as dash

### DIFF
--- a/scripts/multi-machine
+++ b/scripts/multi-machine
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2007-2012 Mentor Graphics Corporation
 #


### PR DESCRIPTION
The script itself doesn't need bash, but it seems our setup scripts don't like
it much at this time.

Signed-off-by: Christopher Larson chris_larson@mentor.com
