### PR TITLE
qemu-fsl: Disable native and nativesdk builds

### DIFF
--- a/meta-mel/fsl-arm/recipes-devtools/qemu/qemu-fsl_git.bbappend
+++ b/meta-mel/fsl-arm/recipes-devtools/qemu/qemu-fsl_git.bbappend
@@ -1,0 +1,2 @@
+# FIXME: Avoid WARNING due missing patch for native/nativesdk
+BBCLASSEXTEND = ""


### PR DESCRIPTION
The qemu-fsl is intended for use into the target. The native and
nativesdk flavours are not supported and should rely on the OE-Core
provided ones.

This disables the recipe parsing for native and nativesdk build,
fixing the following warning:

,----
| WARNING: Unable to get checksum for qemu-fsl-native SRC_URI entry
|     fix-libcap-header-issue-on-some-distro.patch: file could not
|     be found
`----

Upstream:

http://git.yoctoproject.org/cgit/cgit.cgi/meta-fsl-arm/commit/?h=dizzy&id=9eb08907e291fe049d5d83f76c9e2dd63f4496dc

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>