### PR TITLE
tcf-agent: Fix LDFLAGS warning during QA_PACKAGE stage

### DIFF
--- a/meta-mel/fsl-arm/recipes-devtools/tcf-agent/files/0001-tcf-client-Add-LDFLAGS-to-fix-QA-Warning.patch
+++ b/meta-mel/fsl-arm/recipes-devtools/tcf-agent/files/0001-tcf-client-Add-LDFLAGS-to-fix-QA-Warning.patch
@@ -1,0 +1,41 @@
+From 96eb9f21a090aa88efbf4f6403b6c8d75b9e70d3 Mon Sep 17 00:00:00 2001
+From: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+Date: Mon, 30 Mar 2015 16:11:19 +0530
+Subject: [PATCH] tcf-client: Add LDFLAGS to fix QA Warning
+
+---
+ Makefile | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 97038d3..579041d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,19 +29,19 @@ $(BINDIR)/libtcf$(EXTLIB) : $(OFILES)
+ 	$(RANLIB)
+ 
+ $(BINDIR)/agent$(EXTEXE): $(BINDIR)/main/main$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+-	$(CC) $(CFLAGS) -o $@ $(BINDIR)/main/main$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(BINDIR)/main/main$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
+ 
+ $(BINDIR)/client$(EXTEXE): $(BINDIR)/main/main_client$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+-	$(CC) $(CFLAGS) -o $@ $(BINDIR)/main/main_client$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(BINDIR)/main/main_client$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
+ 
+ $(BINDIR)/tcflua$(EXTEXE): $(BINDIR)/main/main_lua$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+-	$(CC) $(CFLAGS) $(EXPORT_DYNAMIC) -o $@ $(BINDIR)/main/main_lua$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LUALIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) $(EXPORT_DYNAMIC) -o $@ $(BINDIR)/main/main_lua$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LUALIBS)
+ 
+ $(BINDIR)/tcfreg$(EXTEXE): $(BINDIR)/main/main_reg$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+-	$(CC) $(CFLAGS) -o $@ $(BINDIR)/main/main_reg$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(BINDIR)/main/main_reg$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
+ 
+ $(BINDIR)/valueadd$(EXTEXE): $(BINDIR)/main/main_va$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+-	$(CC) $(CFLAGS) -o $@ $(BINDIR)/main/main_va$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(BINDIR)/main/main_va$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
+ 
+ $(BINDIR)/tcflog$(EXTEXE): $(BINDIR)/main/main_log$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB)
+ 	$(CC) $(CFLAGS) -o $@ $(BINDIR)/main/main_log$(EXTOBJ) $(BINDIR)/libtcf$(EXTLIB) $(LIBS)
+-- 
+1.9.1
+

--- a/meta-mel/fsl-arm/recipes-devtools/tcf-agent/tcf-agent_git.bbappend
+++ b/meta-mel/fsl-arm/recipes-devtools/tcf-agent/tcf-agent_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-tcf-client-Add-LDFLAGS-to-fix-QA-Warning.patch"


### PR DESCRIPTION
tcf-agent obey LDFLAGS needed to quiet 'No GNU_HASH in the elf binary'
warnings.

JIRA: SB-4884.
Signed-off-by: Arun Khandavalli <arun.khandavalli@mentor.com>