### PR TITLE
pulseaudio: make starting up PA deterministic

### DIFF
--- a/meta-mel/recipes-multimedia/pulseaudio/pulseaudio/disable_autospawn_by_default.patch
+++ b/meta-mel/recipes-multimedia/pulseaudio/pulseaudio/disable_autospawn_by_default.patch
@@ -1,0 +1,16 @@
+For AMD BSPs we solely rely on the pulseaudio systemd service
+to start a server. So we disable PA autospawning by default.
+
+diff --git a/src/pulse/client.conf.in2 b/src/pulse/client.conf.in
+index 17753b0..6896640 100644
+--- a/src/pulse/client.conf.in2
++++ b/src/pulse/client.conf.in
+@@ -24,7 +24,7 @@
+ ; default-server =
+ ; default-dbus-server =
+ 
+-; autospawn = yes
++autospawn = no
+ ; daemon-binary = @PA_BINARY@
+ ; extra-arguments = --log-target=syslog
+ 

--- a/meta-mel/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
+++ b/meta-mel/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
@@ -1,5 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 VIRTUAL-RUNTIME_bluetooth-stack ?= "bluez5"
 PACKAGECONFIG := "${@PACKAGECONFIG.replace('bluez5', '${VIRTUAL-RUNTIME_bluetooth-stack}')}"
+
+# Strictly for MEL, we only like systemd starting up our PA server
+# so no autospawning.
+SRC_URI_append = " file://disable_autospawn_by_default.patch \
+"
 
 do_install_append_mel () {
         sed -i 's/; resample-method.*/resample-method \= speex-fixed-3/' ${D}/etc/pulse/daemon.conf

--- a/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/avoid-specifically-starting-PA-rely-on-autospawn.patch
+++ b/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/avoid-specifically-starting-PA-rely-on-autospawn.patch
@@ -1,0 +1,33 @@
+From 42156d2b5ac797e5f28f8d0d38b691053f3f6fc7 Mon Sep 17 00:00:00 2001
+From: Colin Guthrie <colin@mageia.org>
+Date: Fri, 17 Oct 2014 14:43:18 +0200
+Subject: launch: Avoid specifically starting PA and rely on autospawn/socket
+ activation
+
+This --start is patched out in several downstreams to allow users to easily
+disable PA by simply disabling autospawn.
+
+If autospawn is enabled, then the first pactl command will start it and if not
+it will fail and the script will exit.
+
+When switching to systemd socket activation, we very much do not want to
+start PA manually here. We could replace it with a
+  systemctl --user start pulseaudio
+but really it just makes sense to rely on the socket activation as this
+should apply equally to non-systemd setups which use PA's own autospawn.
+
+diff --git a/src/daemon/start-pulseaudio-x11.in b/src/daemon/start-pulseaudio-x11.in
+index 620e50f..63ed740 100755
+--- a/src/daemon/start-pulseaudio-x11.in
++++ b/src/daemon/start-pulseaudio-x11.in
+@@ -19,8 +19,6 @@
+ 
+ set -e
+ 
+-@PA_BINARY@ --start "$@"
+-
+ if [ x"$DISPLAY" != x ] ; then
+ 
+     @PACTL_BINARY@ load-module module-x11-publish "display=$DISPLAY" > /dev/null
+-- 
+cgit v0.10.2

--- a/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/consolidate-startup-scripts.patch
+++ b/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/consolidate-startup-scripts.patch
@@ -1,0 +1,94 @@
+From 2b85ae048970b7faa7505fd0cd4746541d1b09eb Mon Sep 17 00:00:00 2001
+From: Rex Dieter <rdieter@math.unl.edu>
+Date: Wed, 22 Jan 2014 09:41:35 -0600
+Subject: daemon: consolidate startup scripts
+
+simplify pulseaudio autostart into one, avoid needless extra
+work for kde, and avoid possible startup races.
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 857fda3..59f0bcd 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -95,12 +95,10 @@ EXTRA_DIST = \
+ 		depmod.py \
+ 		daemon/esdcompat.in \
+ 		daemon/start-pulseaudio-x11.in \
+-		daemon/start-pulseaudio-kde.in \
+ 		utils/padsp.in \
+ 		utils/qpaeq \
+ 		modules/module-defs.h.m4 \
+ 		daemon/pulseaudio.desktop.in \
+-		daemon/pulseaudio-kde.desktop.in \
+ 		map-file \
+ 		daemon/pulseaudio-system.conf \
+ 		modules/echo-cancel/adrian-license.txt
+diff --git a/src/daemon/pulseaudio-kde.desktop.in b/src/daemon/pulseaudio-kde.desktop.in
+deleted file mode 100644
+index f0bfa8f..0000000
+--- a/src/daemon/pulseaudio-kde.desktop.in
++++ /dev/null
+@@ -1,10 +0,0 @@
+-[Desktop Entry]
+-Version=1.0
+-_Name=PulseAudio Sound System KDE Routing Policy
+-_Comment=Start the PulseAudio Sound System with KDE Routing Policy
+-Exec=start-pulseaudio-kde
+-Terminal=false
+-Type=Application
+-Categories=
+-GenericName=
+-OnlyShowIn=KDE;
+diff --git a/src/daemon/start-pulseaudio-kde.in b/src/daemon/start-pulseaudio-kde.in
+deleted file mode 100755
+index c319e7d..0000000
+--- a/src/daemon/start-pulseaudio-kde.in
++++ /dev/null
+@@ -1,30 +0,0 @@
+-#!/bin/sh
+-
+-# This file is part of PulseAudio.
+-#
+-# PulseAudio is free software; you can redistribute it and/or modify
+-# it under the terms of the GNU Lesser General Public License as published by
+-# the Free Software Foundation; either version 2 of the License, or
+-# (at your option) any later version.
+-#
+-# PulseAudio is distributed in the hope that it will be useful, but
+-# WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+-# General Public License for more details.
+-#
+-# You should have received a copy of the GNU Lesser General Public License
+-# along with PulseAudio; if not, write to the Free Software
+-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+-# USA.
+-
+-set -e
+-
+-[ -z "$PULSE_SERVER" ]
+-
+-@PA_BINARY@ --start "$@"
+-
+-if [ x"$DISPLAY" != x ] ; then
+-
+-    @PACTL_BINARY@ load-module module-device-manager "do_routing=1" > /dev/null
+-
+-fi
+diff --git a/src/daemon/start-pulseaudio-x11.in b/src/daemon/start-pulseaudio-x11.in
+index 391a6d3..620e50f 100755
+--- a/src/daemon/start-pulseaudio-x11.in
++++ b/src/daemon/start-pulseaudio-x11.in
+@@ -26,6 +26,10 @@ if [ x"$DISPLAY" != x ] ; then
+     @PACTL_BINARY@ load-module module-x11-publish "display=$DISPLAY" > /dev/null
+     @PACTL_BINARY@ load-module module-x11-cork-request "display=$DISPLAY" > /dev/null
+ 
++    if [ x"$KDE_FULL_SESSION" = x"true" ]; then
++       @PACTL_BINARY@ load-module module-device-manager "do_routing=1" > /dev/null
++    fi
++
+     if [ x"$SESSION_MANAGER" != x ] ; then
+ 	@PACTL_BINARY@ load-module module-x11-xsmp "display=$DISPLAY session_manager=$SESSION_MANAGER" > /dev/null
+     fi
+-- 
+cgit v0.10.2

--- a/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/remove-kde-references.patch
+++ b/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio/remove-kde-references.patch
@@ -1,0 +1,174 @@
+From f46799579f438125b695dced4edf8bca05cbe90a Mon Sep 17 00:00:00 2001
+From: Tanu Kaskinen <tanu.kaskinen@linux.intel.com>
+Date: Sun, 26 Jan 2014 17:40:31 +0200
+Subject: Remove all references to the removed KDE files
+
+
+diff --git a/configure.ac b/configure.ac
+index 4854711..e75973f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1382,13 +1382,11 @@ man/pulse-daemon.conf.5.xml
+ man/pulse-client.conf.5.xml
+ man/default.pa.5.xml
+ man/pulse-cli-syntax.5.xml
+-man/start-pulseaudio-kde.1.xml
+ man/start-pulseaudio-x11.1.xml
+ ])
+ 
+ AC_CONFIG_FILES([src/esdcompat:src/daemon/esdcompat.in], [chmod +x src/esdcompat])
+ AC_CONFIG_FILES([src/start-pulseaudio-x11:src/daemon/start-pulseaudio-x11.in], [chmod +x src/start-pulseaudio-x11])
+-AC_CONFIG_FILES([src/start-pulseaudio-kde:src/daemon/start-pulseaudio-kde.in], [chmod +x src/start-pulseaudio-kde])
+ AC_CONFIG_FILES([src/client.conf:src/pulse/client.conf.in])
+ AC_CONFIG_FILES([src/daemon.conf:src/daemon/daemon.conf.in],
+     [m4 src/daemon.conf > src/daemon.conf.gen && mv src/daemon.conf.gen src/daemon.conf])
+diff --git a/man/Makefile.am b/man/Makefile.am
+index d0cc8e7..d80ba6a 100644
+--- a/man/Makefile.am
++++ b/man/Makefile.am
+@@ -32,7 +32,6 @@ noinst_DATA = \
+ 	pulse-client.conf.5.xml \
+ 	default.pa.5.xml \
+ 	pulse-cli-syntax.5.xml \
+-	start-pulseaudio-kde.1.xml \
+ 	start-pulseaudio-x11.1.xml
+ 
+ xmllint: $(noinst_DATA)
+@@ -56,7 +55,6 @@ dist_man_MANS = \
+ 	pulse-client.conf.5 \
+ 	default.pa.5 \
+ 	pulse-cli-syntax.5 \
+-	start-pulseaudio-kde.1 \
+ 	start-pulseaudio-x11.1
+ 
+ CLEANFILES = \
+@@ -81,7 +79,6 @@ EXTRA_DIST = \
+ 	pulse-client.conf.5.xml.in \
+ 	default.pa.5.xml.in \
+ 	pulse-cli-syntax.5.xml.in \
+-	start-pulseaudio-kde.1.xml.in \
+ 	start-pulseaudio-x11.1.xml.in \
+ 	xmltoman \
+ 	xmltoman.css \
+diff --git a/man/start-pulseaudio-kde.1.xml.in b/man/start-pulseaudio-kde.1.xml.in
+deleted file mode 100644
+index ef32906..0000000
+--- a/man/start-pulseaudio-kde.1.xml.in
++++ /dev/null
+@@ -1,48 +0,0 @@
+-<?xml version="1.0"?><!--*-nxml-*-->
+-<!DOCTYPE manpage SYSTEM "xmltoman.dtd">
+-<?xml-stylesheet type="text/xsl" href="xmltoman.xsl" ?>
+-
+-<!--
+-This file is part of PulseAudio.
+-
+-PulseAudio is free software; you can redistribute it and/or modify it
+-under the terms of the GNU Lesser General Public License as
+-published by the Free Software Foundation; either version 2.1 of the
+-License, or (at your option) any later version.
+-
+-PulseAudio is distributed in the hope that it will be useful, but WITHOUT
+-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+-or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+-Public License for more details.
+-
+-You should have received a copy of the GNU Lesser General Public
+-License along with PulseAudio; if not, write to the Free Software
+-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+-USA.
+--->
+-
+-<manpage name="start-pulseaudio-kde" section="1" desc="PulseAudio Sound Server KDE Startup Script">
+-
+-  <synopsis>
+-    <cmd>start-pulseaudio-kde [<arg>pulseaudio options</arg>]</cmd>
+-  </synopsis>
+-
+-  <description>
+-    <p>This script starts pulseaudio (if not already running) and loads
+-    module-device-manager to use KDE routing policies.</p>
+-
+-    <p>All arguments are directly passed to pulseaudio.</p>
+-  </description>
+-
+-  <section name="Authors">
+-    <p>The PulseAudio Developers &lt;@PACKAGE_BUGREPORT@&gt;;
+-    PulseAudio is available from <url href="@PACKAGE_URL@"/></p>
+-  </section>
+-
+-  <section name="See also">
+-    <p>
+-      <manref name="pulseaudio" section="1"/>
+-    </p>
+-  </section>
+-
+-</manpage>
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+index d06932f..f39abae 100644
+--- a/po/POTFILES.in
++++ b/po/POTFILES.in
+@@ -6,7 +6,6 @@ src/daemon/dumpmodules.c
+ src/daemon/ltdl-bind-now.c
+ src/daemon/main.c
+ src/daemon/pulseaudio.desktop.in
+-src/daemon/pulseaudio-kde.desktop.in
+ src/modules/alsa/alsa-mixer.c
+ src/modules/alsa/alsa-sink.c
+ src/modules/alsa/alsa-source.c
+diff --git a/src/.gitignore b/src/.gitignore
+index 80f6f2c..2f92b44 100644
+--- a/src/.gitignore
++++ b/src/.gitignore
+@@ -22,7 +22,6 @@ pasuspender
+ pax11publish
+ pulseaudio
+ start-pulseaudio-x11
+-start-pulseaudio-kde
+ *-symdef.h
+ *-orc-gen.[ch]
+ # tests
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 59f0bcd..99d76ce 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -116,8 +116,7 @@ endif
+ 
+ if HAVE_X11
+ xdgautostart_in_files = \
+-		daemon/pulseaudio.desktop.in \
+-		daemon/pulseaudio-kde.desktop.in
++		daemon/pulseaudio.desktop.in
+ xdgautostart_DATA = $(xdgautostart_in_files:.desktop.in=.desktop)
+ @INTLTOOL_DESKTOP_RULE@
+ endif
+@@ -190,7 +189,7 @@ endif
+ 
+ if HAVE_X11
+ bin_PROGRAMS += pax11publish
+-bin_SCRIPTS += start-pulseaudio-x11 start-pulseaudio-kde
++bin_SCRIPTS += start-pulseaudio-x11
+ endif
+ 
+ pacat_SOURCES = utils/pacat.c
+@@ -2104,8 +2103,8 @@ module_rygel_media_server_la_CFLAGS = $(AM_CFLAGS) $(DBUS_CFLAGS)
+ #        Some minor stuff         #
+ ###################################
+ 
+-CLEANFILES += daemon/pulseaudio.desktop daemon/pulseaudio-kde.desktop
+-DISTCLEANFILES = esdcompat client.conf default.pa system.pa daemon.conf start-pulseaudio-x11 start-pulseaudio-kde
++CLEANFILES += daemon/pulseaudio.desktop
++DISTCLEANFILES = esdcompat client.conf default.pa system.pa daemon.conf start-pulseaudio-x11
+ 
+ if OS_IS_WIN32
+ SYMLINK_PROGRAM=cd $(DESTDIR)$(bindir) && cp
+diff --git a/src/daemon/.gitignore b/src/daemon/.gitignore
+index 54e4299..0efa55b 100644
+--- a/src/daemon/.gitignore
++++ b/src/daemon/.gitignore
+@@ -1,3 +1,2 @@
+ org.pulseaudio.policy
+ pulseaudio.desktop
+-pulseaudio-kde.desktop
+-- 
+cgit v0.10.2

--- a/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio_5.0.bbappend
@@ -3,6 +3,12 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " file://pulseaudio.service \
 		           file://pulseaudio \
 			"
+# These patches are already included in version 5.99.1
+# in PA upstream so should be dropped after an upgrade.
+SRC_URI_append = " file://consolidate-startup-scripts.patch \
+		   file://remove-kde-references.patch \
+		   file://avoid-specifically-starting-PA-rely-on-autospawn.patch \
+"
 
 RDEPENDS_pulseaudio-server += "\
     pulseaudio-module-switch-on-port-available \


### PR DESCRIPTION
The autostart behavior for PA is fixed with the help of some patches from upstream. One additional patch that strictly targets MEL is to disable the auto-spawning feature of PA so it is completely controllable through systemd.