### PR TITLE
runqemu.in: Improvise the conditional check for readability

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
+++ b/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
@@ -13,7 +13,7 @@ if ! which tunctl >/dev/null 2>&1; then
     echo >&2 "Unable to find tunctl binary, building qemu-helper-native.."
     bitbake qemu-helper-native
 fi
-if [ ! -e "$STAGING_BINDIR_NATIVE/qemu-system-arm" ]; then
+if ! ls $STAGING_BINDIR_NATIVE/qemu-system-* >/dev/null 2>&1;then
     echo >&2 "Building qemu-native.."
     bitbake qemu-native
 fi


### PR DESCRIPTION
Improving the conditional check for readability. Rather than
checking for qemu-system-arm just use wild card qemu-system-*

Signed-off-by: Sujith H <Sujith_Haridasan@mentor.com>