### PR TITLE
ls1021a: Add alsa utils to the console-image

### DIFF
--- a/meta-mel/fsl-arm/recipes-core/images/console-image.bbappend
+++ b/meta-mel/fsl-arm/recipes-core/images/console-image.bbappend
@@ -1,0 +1,1 @@
+IMAGE_INSTALL += "packagegroup-tools-audio"


### PR DESCRIPTION
Alsa utils which are requied for playback and record is added.

JIRA:SB-4642
Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>