### PR TITLE
mel: enable meta-sourcery's QA test(s)

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -188,6 +188,10 @@ require conf/distro/include/kernel-link.inc
 # Default to ipk packaging
 PACKAGE_CLASSES ?= "package_ipk"
 
+# Add meta-sourcery QA test(s)
+PACKAGE_CLASSES .= "${@' package_qa_sourcery' if 'sourcery' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+ERROR_QA .= "${@' ${SOURCERY_QA}' if 'sourcery' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+
 # Pull in info about what layer a recipe came from
 INHERIT += "extra_layerinfo"
 


### PR DESCRIPTION
The main test coming from there at the moment is a check for host user
ownership contamination.

JIRA: SB-4185

Signed-off-by: Christopher Larson <kergoth@gmail.com>