### PR TITLE
u-boot-ls1: update the licence and md5 info for u-boot ls1

### DIFF
--- a/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
+++ b/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
@@ -1,5 +1,14 @@
 require recipes-bsp/u-boot/u-boot.inc
-require recipes-bsp/u-boot/u-boot-ls1.inc
+
+DESCRIPTION = "U-Boot provided by Freescale with focus on QorIQ Layerscape1 boards"
+LICENSE = "GPLv2 & BSD-3-Clause & BSD-2-Clause & LGPL-2.0 & LGPL-2.1"
+LIC_FILES_CHKSUM = " \
+    file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5 \
+    file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c \
+    file://Licenses/lgpl-2.0.txt;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
+    file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
+"
 
 UBOOT_BASE_BINARY = "u-boot.bin"
 PROVIDES = "${PN}"


### PR DESCRIPTION
For cedar release u-boot 2014.01 version shall be used because
with the latest release u-boot and gcc-4.9 rcu stall crash is still
observed, also updated the license infomation with the latest
sdk-v1.8

Jira: SB-5436

Signed-off-by: arun-khandavalli <arun_khandavalli@mentor.com>