### PR TITLE
mux-server: get rid of 'No GNU_HASH in the elf binary' warning

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-virtualization/mux-server/mux-server_1.02.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-virtualization/mux-server/mux-server_1.02.bbappend
@@ -1,0 +1,1 @@
+TARGET_CC_ARCH += "${LDFLAGS}"


### PR DESCRIPTION
Signed-off-by: Fahad Usman fahad_usman@mentor.com
