### PR TITLE
mel: add ADE_TIMESTAMP to the config whitelist

### DIFF
--- a/meta-mel/conf/distro/include/ade-version.inc
+++ b/meta-mel/conf/distro/include/ade-version.inc
@@ -1,0 +1,8 @@
+ADE_TIMESTAMP := "${@str(int(time.time()))}"
+ADE_VERSION ?= "${@'${SDK_VERSION}'.replace('+snapshot', '')}.${ADE_TIMESTAMP}"
+
+python ade_version_setup () {
+    e.data.appendVar("BB_HASHCONFIG_WHITELIST", " ADE_TIMESTAMP")
+}
+ade_version_setup[eventmask] = "bb.event.ConfigParsed"
+addhandler ade_version_setup

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -17,11 +17,10 @@ MELDIR ?= "${COREBASE}/.."
 ADE_PROVIDER ?= "Mentor Graphics Corporation"
 ADE_IDENTIFIER ?= "${MACHINE}-${ADE_VERSION}"
 ADE_SITENAME ?= "ADE for ${ADE_IDENTIFIER}"
-
-ADE_TIMESTAMP := "${@str(int(time.time()))}"
-ADE_VERSION ?= "${@'${SDK_VERSION}'.replace('+snapshot', '')}.${ADE_TIMESTAMP}"
 ADE_SECTIONS = ""
 ADE_SECTIONS_EXCLUDED = "locale"
+
+require conf/distro/include/ade-version.inc
 
 # Default image for our installers
 RELEASE_IMAGE ?= "console-image"


### PR DESCRIPTION
This prevents a full reparse from occurring every time. The parse cache was
useless since the timestamp kept changing, invalidating it.

JIRA: SB-3922

Signed-off-by: Christopher Larson chris_larson@mentor.com
