### PR TITLE
runqemu.in: qemu-system-ppc is required in build directory

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
+++ b/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
@@ -13,7 +13,7 @@ if ! which tunctl >/dev/null 2>&1; then
     echo >&2 "Unable to find tunctl binary, building qemu-helper-native.."
     bitbake qemu-helper-native
 fi
-if [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-arm" ]; then
+if [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-arm" ] || [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-ppc" ]; then
     echo >&2 "Building qemu-native.."
     bitbake qemu-native
 fi


### PR DESCRIPTION
Conditional check has been added for qemu-system-ppc in
$STAGING_BINDIR_NATIVE folder so that for qemuppc it would
pickup the qemu-system-ppc from STAGING_BINDIR_NATIVE.

JIRA: SB-4106

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
