### PR TITLE
Revert "runqemu.in: qemu-system-ppc is required in build directory"

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
+++ b/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
@@ -13,7 +13,7 @@ if ! which tunctl >/dev/null 2>&1; then
     echo >&2 "Unable to find tunctl binary, building qemu-helper-native.."
     bitbake qemu-helper-native
 fi
-if [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-arm" ] || [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-ppc" ]; then
+if [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-arm" ]; then
     echo >&2 "Building qemu-native.."
     bitbake qemu-native
 fi


### PR DESCRIPTION
This reverts commit 26671cbf41615cf0c186260df5d6a28050f4f90c.

This change is not required as the previous change was sufficient
to get qemu-system-ppc. Hence reverting the change.
