### PR TITLE
ls1021a: Switchback to u-boot-2014.01 for stability

### DIFF
--- a/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
+++ b/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
@@ -1,0 +1,21 @@
+require recipes-bsp/u-boot/u-boot.inc
+require recipes-bsp/u-boot/u-boot-ls1.inc
+
+SRCBRANCH = "LS1-dev"
+SRC_URI = "git://git.freescale.com/layerscape/ls1021a/u-boot.git;protocol=git;branch=${SRCBRANCH}"
+SRCREV = "50d684801cd05ed6b77d52d1ca9ed00fefeac469"
+
+S = "${WORKDIR}/git"
+
+inherit fsl-u-boot-localversion
+
+LOCALVERSION ?= "-${SRCBRANCH}"
+
+PACKAGES += "${PN}-images"
+FILES_${PN}-images += "/boot"
+
+ALLOW_EMPTY_${PN} = "1"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(ls102xa)"
+


### PR DESCRIPTION
With u-boot-2014.07, toolchain version GCC-4.9.0 issues have been
encountered in the kernel where recursive rcu stalls are observed.

Several key features, fixes are also missing in the SDK-V1.7 u-boot.
So, switching to a stable u-boot from layersacpe.

JIRA:SB-4638

Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>