### PR TITLE
connman: Use PACKAGECONFIGs to handle dependencies

### DIFF
--- a/meta-mel/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-mel/recipes-connectivity/connman/connman_%.bbappend
@@ -1,2 +1,3 @@
-VIRTUAL-RUNTIME_bluetooth-stack ?= "bluez4"
-PACKAGECONFIG[bluetooth] := "${@d.getVarFlag('PACKAGECONFIG', 'bluetooth').replace('bluez4', '${VIRTUAL-RUNTIME_bluetooth-stack}')}"
+# Use PACKAGECONFIG handling for rdepends
+RDEPENDS_${PN} = "dbus xuser-account"
+PACKAGECONFIG[bluetooth] = "--enable-bluetooth, --disable-bluetooth,virtual/libbluetooth,${VIRTUAL-RUNTIME_bluetooth-stack}"


### PR DESCRIPTION
Use PACKAGECONFIGs to handle runtime dependencies. This was dropped
earlier in favor of RDEPENDS handling in connman.inc from poky but we still
need this for our building-block implementation.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>