### PR TITLE
openjade-native: fix link issue with ld.gold by static link

### DIFF
--- a/meta-mentor-staging/recipes-devtools/openjade/openjade-native_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/openjade/openjade-native_%.bbappend
@@ -1,0 +1,23 @@
+EXTRA_OECONF += "--enable-static --disable-shared"
+
+# override do_install
+do_install() {
+        # Refer to http://www.linuxfromscratch.org/blfs/view/stable/pst/openjade.html
+        # for details.
+        install -d ${D}${bindir}
+        install -m 0755 ${S}/jade/openjade ${D}${bindir}/openjade
+        ln -sf openjade ${D}${bindir}/jade
+
+        install -d ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/catalog ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.dtd ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.dsl ${D}${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/*.sgm ${D}${datadir}/sgml/openjade-${PV}
+
+        install -d ${datadir}/sgml/openjade-${PV}
+        install -m 644 dsssl/catalog ${datadir}/sgml/openjade-${PV}/catalog
+
+        install -d ${D}${sysconfdir}/sgml
+        echo "CATALOG ${datadir}/sgml/openjade-${PV}/catalog" > \
+                ${D}${sysconfdir}/sgml/openjade-${PV}.cat
+}


### PR DESCRIPTION
This patch provide static link of openjade with its local libs,
it is required to fix the link issue specific with gold linker.

In case of gold linker we unable to get dynamic link with local lib:
libogrove.so, which results in build break of its consumers.

Overriding do_install to handle the disable shared libs.

reference:
https://bugzilla.yoctoproject.org/show_bug.cgi?id=2972#c0
http://pastebin.com/cUb1x2Qj

JIRA: SB-5027

Signed-off-by: Neeraj Sharma <neeraj.sharma@alumni.iitg.ernet.in>
Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>