### PR TITLE
mel: remove toolchain from Yocto SDK for external

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -121,6 +121,10 @@ SSTATE_MIRROR_SITES += "file://${MELDIR}/cached-binaries"
 # The default value follows:
 #TMPDIR = "${TOPDIR}/tmp"
 
+# When we're using an external toolchain, we don't want to ship a newly built
+# toolchain inside the Yocto SDK.
+require conf/include/drop-toolchain-from-sdk.inc
+
 #
 # Package Management configuration
 #

--- a/meta-mel/conf/include/drop-toolchain-from-sdk.inc
+++ b/meta-mel/conf/include/drop-toolchain-from-sdk.inc
@@ -1,0 +1,13 @@
+# When we're using an external toolchain, we don't want to ship a newly built
+# toolchain inside the Yocto SDK. Normally meta-environment comes from the
+# same packagegroup which installs the toolchain, so add that back in
+# explicitly.
+python () {
+    host_task = d.getVar('TOOLCHAIN_HOST_TASK', True)
+    if host_task:
+        tcmode = d.getVar('TCMODE', True)
+        packagegroup = d.expand('packagegroup-cross-canadian-${MACHINE}')
+        if packagegroup in host_task.split() and tcmode.startswith('external'):
+            d.setVar('TOOLCHAIN_HOST_TASK_remove', 'packagegroup-cross-canadian-${MACHINE}')
+            d.appendVar('TOOLCHAIN_HOST_TASK', ' meta-environment-${MACHINE}')
+}


### PR DESCRIPTION
As we're using an external toolchain, we don't want to ship a newly built
toolchain inside a Yocto SDK.

This is an _remove, becuase I didn't want to hardcode the full package list
for TOOLCHAIN_HOST_TASK. The problem with this is, once an _remove is defined,
there's no way to undo it, so a user wouldn't be able to undo this. It's
placed in a local.conf.append to ensure it's user visible, letting them
comment it out or delete the line to undo it if they choose to.

Signed-off-by: Christopher Larson <kergoth@gmail.com>