### PR TITLE
mel-lite.conf: fix validated host distro

### DIFF
--- a/meta-mel/conf/distro/mel-lite.conf
+++ b/meta-mel/conf/distro/mel-lite.conf
@@ -7,5 +7,5 @@ DISTROOVERRIDES = "${DISTRO}:mel"
 require conf/distro/include/mel.conf
 
 SANITY_TESTED_DISTROS = "\
-    Ubuntu-12.04 \n\
+    Ubuntu-14.04 \n\
 "


### PR DESCRIPTION
Validated host for mel-lite 2014.12 is only Ubuntu 14.04
so we make the adjustment accordingly.

Signed-off-by: Awais Belal <awais_belal@mentor.com>