### PR TITLE
mel: fix parse cache problem

### DIFF
--- a/meta-mel/conf/distro/include/ade-version.inc
+++ b/meta-mel/conf/distro/include/ade-version.inc
@@ -1,8 +1,0 @@
-ADE_TIMESTAMP := "${@str(int(time.time()))}"
-ADE_VERSION ?= "${@'${SDK_VERSION}'.replace('+snapshot', '')}.${ADE_TIMESTAMP}"
-
-python ade_version_setup () {
-    e.data.appendVar("BB_HASHCONFIG_WHITELIST", " ADE_TIMESTAMP")
-}
-ade_version_setup[eventmask] = "bb.event.ConfigParsed"
-addhandler ade_version_setup

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -18,7 +18,7 @@ ADE_PROVIDER ?= "Mentor Graphics Corporation"
 ADE_SECTIONS = ""
 ADE_SECTIONS_EXCLUDED = "locale"
 
-DATETIME_SECS := "${@int(time.mktime(time.strptime('${DATETIME}', '%Y%m%d%H%M%S')))}"
+DATETIME_SECS = "${@int(time.mktime(time.strptime('${DATETIME}', '%Y%m%d%H%M%S')))}"
 ADE_VERSION ?= "${SDK_VERSION}.${DATETIME_SECS}"
 ADE_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}"
 ADE_IDENTIFIER_SUBDIR = "/ade-${ADE_IDENTIFIER}"
@@ -27,8 +27,6 @@ ADE_PATH ?= "ade${ADE_IDENTIFIER_SUBDIR}/"
 ADE_ARTIFACT_SUFFIX ?= ".${ADE_IDENTIFIER}"
 ADE_SITENAME ?= "ADE for ${ADE_IDENTIFIER}"
 ADE_TOP_CATEGORY ?= "${DISTRO_NAME} [${ADE_IDENTIFIER}]"
-
-require conf/distro/include/ade-version.inc
 
 # Default image for our installers
 RELEASE_IMAGE ?= "console-image"


### PR DESCRIPTION
The unnecessary immediate expansion of DATETIME_SECS was causing the timestamp
in seconds to end up in the configuration metadata checksum. While we can add
it to BB_HASHCONFIG_WHITELIST, we can just skip the immediate expansion
instead, as the time savings should be miniscule.

Signed-off-by: Christopher Larson <kergoth@gmail.com>