### PR TITLE
connman 1.25 -> connman 1.28 (v2)

### DIFF
--- a/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
+++ b/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
@@ -1,0 +1,10 @@
+require recipes-connectivity/connman/connman.inc
+
+SRC_URI  = "${KERNELORG_MIRROR}/linux/network/${BPN}/${BP}.tar.xz \
+            file://0001-plugin.h-Change-visibility-to-default-for-debug-symb.patch \
+            file://add_xuser_dbus_permission.patch \
+            "
+SRC_URI[md5sum] = "a449d2e49871494506e48765747e6624"
+SRC_URI[sha256sum] = "c1d266d6be18d2f66231f3537a7ed17b57637ca43c27328bc13c508cbeacce6e"
+
+RRECOMMENDS_${PN} = "connman-conf"

--- a/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
+++ b/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
@@ -4,6 +4,7 @@ SRC_URI  = "${KERNELORG_MIRROR}/linux/network/${BPN}/${BP}.tar.xz \
             file://0001-plugin.h-Change-visibility-to-default-for-debug-symb.patch \
             file://add_xuser_dbus_permission.patch \
             file://0001-Revert-dhcp-Keep-the-retry-timeout-nor-the-ipv4ll-ta.patch \
+            file://0011-service-Connect-ethernet-networks-when-created.patch \
             "
 SRC_URI[md5sum] = "6e07c93877f80bb73c9d4dbfc697f3fc"
 SRC_URI[sha256sum] = "b1d5e7dd2652725906e220a8b0206477e97080e835272971e3b2fd10943c5c94"

--- a/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
+++ b/meta-mel-support/recipes-connectivity/connman/connman_1.28.bb
@@ -3,8 +3,9 @@ require recipes-connectivity/connman/connman.inc
 SRC_URI  = "${KERNELORG_MIRROR}/linux/network/${BPN}/${BP}.tar.xz \
             file://0001-plugin.h-Change-visibility-to-default-for-debug-symb.patch \
             file://add_xuser_dbus_permission.patch \
+            file://0001-Revert-dhcp-Keep-the-retry-timeout-nor-the-ipv4ll-ta.patch \
             "
-SRC_URI[md5sum] = "a449d2e49871494506e48765747e6624"
-SRC_URI[sha256sum] = "c1d266d6be18d2f66231f3537a7ed17b57637ca43c27328bc13c508cbeacce6e"
+SRC_URI[md5sum] = "6e07c93877f80bb73c9d4dbfc697f3fc"
+SRC_URI[sha256sum] = "b1d5e7dd2652725906e220a8b0206477e97080e835272971e3b2fd10943c5c94"
 
 RRECOMMENDS_${PN} = "connman-conf"

--- a/meta-mel-support/recipes-connectivity/connman/files/0001-Revert-dhcp-Keep-the-retry-timeout-nor-the-ipv4ll-ta.patch
+++ b/meta-mel-support/recipes-connectivity/connman/files/0001-Revert-dhcp-Keep-the-retry-timeout-nor-the-ipv4ll-ta.patch
@@ -1,0 +1,33 @@
+From 151e6f654a1e4630125aae11b5f5466b43d643b7 Mon Sep 17 00:00:00 2001
+From: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+Date: Tue, 17 Mar 2015 17:55:37 +0530
+Subject: [PATCH] Revert "dhcp: Keep the retry timeout nor the ipv4ll task in
+ dhcp_invalidate"
+
+This reverts commit 42779cd63ce6d95923248e87d146173ebdd4c6f0.
+---
+ src/dhcp.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/dhcp.c b/src/dhcp.c
+index 09f462b..0e446e7 100644
+--- a/src/dhcp.c
++++ b/src/dhcp.c
+@@ -155,6 +155,14 @@ static void dhcp_invalidate(struct connman_dhcp *dhcp, bool callback)
+ 	__connman_ipconfig_set_gateway(dhcp->ipconfig, NULL);
+ 	__connman_ipconfig_set_prefixlen(dhcp->ipconfig, 0);
+ 
++	if (dhcp->timeout > 0) {
++		g_source_remove(dhcp->timeout);
++		dhcp->timeout = 0;
++	}
++
++	if (ipv4ll_running)
++		ipv4ll_stop_client(dhcp);
++
+ 	if (dhcp->callback && callback)
+ 		dhcp->callback(dhcp->ipconfig, dhcp->network,
+ 						false, dhcp->user_data);
+-- 
+1.9.1
+

--- a/meta-mel-support/recipes-connectivity/connman/files/0001-plugin.h-Change-visibility-to-default-for-debug-symb.patch
+++ b/meta-mel-support/recipes-connectivity/connman/files/0001-plugin.h-Change-visibility-to-default-for-debug-symb.patch
@@ -1,0 +1,35 @@
+From 4ddaf78dad5a9ee4a0658235f71b75132192123e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 7 Apr 2012 18:52:12 -0700
+Subject: [PATCH] plugin.h: Change visibility to default for debug symbols
+
+gold refuses to link in undefined weak symbols which
+have hidden visibility
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+
+Upstream-Status: Pending
+---
+ include/plugin.h |    4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/plugin.h b/include/plugin.h
+index 692a4e5..a9361c3 100644
+--- a/include/plugin.h
++++ b/include/plugin.h
+@@ -89,9 +89,9 @@ struct connman_plugin_desc {
+ #else
+ #define CONNMAN_PLUGIN_DEFINE(name, description, version, priority, init, exit) \
+ 		extern struct connman_debug_desc __start___debug[] \
+-				__attribute__ ((weak, visibility("hidden"))); \
++				__attribute__ ((weak, visibility("default"))); \
+ 		extern struct connman_debug_desc __stop___debug[] \
+-				__attribute__ ((weak, visibility("hidden"))); \
++				__attribute__ ((weak, visibility("default"))); \
+ 		extern struct connman_plugin_desc connman_plugin_desc \
+ 				__attribute__ ((visibility("default"))); \
+ 		struct connman_plugin_desc connman_plugin_desc = { \
+-- 
+1.7.5.4
+

--- a/meta-mel-support/recipes-connectivity/connman/files/0011-service-Connect-ethernet-networks-when-created.patch
+++ b/meta-mel-support/recipes-connectivity/connman/files/0011-service-Connect-ethernet-networks-when-created.patch
@@ -1,0 +1,61 @@
+Upstream-Status: Backport
+From 3e83cb2400b15b775e24945aa4a581cf41f6c4cb Mon Sep 17 00:00:00 2001
+From: Patrik Flykt <patrik.flykt@linux.intel.com>
+Date: Thu, 5 Mar 2015 13:32:55 +0200
+Subject: service: Connect ethernet networks when created
+
+Ethernet networks are created once a cable is plugged in, i.e. carrier
+is detected. According to the documentation in doc/service-api.txt,
+ethernet networks will act as a Connect() D-Bus API call is issued with
+the cable plug in.
+
+Fix the code so that all ethernet services are connected at once when
+created, provided that the network type is autoconnectable either by
+default or by explicitely specifying the technology with the
+DefaultAutoConnectTechnologies main.conf variable.
+
+Reported by Mihai Neagu.
+
+diff --git a/src/service.c b/src/service.c
+index 4cc645a..a3105fa 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -6742,8 +6742,32 @@ struct connman_service * __connman_service_create_from_network(struct connman_ne
+ 
+ 	if (service->favorite) {
+ 		device = connman_network_get_device(service->network);
+-		if (device && !connman_device_get_scanning(device))
+-			__connman_service_auto_connect(CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++		if (device && !connman_device_get_scanning(device)) {
++
++			switch (service->type) {
++			case CONNMAN_SERVICE_TYPE_UNKNOWN:
++			case CONNMAN_SERVICE_TYPE_SYSTEM:
++			case CONNMAN_SERVICE_TYPE_P2P:
++				break;
++
++			case CONNMAN_SERVICE_TYPE_GADGET:
++			case CONNMAN_SERVICE_TYPE_ETHERNET:
++				if (service->autoconnect) {
++					__connman_service_connect(service,
++						CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++					break;
++				}
++
++				/* fall through */
++			case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++			case CONNMAN_SERVICE_TYPE_GPS:
++			case CONNMAN_SERVICE_TYPE_VPN:
++			case CONNMAN_SERVICE_TYPE_WIFI:
++			case CONNMAN_SERVICE_TYPE_CELLULAR:
++				__connman_service_auto_connect(CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++				break;
++			}
++		}
+ 	}
+ 
+ 	__connman_notifier_service_add(service, service->name);
+-- 
+cgit v0.10.2
+
+

--- a/meta-mel-support/recipes-connectivity/connman/files/add_xuser_dbus_permission.patch
+++ b/meta-mel-support/recipes-connectivity/connman/files/add_xuser_dbus_permission.patch
@@ -1,0 +1,21 @@
+Because Poky doesn't support at_console we need to special-case the session
+user.
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/src/connman-dbus.conf b/src/connman-dbus.conf
+index 98a773e..466809c 100644
+--- a/src/connman-dbus.conf
++++ b/src/connman-dbus.conf
+@@ -8,6 +8,9 @@
+         <allow send_interface="net.connman.Counter"/>
+         <allow send_interface="net.connman.Notification"/>
+     </policy>
++    <policy user="xuser">
++        <allow send_destination="net.connman"/>
++    </policy>
+     <policy at_console="true">
+         <allow send_destination="net.connman"/>
+     </policy>

--- a/meta-mel/conf/distro/include/mel-versions.conf
+++ b/meta-mel/conf/distro/include/mel-versions.conf
@@ -2,4 +2,7 @@ PREFERRED_VERSION_udev ?= "182"
 PREFERRED_VERSION_udev_am37x-evm = "164"
 PREFERRED_VERSION_udev_dm37x-evm = "164"
 
+PREFERRED_VERSION_connman_p1020rdb ?= "1.28"
+PREFERRED_VERSION_connman_p2020rdb ?= "1.28"
+
 include conf/distro/include/qt5-versions.inc

--- a/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
@@ -4,3 +4,7 @@ do_install_append () {
     install -d ${D}${sysconfdir}
     touch ${D}${sysconfdir}/resolv.conf
 }
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-connman-implement-network-interface-management-techn.patch"

--- a/meta-mentor-staging/recipes-connectivity/connman/connman_1.25.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_1.25.bbappend
@@ -3,7 +3,3 @@ RDEPENDS_${PN} = "dbus xuser-account"
 PACKAGECONFIG[wifi] = "--enable-wifi, --disable-wifi,,wpa-supplicant"
 PACKAGECONFIG[bluetooth] = "--enable-bluetooth, --disable-bluetooth,,bluez5"
 PACKAGECONFIG[3g] = "--enable-ofono, --disable-ofono,,ofono"
-
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-
-SRC_URI += "file://0001-connman-implement-network-interface-management-techn.patch"

--- a/meta-mentor-staging/recipes-connectivity/connman/connman_1.25.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_1.25.bbappend
@@ -1,5 +1,0 @@
-# Use PACKAGECONFIG handling for rdepends
-RDEPENDS_${PN} = "dbus xuser-account"
-PACKAGECONFIG[wifi] = "--enable-wifi, --disable-wifi,,wpa-supplicant"
-PACKAGECONFIG[bluetooth] = "--enable-bluetooth, --disable-bluetooth,,bluez5"
-PACKAGECONFIG[3g] = "--enable-ofono, --disable-ofono,,ofono"


### PR DESCRIPTION
Move to connman 1.28 plus a couple of extra patches to address the network issues reported in SB-4740.
