### PR TITLE
xinetd: Remove local fix of setting INHIBIT_UPDATERCD_BBCLASS

### DIFF
--- a/meta-mentor-staging/recipes-extended/xinetd/xinetd_2.3.15.bbappend
+++ b/meta-mentor-staging/recipes-extended/xinetd/xinetd_2.3.15.bbappend
@@ -1,4 +1,0 @@
-python () {
-    if not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d):
-        d.setVar("INHIBIT_UPDATERCD_BBCLASS", "1")
-}


### PR DESCRIPTION
* Upstream recipe now inherit systemd.bbclas so now we don't need
  our local fix.

Signe-off-by: Noor Ahsan <noor_ahsan@mentor.com>