### PR TITLE
u-boot-ls1: Add support for lpuart u-boot

### DIFF
--- a/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
+++ b/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2014.01.bb
@@ -34,6 +34,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(ls102xa)"
 
 UBOOT_CONFIGS = "ls1021atwr_nor_config,u-boot-ls1-nor\
+                 ls1021atwr_lpuart_config,u-boot-ls1-lpuart\
                  ls1021atwr_sdcard_config,u-boot-ls1-sd"
 
 do_compile () {


### PR DESCRIPTION
lpuart u-boot is required for the the DCU/HDMI  support in the
layerscape scenario, if we want to use hdmi we need to boot
from LP uart rather than normal uart then we can have console-images +hdmi.

We need to pass console as console=ttyLP0,115200 hdmi as parameter for hdmi
support

Jira:SB-5450

Signed-off-by: arun-khandavalli <arun_khandavalli@mentor.com>