### PR TITLE
gnutls: Remove bbappend

### DIFF
--- a/meta-mentor-staging/recipes-support/gnutls/gnutls_%.bbappend
+++ b/meta-mentor-staging/recipes-support/gnutls/gnutls_%.bbappend
@@ -1,3 +1,0 @@
-PACKAGES =+ "${PN}-xssl"
-FILES_${PN}-xssl = "${libdir}/libgnutls-xssl.so.*"
-LICENSE_${PN}-xssl = "LGPLv2.1+"


### PR DESCRIPTION
* We were adding a new package gnutls-xssl for libgnutls-xssl.so library.
  That library has been removed since version 3.3.0. Poky now has 3.3.14.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>