### PR TITLE
mel-versions.conf: use connman v1.28 for T4240RDB

### DIFF
--- a/meta-mel/conf/distro/include/mel-versions.conf
+++ b/meta-mel/conf/distro/include/mel-versions.conf
@@ -4,6 +4,7 @@ PREFERRED_VERSION_udev_dm37x-evm = "164"
 
 PREFERRED_VERSION_connman_p1020rdb ?= "1.28"
 PREFERRED_VERSION_connman_p2020rdb ?= "1.28"
+PREFERRED_VERSION_connman_t4240rdb-64b ?= "1.28"
 
 PREFERRED_VERSION_connman_amd ?= "1.28"
 


### PR DESCRIPTION
* connman 1.25 is unable to assign IP automatically at
  boot and needs to be restarted manually

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>