### PR TITLE
imx-gpu-viv: correct file ownership

### DIFF
--- a/meta-mentor-staging/fsl-arm/recipes-graphics/imx-gpu-viv/imx-gpu-viv_%.bbappend
+++ b/meta-mentor-staging/fsl-arm/recipes-graphics/imx-gpu-viv/imx-gpu-viv_%.bbappend
@@ -1,0 +1,4 @@
+do_install[postfuncs] += "fixup_perms"
+fixup_perms () {
+    chown -R root:root "${D}"
+}


### PR DESCRIPTION
This recipe copies binary files with `cp`, including `cp -a`, so the file
ownership can end up being the same as the build user. Work around this by
chown'ing everything to root:root.

This avoids a package_qa failure.

JIRA: SB-5184

Signed-off-by: Christopher Larson <chris_larson@mentor.com>