### PR TITLE
LS1021A: Install Alsa package through Machine features

### DIFF
--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -1,0 +1,2 @@
+# LS1021atwr supports usb-audio & simple soundcard, alsa utils are required for playback/record operations
+MACHINE_FEATURES_append_ls1021atwr = " alsa"

--- a/meta-mel/fsl-arm/recipes-core/images/console-image.bbappend
+++ b/meta-mel/fsl-arm/recipes-core/images/console-image.bbappend
@@ -1,1 +1,0 @@
-IMAGE_INSTALL += "packagegroup-tools-audio"


### PR DESCRIPTION
Alsa/Audio packages should not be installed directly, Corrected the
installation of Alsa into image using the machine features.

JIRA:SB-4642
Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>