### PR TITLE
archive-release: Install rcw into pre-built binaries

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -64,6 +64,7 @@ DEPLOY_IMAGES = "\
     ${RELEASE_IMAGE}-${MACHINE}.license_manifest \
     ${RELEASE_IMAGE}-${MACHINE}.license_manifest.csv \
     ${KERNEL_IMAGETYPE}* \
+    ${EXTRA_IMAGES_ARCHIVE_RELEASE} \
 "
 DEPLOY_IMAGES[doc] = "List of files from DEPLOY_DIR_IMAGE which will be archived"
 
@@ -345,7 +346,7 @@ do_prepare_release () {
         echo "--transform=s,-${MACHINE},,i" >include
         echo "--transform=s,${DEPLOY_DIR_IMAGE},${MACHINE}/binary," >>include
         {
-            ${@'\n'.join('find ${DEPLOY_DIR_IMAGE}/ -maxdepth 1 -type l -iname "%s" || true' % pattern for pattern in DEPLOY_IMAGES.split())}
+            ${@'\n'.join('find ${DEPLOY_DIR_IMAGE}/ -maxdepth 1  -iname "%s" || true' % pattern for pattern in DEPLOY_IMAGES.split())}
         } >>include
 
         if echo "${OVERRIDES}" | tr ':' '\n' | grep -qx 'qemuall'; then

--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -1,2 +1,5 @@
 # LS1021atwr supports usb-audio & simple soundcard, alsa utils are required for playback/record operations. Also we need to support vfat.
 MACHINE_FEATURES_append_ls1021atwr = " alsa vfat"
+
+# In archive-release for ls1201atwr install rcw along with other image binaries.
+EXTRA_IMAGES_ARCHIVE_RELEASE = "rcw"


### PR DESCRIPTION
For layerscape bsp rcw should also be flashed along with
rcw for board to boot.

RCW was missing from pre-built binaries, so added RCW through
EXTRA_IMAGES.

JIRA: SB-4773

Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>