### PR TITLE
mel: fix builds without meta-sourcery

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -190,6 +190,7 @@ PACKAGE_CLASSES ?= "package_ipk"
 
 # Add meta-sourcery QA test(s)
 PACKAGE_CLASSES .= "${@' package_qa_sourcery' if 'sourcery' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+SOURCERY_QA ?= ""
 ERROR_QA .= "${@' ${SOURCERY_QA}' if 'sourcery' in '${BBFILE_COLLECTIONS}'.split() else ''}"
 
 # Pull in info about what layer a recipe came from


### PR DESCRIPTION
One can't use a variable expansion inside inline python with an undefined
variable, or we get parse failures. Either I could have changed it to use
d.getVar(), or ensure the variable always have a value, which is what this
does.

Signed-off-by: Christopher Larson <kergoth@gmail.com>