### PR TITLE
local.conf.sample: drop oprofile from CORE_IMAGE_EXTRA_INSTALL

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -21,8 +21,9 @@ MACHINE ??= "qemux86"
 #TCLIBC = "uclibc"
 
 # The CORE_IMAGE_EXTRA_INSTALL variable allows extra individual packages to be
-# added to any of the "core" images (e.g. core-image-base,
-# core-image-minimal).
+# added to any of the images inheriting core-image.bbclass, including the
+# "core" images (e.g. core-image-base, core-image-minimal) as well as
+# console-image.
 #CORE_IMAGE_EXTRA_INSTALL += "bash"
 
 # The EXTRA_IMAGE_FEATURES variable allows groups of packages to be added to


### PR DESCRIPTION
This package is already included by default via tools-profile. Of course, we
still need an example usage of CORE_IMAGE_EXTRA_INSTALL, so comment it out and
change the package to something else, I chose bash as a straightforward option
which is in oe-core.

JIRA: SB-3999

Signed-off-by: Christopher Larson chris_larson@mentor.com
