### PR TITLE
consolekit: use systemd_unitdir for modifications

### DIFF
--- a/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
+++ b/meta-mentor-staging/recipes-support/consolekit/consolekit_0.4.6.bbappend
@@ -7,5 +7,5 @@ SRC_URI += " \
 do_install_append () {
     rm -rf ${D}${localstatedir}/log ${D}${localstatedir}/run ${D}${localstatedir}/volatile
     install -D -m 0644 ${WORKDIR}/02-consolekit.conf ${D}${sysconfdir}/tmpfiles.d/02-consolekit.conf
-    ${@bb.utils.contains("DISTRO_FEATURES", "systemd", "sed -i '/After=/a After=systemd-tmpfiles-setup.service' ${D}${base_libdir}/systemd/system/console-kit-log-system-start.service", "", d)}
+    ${@bb.utils.contains("DISTRO_FEATURES", "systemd", "sed -i '/After=/a After=systemd-tmpfiles-setup.service' ${D}${systemd_unitdir}/system/console-kit-log-system-start.service", "", d)}
 }


### PR DESCRIPTION
In case of 64-bit systems the base_libdir is set to lib64 whereas
the systemd units are still installed into to lib/systemd so usage
of base_libdir for modifications to unit files breaks on 64-bit
systems.
We now use the systemd_unitdir variable for unit files path which
is the same passed for installation to the package.

Signed-off-by: Awais Belal awais_belal@mentor.com
