### PR TITLE
watchdog: kill update-rc.d when not using sysvinit

### DIFF
--- a/meta-mentor-staging/recipes-extended/watchdog/watchdog_5.14.bbappend
+++ b/meta-mentor-staging/recipes-extended/watchdog/watchdog_5.14.bbappend
@@ -1,0 +1,4 @@
+python () {
+    if not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d):
+        d.setVar("INHIBIT_UPDATERCD_BBCLASS", "1")
+}


### PR DESCRIPTION
Fixes a dependency on a nonexistent initscripts-functions package.

Signed-off-by: Christopher Larson <kergoth@gmail.com>