### PR TITLE
mksdboot_ls1: use correct rcw while booting from bank0

### DIFF
--- a/scripts/mksdboot_ls1.sh
+++ b/scripts/mksdboot_ls1.sh
@@ -188,7 +188,7 @@ execute "sudo tar -xvf $root_fs -C /tmp/sdk/$$/rootfs"
 sync
 
 execute "cp -f $sdkdir/u-boot.bin /tmp/sdk/$$/boot/"
-execute "cp -f $sdkdir/rcw/ls1021atwr/SSR_PPN_20/rcw_1000.bin /tmp/sdk/$$/boot/"
+execute "cp -f $sdkdir/rcw/ls1021atwr/RSR_PPS_70/rcw_1000.bin /tmp/sdk/$$/boot/"
 execute "cp -f $sdkdir/uImage /tmp/sdk/$$/boot/"
 execute "cp -f $sdkdir/$dtb /tmp/sdk/$$/boot/"
 


### PR DESCRIPTION
mksdboot_ls1 script was copying the rcw_1000.bin from the
SSR_PPN_20 which is generally used for display and lpuart.

While booting from bank0 we need to use rcw from RSR_PPS_70.

RSR_PPS_70 is abbrevation for following:

RSR: eTSEC1:RGMII, eTSEC2:SGMII,eTSEC3:RGMII
PPS: PCIe1@slot:Supported PCIe2@slot:Supported SATA:Supported
70 : SERDES Protocol

JIRA:SB-4731.

Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>