### PR TITLE
sed: remove sed_4.2.2.bbappend

### DIFF
--- a/meta-mentor-staging/recipes-extended/sed/sed_4.2.2.bbappend
+++ b/meta-mentor-staging/recipes-extended/sed/sed_4.2.2.bbappend
@@ -1,5 +1,0 @@
-# Remove hardcoded dependency upon locale-base-ru-ru in favor of
-# a recommendation, as it isn't always available, depending on the value of
-# GLIBC_GENERATE_LOCALES.
-RDEPENDS_${PN}-ptest_remove = "locale-base-ru-ru"
-RRECOMMENDS_${PN}-ptest += "locale-base-ru-ru"


### PR DESCRIPTION
Remove sed_4.2.2.bbappend as fixes in this file have been merged
in upstream.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>