### PR TITLE
mel.conf: Enable vfat support for ARM targets

### DIFF
--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -1,2 +1,2 @@
-# LS1021atwr supports usb-audio & simple soundcard, alsa utils are required for playback/record operations
-MACHINE_FEATURES_append_ls1021atwr = " alsa"
+# LS1021atwr supports usb-audio & simple soundcard, alsa utils are required for playback/record operations. Also we need to support vfat.
+MACHINE_FEATURES_append_ls1021atwr = " alsa vfat"


### PR DESCRIPTION
Add 'vfat' to MACHINE_FEATURES which in turn includes
dosfstools via packagegroup-base

JIRA: SB-4678

Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>