### PR TITLE
u-boot-qoriq: fix recipe for older u-boot confs

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bb
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2014.01.bb
@@ -94,15 +94,15 @@ do_compile () {
         if [ "x${UBOOT_TARGET}" != "x" ]; then
             # some boards' nand image was named as u-boot-with-spl
             if [ "${UBOOT_TARGET}" = "u-boot-nand" ];then
-                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS|BSC913|C293)";then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB-P[C|D]|P1021RDB|P2020RDB-PC|P1022DS|BSC913|C293)";then
                     UBOOT_SOURCE=u-boot-with-spl
                 fi
             elif [ "${UBOOT_TARGET}" = "u-boot-spi" ];then
-                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS)";then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB-P[C|D]|P1021RDB|P2020RDB-PC|P1022DS)";then
                     UBOOT_SOURCE=u-boot-with-spl
                 fi
             elif [ "${UBOOT_TARGET}" = "u-boot-sd" ];then
-                if echo $board |egrep -q "(P1010RDB|P1020RDB|P1021RDB|P2020RDB|P1022DS)";then
+                if echo $board |egrep -q "(P1010RDB|P1020RDB-P[C|D]|P1021RDB|P2020RDB-PC|P1022DS)";then
                     UBOOT_SOURCE=u-boot-with-spl
                 fi
             fi


### PR DESCRIPTION
U-boot binary name for nand image on some of the newer targets is
'u-boot-with-spl.bin' however for older configurations it is 'u-boot.bin'.
The u-boot recipe expects 'u-boot-with-spl.bin' for all configurations of
certain boards and fail if we use older variants like P2020RDB and P1020RDB.

This patch only fixes the problem for P2020RDB and P1020RDB, other tarigets
might also require a similar fix.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-4564
UPSTREAM STATUS: Pending.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>