### PR TITLE
libunwind: fix linker error by linking against libunwind library

### DIFF
--- a/meta-mel/classes/qoriq_build_64bit_kernel.bbclass
+++ b/meta-mel/classes/qoriq_build_64bit_kernel.bbclass
@@ -1,0 +1,18 @@
+inherit distro_features_check
+REQUIRED_DISTRO_FEATURES_e6500 += "multiarch"
+
+python () {
+    pkgarch = d.getVar("TUNE_PKGARCH", True)
+    if not "ppc64e6500" == pkgarch:
+        return
+
+    promote_kernel = d.getVar('BUILD_64BIT_KERNEL')
+    if promote_kernel == "1":
+        d.setVar('KERNEL_CC_append', ' -m64')
+        d.setVar('KERNEL_LD_append', ' -melf64ppc')
+
+    error_qa = d.getVar('ERROR_QA', True)
+    if 'arch' in error_qa:
+        d.setVar('ERROR_QA', error_qa.replace(' arch', ''))
+}
+

--- a/meta-mel/conf/local.conf.append.t4240rdb-64b
+++ b/meta-mel/conf/local.conf.append.t4240rdb-64b
@@ -1,0 +1,3 @@
+# Enable 64bit kenrel build support for t4240rdb-64b machine
+BUILD_64BIT_KERNEL_t4240rdb-64b = "1"
+

--- a/meta-mel/conf/local.conf.append.t4240rdb-64b
+++ b/meta-mel/conf/local.conf.append.t4240rdb-64b
@@ -1,3 +1,5 @@
 # Enable 64bit kenrel build support for t4240rdb-64b machine
 BUILD_64BIT_KERNEL_t4240rdb-64b = "1"
 
+#Conditionally set TOOLCHAIN variable to external-sourcery
+TOOLCHAIN = "${@base_contains("TCMODE", "external-sourcery", "external-sourcery", "",d)}"

--- a/meta-mel/conf/machine/include/e6500-64b.inc
+++ b/meta-mel/conf/machine/include/e6500-64b.inc
@@ -1,0 +1,7 @@
+TARGET_FPU = "hard"
+DEFAULTTUNE ?= "ppc64e6500"
+
+require conf/machine/include/tune-ppce6500.inc
+require conf/machine/include/qoriq-base.inc
+
+MACHINEOVERRIDES .= ":e6500-64b"

--- a/meta-mel/recipes-support/libunwind/libunwind-1.1/Fix-test-case-link-failure-on-PowerPC-systems-with-Altivec.patch
+++ b/meta-mel/recipes-support/libunwind/libunwind-1.1/Fix-test-case-link-failure-on-PowerPC-systems-with-Altivec.patch
@@ -1,0 +1,32 @@
+@@ -0,0 +1,31 @@
+From 4c62c4a9556f92495d93eddc7641497e1ce1e35c Mon Sep 17 00:00:00 2001
+From: Ulrich Weigand <uweigand@de.ibm.com>
+Date: Tue, 17 Dec 2013 15:00:54 +0100
+Subject: [PATCH] Fix test case link failure on PowerPC systems with Altivec
+
+Upstream-Status:backport
+
+On systems where the system compiler supports Altivec by default,
+the libunwind Makefile will attempt to build an extra test case
+ppc64-test-altivec.  Unfortunately, the link step will fail since
+the Makefile does not actually link against the libunwind library.
+
+Fixed by adding the appropriate LDADD macro.
+
+Signed-off-by: Ulrich Weigand <uweigand@de.ibm.com>
+---
+ tests/Makefile.am |    1 +
+ 1 files changed, 1 insertions(+), 0 deletions(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 0e30536..9c76628 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -201,3 +201,4 @@ Lia64_test_rbs_LDADD = $(LIBUNWIND_local)
+ Lia64_test_readonly_LDADD = $(LIBUNWIND_local)
+ ia64_test_dyn1_LDADD = $(LIBUNWIND)
+ ia64_test_sig_LDADD = $(LIBUNWIND)
++ppc64_test_altivec_LDADD = $(LIBUNWIND)
+--
+1.7.2.5
+

--- a/meta-mel/recipes-support/libunwind/libunwind_1.1.bbappend
+++ b/meta-mel/recipes-support/libunwind/libunwind_1.1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
+
+SRC_URI += "\
+    file://Fix-test-case-link-failure-on-PowerPC-systems-with-Altivec.patch \
+"

--- a/meta-mentor-staging/conf/layer.conf
+++ b/meta-mentor-staging/conf/layer.conf
@@ -2,9 +2,11 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-# Let us add layer-specific bbappends which are only applied when that
+# Let us add layer-specific bb/bbappends which are only applied when that
 # layer is included in our configuration
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
+               for layer in BBFILE_COLLECTIONS.split())}"
+BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
 BBFILE_COLLECTIONS += "mentor-staging"

--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bb
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bb
@@ -1,0 +1,180 @@
+DESCRIPTION = "U-boot bootloader"
+HOMEPAGE = "http://u-boot.sf.net"
+SECTION = "bootloaders"
+PROVIDES = "virtual/bootloader u-boot"
+LICENSE = "GPLv2 & BSD-3-Clause & BSD-2-Clause & LGPL-2.0 & LGPL-2.1"
+LIC_FILES_CHKSUM = " \
+    file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5 \
+    file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c \
+    file://Licenses/lgpl-2.0.txt;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
+    file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
+"
+
+PV = "2014.01+fslgit"
+INHIBIT_DEFAULT_DEPS = "1"
+TOOLCHAIN ?= "external-fsl"
+DEPENDS = "boot-format-native libgcc ${@base_contains('TCMODE', '${TOOLCHAIN}', '', 'virtual/${TARGET_PREFIX}gcc', d)}"
+
+inherit deploy
+
+SRC_URI = "git://git.freescale.com/ppc/sdk/u-boot.git;nobranch=1"
+SRCREV = "fe1d4f5739e752ad45ada6227a9fb19590af7194"
+
+python () {
+    if d.getVar("TCMODE", True) == d.getVar("TOOLCHAIN", True):
+        return
+
+    ml = d.getVar("MULTILIB_VARIANTS", True)
+    arch = d.getVar("OVERRIDES", True)
+
+    if ("e5500-64b:" in arch or "e6500-64b:" in arch) and not "lib32" in ml:
+        raise bb.parse.SkipPackage("Building the u-boot for this arch requires multilib to be enabled")
+}
+
+DEPENDS_append_e5500-64b = "${@base_contains('TCMODE', '${TOOLCHAIN}', '', ' lib32-gcc-cross-powerpc lib32-libgcc', d)}"
+PATH_append_e5500-64b = ":${STAGING_BINDIR_NATIVE}/powerpc${TARGET_VENDOR_virtclass-multilib-lib32}-${HOST_OS}/"
+TOOLCHAIN_OPTIONS_append_e5500-64b = "${@base_contains('TCMODE', '${TOOLCHAIN}', '', '/../lib32-${MACHINE}', d)}"
+TARGET_VENDOR_virtclass-multilib-lib32 ?= "${@base_contains('TCMODE', '${TOOLCHAIN}', '', '-${DISTRO}mllib32', d)}"
+WRAP_TARGET_PREFIX_e5500-64b := "powerpc${TARGET_VENDOR_virtclass-multilib-lib32}-${HOST_OS}-"
+
+DEPENDS_append_e6500-64b = "${@base_contains('TCMODE', '${TOOLCHAIN}', '', ' lib32-gcc-cross-powerpc lib32-libgcc', d)}"
+PATH_append_e6500-64b = ":${STAGING_BINDIR_NATIVE}/powerpc${TARGET_VENDOR_virtclass-multilib-lib32}-${HOST_OS}/"
+TOOLCHAIN_OPTIONS_append_e6500-64b = "${@base_contains('TCMODE', '${TOOLCHAIN}', '', '/../lib32-${MACHINE}', d)}"
+TARGET_VENDOR_virtclass-multilib-lib32 ?= "${@base_contains('TCMODE', '${TOOLCHAIN}', '', '-${DISTRO}mllib32', d)}"
+WRAP_TARGET_PREFIX_e6500-64b := "powerpc${TARGET_VENDOR_virtclass-multilib-lib32}-${HOST_OS}-"
+WRAP_TARGET_PREFIX = "${TARGET_PREFIX}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+UBOOT_LOCALVERSION = "${@d.getVar('SDK_VERSION', True).partition(' ')[0]}"
+
+USRC ?= ""
+S = '${@base_conditional("USRC", "", "${WORKDIR}/git", "${USRC}", d)}'
+
+CROSS_COMPILE = '${@base_conditional("TCMODE", "${TOOLCHAIN}", "${TARGET_PREFIX}", "${WRAP_TARGET_PREFIX}", d)}'
+EXTRA_OEMAKE = 'CROSS_COMPILE=${CROSS_COMPILE} CC="${CROSS_COMPILE}gcc ${TOOLCHAIN_OPTIONS}"'
+
+do_compile () {
+    unset LDFLAGS
+    unset CFLAGS
+    unset CPPFLAGS
+
+    if [ ! -e ${B}/.scmversion -a ! -e ${S}/.scmversion ]
+    then
+        head=`git rev-parse --verify --short HEAD 2> /dev/null`
+        printf "%s%s%s" ${UBOOT_LOCALVERSION} +g $head > ${B}/.scmversion
+        printf "%s%s%s" ${UBOOT_LOCALVERSION} +g $head > ${S}/.scmversion
+    fi
+
+    if [ "x${UBOOT_MACHINES}" = "x" ]; then
+        UBOOT_MACHINES=${UBOOT_MACHINE}
+    fi
+
+    for board in ${UBOOT_MACHINES}; do
+        if ! grep -wq $board ${S}/boards.cfg;then
+            echo "WARNING: $board not supported in boards.cfg"
+            continue
+        fi
+
+        oe_runmake O=${board} distclean
+        oe_runmake O=${board} ${board}
+        oe_runmake O=${board} all
+
+        case "${board}" in
+            *SDCARD*)   UBOOT_TARGET="u-boot-sd";;
+            *SPIFLASH*) UBOOT_TARGET="u-boot-spi";;
+            *NAND*)     UBOOT_TARGET="u-boot-nand";;
+            *SRIO*)     UBOOT_TARGET="u-boot-srio";;
+            *)      UBOOT_TARGET="";;
+        esac
+
+        # deal with sd/spi/nand/srio image
+        UBOOT_SOURCE=u-boot
+        if [ "x${UBOOT_TARGET}" != "x" ]; then
+            # some boards' nand image was named as u-boot-with-spl
+            if [ "${UBOOT_TARGET}" = "u-boot-nand" ];then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS|BSC913|C293)";then
+                    UBOOT_SOURCE=u-boot-with-spl
+                fi
+            elif [ "${UBOOT_TARGET}" = "u-boot-spi" ];then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS)";then
+                    UBOOT_SOURCE=u-boot-with-spl
+                fi
+            elif [ "${UBOOT_TARGET}" = "u-boot-sd" ];then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS)";then
+                    UBOOT_SOURCE=u-boot-with-spl
+                fi
+            fi
+            cp ${S}/${board}/${UBOOT_SOURCE}.bin  ${S}/${board}/${UBOOT_TARGET}.bin
+
+            # use boot-format to regenerate spi image if BOOTFORMAT_CONFIG is not empty
+            if [ "${UBOOT_TARGET}" = "u-boot-spi" ] && [ -n "${BOOTFORMAT_CONFIG}" ];then
+                ${STAGING_BINDIR_NATIVE}/boot_format \
+                ${STAGING_DATADIR_NATIVE}/boot_format/${BOOTFORMAT_CONFIG} \
+                ${S}/${board}/${UBOOT_SOURCE}.bin -spi ${S}/${board}/${UBOOT_TARGET}.bin
+            fi
+        fi
+    done
+}
+
+do_install(){
+    if [ "x${UBOOT_MACHINES}" = "x" ]; then
+        UBOOT_MACHINES=${UBOOT_MACHINE}
+    fi
+
+    for board in ${UBOOT_MACHINES}; do
+        if ! grep -wq $board ${S}/boards.cfg;then
+            continue
+        fi
+
+        case "${board}" in
+            *SDCARD*)   UBOOT_TARGET="u-boot-sd";;
+            *SPIFLASH*) UBOOT_TARGET="u-boot-spi";;
+            *NAND*)     UBOOT_TARGET="u-boot-nand";;
+            *SRIO*)     UBOOT_TARGET="u-boot-srio";;
+            *)      UBOOT_TARGET="u-boot";;
+        esac
+
+        if [ -f ${S}/${board}/${UBOOT_TARGET}.bin ]; then
+            mkdir -p ${D}/boot/
+            install ${S}/${board}/${UBOOT_TARGET}.bin ${D}/boot/${UBOOT_TARGET}-${board}-${PV}-${PR}.bin
+            ln -sf ${UBOOT_TARGET}-${board}-${PV}-${PR}.bin ${D}/boot/${UBOOT_TARGET}.bin
+        fi
+    done
+}
+
+do_deploy(){
+    if [ "x${UBOOT_MACHINES}" = "x" ]; then
+        UBOOT_MACHINES=${UBOOT_MACHINE}
+    fi
+
+    for board in ${UBOOT_MACHINES}; do
+        if ! grep -wq $board ${S}/boards.cfg;then
+            continue
+        fi
+
+        case "${board}" in
+            *SDCARD*)   UBOOT_TARGET="u-boot-sd";;
+            *SPIFLASH*) UBOOT_TARGET="u-boot-spi";;
+            *NAND*)     UBOOT_TARGET="u-boot-nand";;
+            *SRIO*)     UBOOT_TARGET="u-boot-srio";;
+            *)      UBOOT_TARGET="u-boot";;
+        esac
+
+        if [ -f ${S}/${board}/${UBOOT_TARGET}.bin ]; then
+            mkdir -p ${DEPLOYDIR}
+            install ${S}/${board}/${UBOOT_TARGET}.bin ${DEPLOYDIR}/${UBOOT_TARGET}-${board}-${PV}-${PR}.bin
+
+            cd ${DEPLOYDIR}
+            rm -f ${UBOOT_TARGET}-${board}.bin
+            ln -sf ${UBOOT_TARGET}-${board}-${PV}-${PR}.bin ${UBOOT_TARGET}-${board}.bin
+        fi
+    done
+}
+addtask deploy after do_install
+
+PACKAGES += "${PN}-images"
+FILES_${PN}-images += "/boot"
+
+ALLOW_EMPTY_${PN} = "1"

--- a/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/files/usdpaa_makefile.patch
+++ b/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/files/usdpaa_makefile.patch
@@ -1,0 +1,12 @@
+diff -Naur a/Makefile b/Makefile
+--- a/Makefile	2014-10-27 19:42:09.211379807 +0500
++++ b/Makefile	2014-10-27 19:42:11.115379776 +0500
+@@ -47,7 +47,7 @@
+     $(ARCH)_SPEC_DEFINE	 :=
+     $(ARCH)_SPEC_INC_PATH:=
+     $(ARCH)_SPEC_LIB_PATH:=
+-    $(ARCH)_SPEC_CFLAGS	 := -mcpu=e500mc64 -m64
++    $(ARCH)_SPEC_CFLAGS	 := $(TARGET_CC_ARCH)
+     $(ARCH)_SPEC_LDFLAGS :=
+     LIBDIR               ?= lib64
+   else

--- a/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/usdpaa_git.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/usdpaa_git.bbappend
@@ -1,1 +1,8 @@
 TARGET_CC_ARCH += "${LDFLAGS}"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \            
+    file://usdpaa_makefile.patch \
+"
+


### PR DESCRIPTION
From 4c62c4a9556f92495d93eddc7641497e1ce1e35c Mon Sep 17 00:00:00 2001
From: Ulrich Weigand <uweigand@de.ibm.com>
Date: Tue, 17 Dec 2013 15:00:54 +0100
Subject: [PATCH] Fix test case link failure on PowerPC systems with Altivec

Upstream-Status:backport

On systems where the system compiler supports Altivec by default,
the libunwind Makefile will attempt to build an extra test case
ppc64-test-altivec.  Unfortunately, the link step will fail since
the Makefile does not actually link against the libunwind library.

Fixed by adding the appropriate LDADD macro.

Signed-off-by: Ulrich Weigand <uweigand@de.ibm.com>

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>