### PR TITLE
os-release: add to SIGGEN_EXCLUDERECIPES_ABISAFE

### DIFF
--- a/meta-mentor-staging/conf/layer.conf
+++ b/meta-mentor-staging/conf/layer.conf
@@ -13,3 +13,7 @@ BBFILE_PATTERN_mentor-staging = "^${LAYERDIR}/"
 LAYERDEPENDS_mentor-staging = "core"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
+
+# We don't want systemd and everything depending on systemd to rebuild when
+# the metadata stored in os-release changes. TODO: push this to oe-core
+SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"


### PR DESCRIPTION
We don't want systemd and everything that depends on it rebuilding whenever
DISTRO_VERSION changes.

Signed-off-by: Christopher Larson <kergoth@gmail.com>