### PR TITLE
setup-mel-builddir: Drop removal of oprofile

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -303,8 +303,4 @@ fi
 MEL_DISTRO="${MEL_DISTRO:-mel}"
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$MEL_DISTRO\'/" $BUILDDIR/conf/local.conf
-    if [ "$MEL_DISTRO" = "mel-lite" ]; then
-        sed -i -e 's@\(CORE_IMAGE_EXTRA_INSTALL.*\)oprofile\(.*\)@\1\2@' \
-                $BUILDDIR/conf/local.conf
-    fi
 fi


### PR DESCRIPTION
The local.conf.sample file no longer explicitly includes
oprofile.  We don't need to filter it out for MEL Lite.

Signed-off-by: Drew Moseley <drew_moseley@mentor.com>