### PR TITLE
Add eventmask to some event handlers

### DIFF
--- a/meta-mel/classes/extra_layerinfo.bbclass
+++ b/meta-mel/classes/extra_layerinfo.bbclass
@@ -30,9 +30,6 @@ def get_layer_rootdir(layerpath, d):
     return layerpath
 
 python define_layerpath_data() {
-    if not isinstance(e, bb.event.ConfigParsed):
-        return
-
     for layerpath in oe.data.typed_value('BBLAYERS', e.data):
         layerconf = os.path.join(layerpath, 'conf', 'layer.conf')
 
@@ -45,6 +42,7 @@ python define_layerpath_data() {
             e.data.setVarFlag('LAYERPATHS', layername, layerpath)
             e.data.setVarFlag('BBFILE_PATTERNS', layername, d.getVar('BBFILE_PATTERN_%s' % layername, False))
 }
+define_layerpath_data[eventmask] = "bb.event.ConfigParsed"
 addhandler define_layerpath_data
 
 RECIPE_LAYERNAME = "${@get_file_layer(FILE, d)}"

--- a/meta-mel/classes/restore-dumped-headrevs.bbclass
+++ b/meta-mel/classes/restore-dumped-headrevs.bbclass
@@ -19,9 +19,6 @@ DUMP_HEADREVS_DB ?= '${COREBASE}/saved_persist_data.db'
 DUMP_HEADREVS_STAMP ?= '${STAMP}.restored_headrevs'
 
 python restore_dumped_headrevs() {
-    if not isinstance(e, bb.event.ConfigParsed):
-        return
-
     stamp_path = e.data.getVar('DUMP_HEADREVS_STAMP', True)
     dump_db_path = e.data.getVar('DUMP_HEADREVS_DB', True)
     if not os.path.exists(stamp_path) and os.path.exists(dump_db_path):
@@ -29,4 +26,5 @@ python restore_dumped_headrevs() {
         bb.utils.mkdirhier(os.path.dirname(stamp_path))
         open(stamp_path, 'w').close()
 }
+restore_dumped_headrevs[eventmask] = "bb.event.ConfigParsed"
 addhandler restore_dumped_headrevs

--- a/meta-mel/conf/distro/include/gdbserver-gplv3.inc
+++ b/meta-mel/conf/distro/include/gdbserver-gplv3.inc
@@ -8,8 +8,6 @@ INCOMPATIBLE_LICENSE_pn-external-sourcery-toolchain = ""
 ROOTFS_POSTPROCESS_COMMAND_append = " check_for_gdbserver;"
 
 python adjust_packagegroup_gdbserver () {
-    if not isinstance(e, bb.event.ConfigParsed):
-        return
     d = e.data
 
     if 'GPLv3' in (d.getVar('INCOMPATIBLE_LICENSE', True) or ''):
@@ -19,6 +17,7 @@ python adjust_packagegroup_gdbserver () {
             pkggroup.remove('gdbserver')
             d.setVar('FEATURE_PACKAGES_codebench-debug', ' '.join(pkggroup))
 }
+adjust_packagegroup_gdbserver[eventmask] = "bb.event.ConfigParsed"
 addhandler adjust_packagegroup_gdbserver
 
 check_for_gdbserver () {

--- a/meta-mel/conf/distro/include/kernel-link.inc
+++ b/meta-mel/conf/distro/include/kernel-link.inc
@@ -1,7 +1,8 @@
 python add_kernel_imgtype_link () {
-    if isinstance(e, bb.event.RecipePreFinalise) and oe.utils.inherits(e.data, 'kernel'):
+    if oe.utils.inherits(e.data, 'kernel'):
         e.data.setVar('kernel_do_deploy_append', 'kernel_imgtype_link\n')
 }
+add_kernel_imgtype_link[eventmask] = "bb.event.RecipePreFinalise"
 addhandler add_kernel_imgtype_link
 
 kernel_imgtype_link () {


### PR DESCRIPTION
This fixed builds with current layers, though upstream has since fixed the
code to be more tolerant. Even so, event handlers should all be using
eventmask anyway to avoid their running for events they don't care about.

Signed-off-by: Christopher Larson <kergoth@gmail.com>