### PR TITLE
sed: rrec on locale-base-ru-ru, not rdep

### DIFF
--- a/meta-mentor-staging/recipes-extended/sed/sed_4.2.2.bbappend
+++ b/meta-mentor-staging/recipes-extended/sed/sed_4.2.2.bbappend
@@ -1,0 +1,5 @@
+# Remove hardcoded dependency upon locale-base-ru-ru in favor of
+# a recommendation, as it isn't always available, depending on the value of
+# GLIBC_GENERATE_LOCALES.
+RDEPENDS_${PN}-ptest_remove = "locale-base-ru-ru"
+RRECOMMENDS_${PN}-ptest += "locale-base-ru-ru"


### PR DESCRIPTION
This locale package isn't guaranteed to exist, depending on the value of
GLIBC_GENERATE_LOCALES.

JIRA: SB-3882

Signed-off-by: Christopher Larson chris_larson@mentor.com
