### PR TITLE
mel: don't hardcode *_QA

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -211,15 +211,7 @@ PATCHRESOLVE = "noop"
 MACHINE_KERNEL_PR_beagleboard ?= "r1"
 
 # We aren't quite so picky as poky
-WARN_QA = "ldflags useless-rpaths rpaths staticdev libdir xorg-driver-abi \
-           textrel already-stripped incompatible-license files-invalid \
-           installed-vs-shipped compile-host-path install-host-path \
-           pn-overrides \
-           "
-ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la \
-            perms dep-cmp pkgvarcheck perm-config perm-line perm-link \
-            split-strip packages-list pkgv-undefined var-undefined \
-            "
+WARN_TO_ERROR_QA = ""
 
 # Disable reliance upon upstream URIs, as we want our customers to be able to
 # build without network connectivity


### PR DESCRIPTION
Now that poky no longer hardcodes the list, we no longer need to hardcode the
list, but can instead use the `WARN_TO_ERROR_QA` variable they added.

This commit ends up enabling other QA checks which we inadvertently missed by
overriding the variables.

Signed-off-by: Christopher Larson <kergoth@gmail.com>