### PR TITLE
recipetool.kernel: add kernel convenience sub-commands

### DIFF
--- a/meta-mel/lib/recipetool/kernel.py
+++ b/meta-mel/lib/recipetool/kernel.py
@@ -1,0 +1,230 @@
+# Recipe creation tool - kernel plugin
+#
+# TODO: figure out how to get all the files added to a single SRC_URI +=
+# rather than multiple, while still getting the nice multi-line value
+# TODO: add support to oe.recipeutils to let us add include/require lines via
+# 'extralines', which is not currently supported. We could then
+# pull in linux-dtb.inc automatically if appropriate.
+#
+# These sub-commands are thin wrappers around appendsrcfile(s) coupled
+# with additional configuration variables.
+#
+# Examples:
+#
+#     $ recipetool kernel_set_defconfig meta-mylayer /path/to/defconfig
+#     $ recipetool kernel_add_fragments meta-mylayer one.cfg two.cfg
+#     $ recipetool kernel_set_configs meta-mylayer CONFIG_LOCALVERSION_AUTO=n CONFIG_LOCALVERSION=-test
+#     $ recipetool kernel_add_dts meta-mylayer *.dts
+#
+#
+# Copyright (C) 2015 Mentor Graphics Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import argparse
+import logging
+import os
+import re
+
+
+logger = logging.getLogger('recipetool')
+tinfoil = None
+
+
+def plugin_init(pluginlist):
+    # Don't need to do anything here right now, but plugins must have this function defined
+    pass
+
+
+def tinfoil_init(instance):
+    global tinfoil
+    tinfoil = instance
+
+
+def _provide_to_pn(cooker, provide):
+    """Get the name of the preferred recipe for the specified provide."""
+    import bb.providers
+    filenames = cooker.recipecache.providers[provide]
+    eligible, foundUnique = bb.providers.filterProviders(filenames, provide, cooker.expanded_data, cooker.recipecache)
+    filename = eligible[0]
+    pn = cooker.recipecache.pkg_fn[filename]
+    return pn
+
+
+def _get_recipe_file(cooker, pn):
+    import oe.recipeutils
+    recipefile = oe.recipeutils.pn_to_recipe(cooker, pn)
+    if not recipefile:
+        skipreasons = oe.recipeutils.get_unavailable_reasons(cooker, pn)
+        if skipreasons:
+            logger.error('\n'.join(skipreasons))
+        else:
+            logger.error("Unable to find any recipe file matching %s" % pn)
+    return recipefile
+
+
+def _parse_recipe(provide, tinfoil):
+    import oe.recipeutils
+    pn = _provide_to_pn(tinfoil.cooker, provide)
+    recipefile = _get_recipe_file(tinfoil.cooker, pn)
+    if not recipefile:
+        # Error already logged
+        return None
+    append_files = tinfoil.cooker.collection.get_file_appends(recipefile)
+    rd = oe.recipeutils.parse_recipe(recipefile, append_files,
+                                     tinfoil.config_data)
+    return rd
+
+
+def append_srcfiles(destlayer, rd, files, use_workdir=False, use_machine=False, wildcard_version=False, extralines=None):
+    import recipetool.append
+
+    pn = rd.getVar('PN', True)
+    if use_machine:
+        machine = rd.getVar('MACHINE', True)
+    else:
+        machine = None
+    appendargs = argparse.Namespace(destlayer=destlayer, recipe=pn, use_workdir=use_workdir, wildcard_version=wildcard_version, machine=machine)
+    recipetool.append.appendsrc(appendargs, files, rd, extralines)
+
+
+def kernel_set_defconfig(args):
+    rd = _parse_recipe('virtual/kernel', tinfoil)
+    if not rd:
+        return 1
+
+    import bb.data
+    if bb.data.inherits_class('kernel-yocto', rd):
+        logger.error('linux-yocto based kernels are not supported by this command.')
+        return 3
+
+    extralines = []
+    for configvar in ['KERNEL_DEFCONFIG', 'DEFCONFIG']:
+        if rd.getVar(configvar, True):
+            extralines.append('{0} = ${{WORKDIR}}/defconfig'.format(configvar))
+
+    return append_srcfiles(args.destlayer, rd, {args.defconfig: 'defconfig'}, use_workdir=True, use_machine=True, extralines=extralines)
+
+
+def kernel_add_dts(args):
+    rd = _parse_recipe('virtual/kernel', tinfoil)
+    if not rd:
+        return 1
+
+    packages = rd.getVar('PACKAGES', True).split()
+    if 'kernel-devicetree' not in packages:
+        logger.warn("kernel-devicetree not in the kernel recipe's PACKAGES. This likely means that linux-dtb.inc was not included, so dts files will not be used. Please include this in your kernel recipe ({0}) to proceed.")
+
+    dtbs = (os.path.basename(dts.replace('dts', 'dtb')) for dts in args.dts_files)
+    extralines = ['KERNEL_DEVICETREE += {0}'.format(' '.join(dtbs))]
+    files = dict((dts, os.path.join('arch/${{ARCH}}/boot/dts/{0}'.format(dts))) for dts in args.dts_files)
+    return append_srcfiles(args.destlayer, rd, files, use_workdir=False, use_machine=True, extralines=extralines)
+
+
+def kernel_add_fragments(args):
+    rd = _parse_recipe('virtual/kernel', tinfoil)
+    if not rd:
+        return 1
+
+    return _kernel_add_fragments(args.destlayer, rd, args.fragments)
+
+
+def _kernel_add_fragments(destlayer, rd, fragments, files=None, extralines=None):
+    depends = rd.getVar('DEPENDS', True).split()
+    md_depends = (rd.getVarFlag('do_kernel_metadata', 'depends') or '').split()
+    depends.extend(dep.split(':', 1)[0] for dep in md_depends)
+
+    if extralines is None:
+        extralines = []
+
+    if 'DELTA_KERNEL_DEFCONFIG' in rd:
+        # linux-qoriq handles fragments itself
+        extralines.append('DELTA_KERNEL_DEFCONFIG += {0}'.format(' '.join('${WORKDIR}/%s' % os.path.basename(f) for f in fragments)))
+    else:
+        if 'kern-tools-native' not in depends:
+            logger.warn("kern-tools-native not found in the kernel's dependencies. This likely means that this kernel recipe ({0}) does not support configuration fragments.".format(rd.getVar('PN', True)))
+
+    if files is None:
+        files = dict((f, os.path.basename(f)) for f in fragments)
+    return append_srcfiles(destlayer, rd, files, use_workdir=True, use_machine=True, extralines=extralines)
+
+
+def get_next_fragment_name(src_uri):
+    fragpat = re.compile('file://recipetool([0-9]+)\.cfg$')
+    matches = filter(None, [re.match(fragpat, u) for u in src_uri])
+    if matches:
+        fragnums = sorted((int(m.group(1)) for m in matches), reverse=True)
+        num = fragnums[0] + 1
+    else:
+        num = 0
+    return 'recipetool%d' % num
+
+
+def kernel_set_configs(args):
+    rd = _parse_recipe('virtual/kernel', tinfoil)
+    if not rd:
+        return 1
+
+    if not args.name:
+        src_uri = rd.getVar('SRC_URI', True).split()
+        args.name = get_next_fragment_name(src_uri)
+
+    import tempfile
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    try:
+        for cfgline in args.config_lines:
+            f.write(cfgline + '\n')
+    finally:
+        f.close()
+
+    fragfn = '{0}.cfg'.format(args.name)
+    try:
+        return _kernel_add_fragments(args.destlayer, rd, fragfn, files={f.name: fragfn})
+    finally:
+        os.unlink(f.name)
+
+
+def layer(layerpath):
+    if not os.path.exists(os.path.join(layerpath, 'conf', 'layer.conf')):
+        raise argparse.ArgumentTypeError('{0!r} must be a path to a valid layer'.format(layerpath))
+    return layerpath
+
+
+def existing_path(filepath):
+    if not os.path.exists(filepath):
+        raise argparse.ArgumentTypeError('{0!r} must be an existing path'.format(filepath))
+    return filepath
+
+
+def register_command(subparsers):
+    parser = subparsers.add_parser('kernel_set_defconfig', help='Override the defconfig used for the kernel.')
+    parser.add_argument('destlayer', metavar='DESTLAYER', help='Base directory of the destination layer to write the bbappend to', type=layer)
+    parser.add_argument('defconfig', metavar='DEFCONFIG', help='File path to the defconfig to be used', type=existing_path)
+    parser.set_defaults(func=kernel_set_defconfig, parserecipes=True)
+
+    parser = subparsers.add_parser('kernel_add_dts', help='Add/replace device tree files in the kernel.')
+    parser.add_argument('destlayer', metavar='DESTLAYER', help='Base directory of the destination layer to write the bbappend to', type=layer)
+    parser.add_argument('dts_files', metavar='DTS_FILE', nargs='+', help='File path to a .dts', type=existing_path)
+    parser.set_defaults(func=kernel_add_dts, parserecipes=True)
+
+    parser = subparsers.add_parser('kernel_add_fragments', help='Add configuration fragments to the kernel.')
+    parser.add_argument('destlayer', metavar='DESTLAYER', help='Base directory of the destination layer to write the bbappend to', type=layer)
+    parser.add_argument('fragments', metavar='FRAGMENT', nargs='+', help='File path to a configuration fragment (.cfg)', type=existing_path)
+    parser.set_defaults(func=kernel_add_fragments, parserecipes=True)
+
+    parser = subparsers.add_parser('kernel_set_configs', help='Set kernel configuration parameters. Generates and includes kernel config fragments for you.')
+    parser.add_argument('-n', '--name', metavar='NAME', help='Name of the fragment to be generated (without .cfg)')
+    parser.add_argument('destlayer', metavar='DESTLAYER', help='Base directory of the destination layer to write the bbappend to', type=layer)
+    parser.add_argument('config_lines', metavar='CONFIG_LINE', nargs='+', help='Kernel configuration line (e.g. CONFIG_FOO=y)')
+    parser.set_defaults(func=kernel_set_configs, parserecipes=True)


### PR DESCRIPTION
All these commands rely on the appendsrc recipetool plugin to do the real work
of adding sources to the kernel in the appropriate place, and all will operate
against the current preferred provider of virtual/kernel. They expect, as the
first argument, the path to a layer where these changes will be placed.

- kernel_set_defconfig: Override the kernel's defconfig. Does not yet function
  for linux-yocto kernels. This command copies the supplied defconfig into the
  layer, adds it to SRC_URI if not already there, and if the kernel recipe
  defines `DEFCONFIG` or `KERNEL_DEFCONFIG`, will set those to the full
  absolute path to the unpacked file. Ex.:

    $ recipetool kernel_set_defconfig meta-mylayer /path/to/defconfig

- kernel_add_fragments: Add supplied kernel configuration fragments (.cfg
  files) to the kernel. This command copies the supplied .cfg files and adds
  them to SRC_URI, and in the case of linux-qoriq, also defines `DELTA_KERNEL_DEFCONFIG`. Ex.:

    $ recipetool kernel_add_fragments meta-mylayer one.cfg two.cfg

- kernel_set_configs: Set the supplied kernel configuration options,
  generating a fragment behind the scenes. This command passes the generated
  fragment to kernel_add_fragments. Ex.:

    $ recipetool kernel_set_configs meta-mylayer CONFIG_LOCALVERSION_AUTO=n CONFIG_LOCALVERSION=-test

- kernel_add_dts: Add device tree files (.dts). Will not work as expected,
  currently, if the kernel doesn't include linux-dtb.inc. This command copies
  the supplied .dts files into the layer, adds them to SRC_URI, arranges for
  them to end up in ${S}/arch/${ARCH}/boot/dts, and adds them to
  `KERNEL_DEVICETREE`. Ex.:

    $ recipetool kernel_add_dts meta-mylayer *.dts

JIRA: SB-4482, SB-5037, SB-4902

Signed-off-by: Christopher Larson <chris_larson@mentor.com>