### PR TITLE
mel-versions.conf: use connman 1.28 for AMD platforms

### DIFF
--- a/meta-mel/conf/distro/include/mel-versions.conf
+++ b/meta-mel/conf/distro/include/mel-versions.conf
@@ -5,4 +5,6 @@ PREFERRED_VERSION_udev_dm37x-evm = "164"
 PREFERRED_VERSION_connman_p1020rdb ?= "1.28"
 PREFERRED_VERSION_connman_p2020rdb ?= "1.28"
 
+PREFERRED_VERSION_connman_amd ?= "1.28"
+
 include conf/distro/include/qt5-versions.inc


### PR DESCRIPTION
The AMD platforms utilize connman 1.28 when built on
mel or mel-lite so we set the version generically rather
than from each BSP layer.

Signed-off-by: Awais Belal <awais_belal@mentor.com>