### PR TITLE
mel: work around bitbake missing vardep bug

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -292,3 +292,6 @@ SRC_URI[vardepsexclude] += "\
 
 # Changing IMAGE_FSTYPES should re-run do_rootfs. This belongs upstream.
 do_rootfs[vardeps] += "IMAGE_FSTYPES"
+
+# Work around missing vardep bug in bitbake
+sstate_stage_all[vardeps] += "sstate_stage_dirs"


### PR DESCRIPTION
This works around the sstate_stage_all->sstate_stage_dirs case.

Signed-off-by: Christopher Larson <kergoth@gmail.com>