### PR TITLE
gpsd: dep on bluez5

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-navigation/gpsd/gpsd_3.14.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-navigation/gpsd/gpsd_3.14.bbappend
@@ -1,0 +1,3 @@
+# gpsd uses libbluetooth, which is compatible between bluez4 & bluez5
+PACKAGECONFIG ??= "qt ${@base_contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)}"
+PACKAGECONFIG[bluez] = "bluez='true',bluez='false',${BLUEZ}"


### PR DESCRIPTION
gpsd uses libbluetooth, which is compatible between bluez4 & bluez5.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>