### PR TITLE
setup-environment: process updates from post scripts

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -64,7 +64,7 @@ else
 
     OPTIONALLAYERS="$OPTIONALLAYERS" EXTRAMELLAYERS="$EXTRAMELLAYERS" EXCLUDEDLAYERS="$EXCLUDEDLAYERS" $layerdir/scripts/setup-mel-builddir "$@"
     if [ $? -eq 0 ] && [ -n "$BUILDDIR" ] && [ -e "$BUILDDIR" ]; then
-        . $BUILDDIR/setup-environment
+        . $BUILDDIR/setup-environment >/dev/null 2>&1
 
         configured_layers () {
             tac $BUILDDIR/conf/bblayers.conf | \
@@ -93,6 +93,7 @@ else
             load_lconf_snippet "$layer" "conf/local.conf.append"
             load_lconf_snippet "$layer" "conf/local.conf.append.$SETUP_ENV_MACHINE"
         done
+        . $BUILDDIR/setup-environment
         unset SETUP_ENV_MACHINE
         unset load_lconf_snippet
         unset configured_layers


### PR DESCRIPTION
Each layer may contain a post-setup-environment script that can modify,
among other things, the build directory's setup-environment script.  The
script is sourced after being generated, but isn't sourced again following
the processing of post-setup-environment.  Adding in a second source (and
dumping the initial one to /dev/null so the same message doesn't appear
twice, adds minimal overhead and allows post-setup-environment scripts an
opportunity to make changes to setup-environment (eg. to append to
environment variables such as MANPATH).

Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>