### PR TITLE
u-boot-qoriq: fix u-boot nand for p2020rdb-pca

### DIFF
--- a/meta-mel/fsl-ppc/recipes-bsp/u-boot/files/p2020rdb-pca-u-boot-nand-fix.patch
+++ b/meta-mel/fsl-ppc/recipes-bsp/u-boot/files/p2020rdb-pca-u-boot-nand-fix.patch
@@ -1,0 +1,14 @@
+Upstream-Status: Already fixed in FSL SDK 1.7
+
+diff --git a/include/configs/p1_p2_rdb_pc.h b/include/configs/p1_p2_rdb_pc.h
+index d20a3ab..120813b 100644
+--- a/include/configs/p1_p2_rdb_pc.h
++++ b/include/configs/p1_p2_rdb_pc.h
+@@ -480,6 +480,7 @@
+ 	| OR_FCM_EHTR)
+ #else
+ #define CONFIG_SYS_NAND_OR_PRELIM	(OR_AM_32KB	/* small page */ \
++	| OR_FCM_PGS	/* Large Page*/ \
+ 	| OR_FCM_CSCT \
+ 	| OR_FCM_CST \
+ 	| OR_FCM_CHT \

--- a/meta-mel/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bbappend
+++ b/meta-mel/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bbappend
@@ -1,1 +1,3 @@
 UBOOT_LOCALVERSION = "+${DISTRO_NAME}-${@d.getVar('SDK_VERSION', True).partition('+')[0]}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " file://p2020rdb-pca-u-boot-nand-fix.patch" 


### PR DESCRIPTION
Add support for NAND memory with 2KB page size, found on p2020rdb-pca.
    
This problem is documented as a known issue in Freescals's "P2020RDB-PCA
Quick Start Guide", document number: 928-26831.

Jira: http://jira.alm.mentorg.com:8080/browse/SB-4039

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>