### PR TITLE
docbook-utils-native: build fix by static linking openjade

### DIFF
--- a/meta-mentor-staging/recipes-devtools/openjade/openjade-native_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/openjade/openjade-native_%.bbappend
@@ -1,0 +1,23 @@
+EXTRA_OECONF += "--enable-static --disable-shared"
+
+# override do_install
+do_install() {
+        # Refer to http://www.linuxfromscratch.org/blfs/view/stable/pst/openjade.html
+        # for details.
+        install -d ${D}${bindir}
+        install -m 0755 ${S}/jade/openjade ${D}${bindir}/openjade
+        ln -sf openjade ${D}${bindir}/jade
+
+        install -d ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/catalog ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.dtd ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.dsl ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.sgm ${D}${datadir}/sgml/openjade-${PV}
+
+        install -d ${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/catalog ${datadir}/sgml/openjade-${PV}/catalog
+
+        install -d ${D}${sysconfdir}/sgml
+        echo "CATALOG ${datadir}/sgml/openjade-${PV}/catalog" > \
+                ${D}${sysconfdir}/sgml/openjade-${PV}.cat
+}


### PR DESCRIPTION
Openjade has an issue being built on x86_64 host
due to a shared lib linking issue (libogrove.so),
which fixed by using static linking.

reference:
https://bugzilla.yoctoproject.org/show_bug.cgi?id=2972#c0
http://pastebin.com/cUb1x2Qj

JIRA: SB-5027

Signed-off-by: Neeraj Sharma <neeraj.sharma@alumni.iitg.ernet.in>
Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>