### PR TITLE
u-boot-ls1: Deploy u-boot for lpuart and nor images

### DIFF
--- a/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2015.01.bbappend
+++ b/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2015.01.bbappend
@@ -3,9 +3,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 # Fix crash issues and kernel lockup issues with GCC-4.9.x
 SRC_URI += "file://0001-ls102xa-LS1021-ARM-Generic-Timer-CompareValue-Set-64.patch"
 
-UBOOT_CONFIG_append = " sdcard lpuart"
+UBOOT_CONFIG_append = "lpuart"
 
-do_install_append () {
-   #override wrong sd-card u-boot for sdcard
-   cp ${S}/ls1021atwr_sdcard_config/u-boot.bin ${WORKDIR}/deploy-u-boot-ls1/u-boot-sdcard-2015.01-r0.bin
+do_deploy () {
+   install -m 0755 ${S}/ls1021atwr_nor_config/u-boot.bin  ${DEPLOY_DIR_IMAGE}/u-boot-nor.bin
+   install -m 0755 ${S}/ls1021atwr_nor_lpuart_config/u-boot.bin ${DEPLOY_DIR_IMAGE}/u-boot-lpuart.bin
 }


### PR DESCRIPTION
Install u-boot images for lpuart and nor images which shall
and also remove support for sd-card, since in latest u-boot
we can write directly to Nor from nor u-boot

Jira:SB-5407

Signed-off-by: arun-khandavalli <arun_khandavalli@mentor.com>