### PR TITLE
mel: use += for IMAGE_CLASSES, not ?=

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -104,7 +104,7 @@ LOCALE_SECTION = "locale"
 BUILD_LDFLAGS += "-Wl,--hash-style=both"
 
 # Additional filesystem types, ade support
-IMAGE_CLASSES ?= "image_types_uboot image_types_mentor ${ADE_IMAGE_CLASS}"
+IMAGE_CLASSES += "image_types_uboot image_types_mentor ${ADE_IMAGE_CLASS}"
 
 # If meta-mentor-private is available, pull in the populate-ade class
 ADE_IMAGE_CLASS = "${@'populate_ade' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"


### PR DESCRIPTION
Some machines use +=, and due to parse order, this will cause our classes to
no longer be inherited. We always want our image classes inherited, so use +=
here instead.

Signed-off-by: Christopher Larson <kergoth@gmail.com>