### PR TITLE
user_features.bbclass: also process DISTRO_FEATURES_LIBC

### DIFF
--- a/meta-mel/classes/user_features.bbclass
+++ b/meta-mel/classes/user_features.bbclass
@@ -1,16 +1,16 @@
 # Add support for 'USER_FEATURES', which is a mechanism by which a user can
-# exert control over DISTRO_FEATURES from local.conf.
+# exert control over DISTRO_FEATURES from local.conf. At this point it's just
+# a convenience wrapper around _append and _remove.
 #
 # To add a feature, simply add it to USER_FEATURES. To remove a feature, add
 # the feature prefixed by ~. For example: USER_FEATURES += "bluetooth"
 
 USER_FEATURES ?= ""
 USER_FEATURES[type] = "list"
+USER_FEATURES_HANDLED_VARS = "DISTRO_FEATURES_LIBC DISTRO_FEATURES"
+USER_FEATURES_HANDLED_VARS[type] = "list"
 
 python process_user_features () {
-    if not isinstance(e, bb.event.ConfigParsed):
-        return
-
     l = e.data.createCopy()
     l.finalize()
     oe_import(l)
@@ -26,9 +26,22 @@ python process_user_features () {
         else:
             to_add.add(feature)
 
-    distro_features = l.getVar('DISTRO_FEATURES', True).split()
-    distro_features = filter(lambda f: f not in to_remove, distro_features)
-    distro_features.extend(to_add)
-    e.data.setVar('DISTRO_FEATURES', ' '.join(distro_features))
+    # If a feature we want to add is listed in the _DEFAULT variable, then we
+    # know which variable it belongs in, so add it there rather than
+    # DISTRO_FEATURES. Also remove from all the vars, not just
+    # DISTRO_FEATURES.
+    for var in oe.data.typed_value('USER_FEATURES_HANDLED_VARS', l):
+        defvar = var + '_DEFAULT'
+        if to_add and defvar in l:
+            defvalue = set((l.getVar(defvar, True) or '').split())
+            to_add_here = set(a for a in to_add if a in defvalue)
+            to_add -= to_add_here
+            e.data.appendVar(var, ' ' + ' '.join(to_add_here))
+
+        e.data.setVar(var + '_remove', ' '.join(to_remove))
+
+    if to_add:
+        e.data.appendVar('DISTRO_FEATURES', ' ' + ' '.join(to_add))
 }
+process_user_features[eventmask] = "bb.event.ConfigParsed"
 addhandler process_user_features


### PR DESCRIPTION
If a feature we want to add is listed in DISTRO_FEATURES_LIBC_DEFAULT, then
add it to DISTRO_FEATURES_LIBC. Remove any features we want to remove from
both DISTRO_FEATURES_LIBC and DISTRO_FEATURES.

JIRA: SB-3931

Signed-off-by: Christopher Larson chris_larson@mentor.com
