### PR TITLE
systemd: Add udev-extraconf to RDEPENDS

### DIFF
--- a/meta-mel/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mel/recipes-core/systemd/systemd_%.bbappend
@@ -2,3 +2,5 @@ PACKAGECONFIG[defaultval] .= "${@' sysvcompat' if 'mel' in OVERRIDES.split(':') 
 
 EXTRA_OECONF := "${@oe_filter_out('--with-sysvrcnd=${sysconfdir}' if 'mel' in OVERRIDES.split(':') else '', EXTRA_OECONF, d)}"
 PACKAGECONFIG[sysvcompat] = "--with-sysvrcnd-path=${sysconfdir},--with-sysvinit-path= --with-sysvrcnd-path=,"
+
+RRECOMMENDS_udev += "udev-extraconf"


### PR DESCRIPTION
Add udev-extraconf package which provides rules and scripts to mount storage
devices as they are connected.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-5114

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>