### PR TITLE
base-files: Add /etc/profile

### DIFF
--- a/meta-mel/recipes-core/base-files/mel/profile
+++ b/meta-mel/recipes-core/base-files/mel/profile
@@ -1,0 +1,38 @@
+# /etc/profile: system-wide .profile file for the Bourne shell (sh(1))
+# and Bourne compatible shells (bash(1), ksh(1), ash(1), ...).
+
+PATH="/usr/local/bin:/usr/bin:/bin"
+EDITOR="/bin/vi"			# needed for packages like cron
+test -z "$TERM" && TERM="vt100"	# Basic terminal capab. For screen etc.
+
+if [ ! -e /etc/localtime -a ! -e /etc/TZ ]; then
+	TZ="UTC"		# Time Zone. Look at http://theory.uwinnipeg.ca/gnu/glibc/libc_303.html 
+				# for an explanation of how to set this to your local timezone.
+	export TZ
+fi
+
+if [ "$HOME" = "/home/root" ]; then
+   PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
+fi
+if [ "$PS1" ]; then
+# works for bash and ash (no other shells known to be in use here)
+   PS1='\u@\h:\w\$ '
+fi
+
+if [ -d /etc/profile.d ]; then
+  for i in /etc/profile.d/* ; do
+    . $i
+  done
+  unset i
+fi
+
+if tty | grep -vq /dev/pts/; then
+  if [ -x /usr/bin/resize ];then
+    /usr/bin/resize > /dev/null
+  fi
+fi
+
+export PATH PS1 OPIEDIR QPEDIR QTDIR EDITOR TERM
+
+umask 022
+


### PR DESCRIPTION
CodeBench hangs on the execution of /usr/bin/resize.  This version
of profile only executes resize for non-pty connections.

JIRA: SB-4054

Signed-off-by: Wade Farnsworth wade_farnsworth@mentor.com
