### PR TITLE
prepare-boot-media.sh: remove default values

### DIFF
--- a/meta-mel/fsl-ppc/scripts/prepare-boot-media.sh
+++ b/meta-mel/fsl-ppc/scripts/prepare-boot-media.sh
@@ -10,9 +10,6 @@
 
 VERSION="0.1"
 
-: ${KERNEL_DEVICETREE:="uImage-p1010rdb-pa.dtb"}
-: ${sdkdir:="`pwd`/tmp/deploy/images/"}
-
 execute ()
 {
     $* >/dev/null


### PR DESCRIPTION
Do not set a default value for dtb file and sdk directory, we expect the
user to always provide these values via respective command-line arguments

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-4643

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>