### PR TITLE
mel-tiny: update to current poky-tiny

### DIFF
--- a/meta-mel/conf/distro/mel-tiny.conf
+++ b/meta-mel/conf/distro/mel-tiny.conf
@@ -1,11 +1,50 @@
+# Distribution definition for: mel-tiny, based on poky-tiny
+#
+# Copyright (c) 2011, Intel Corporation.
+# All rights reserved.
+#
+# This file is released under the MIT license as described in
+# ../meta/COPYING.MIT.
+#
+# Poky-tiny is intended to define a tiny Linux system comprised of a
+# Linux kernel tailored to support each specific MACHINE and busybox.
+# Poky-tiny sets some basic policy to ensure a usable system while still
+# keeping the rootfs and kernel image as small as possible.
+#
+# The policies defined are intended to meet the following goals:
+# o Serial consoles only (no framebuffer or VGA console)
+# o Basic support for IPV4 networking
+# o Single user ash shell
+# o Static images (no support for adding packages or libraries later)
+# o Read-only or RAMFS root filesystem
+# o Combined Linux kernel + rootfs in under 4MB
+# o Allow the user to select between eglibc or uclibc with the TCLIBC variable
+#
+# This is currently a partial definition, the following tasks remain:
+# [ ] Integrate linux-yocto-tiny ktype into linux-yocto
+# [ ] Define linux-yocto-tiny configs for all supported BSPs
+# [ ] Drop ldconfig from the installation
+# [ ] Modify the runqemu scripts to work with ext2 parameter:
+#     runqemu qemux86 qemuparams="-nographic" bootparams="console=ttyS0,115200 root=0800"
+# [ ] Modify busybox to allow for DISTRO_FEATURES-like confiruration
+
 require conf/distro/poky.conf
+require conf/distro/include/mel.conf
 
 DISTRO = "mel-tiny"
 DISTRO_NAME = "Mentor Embedded Linux (tiny)"
 DISTROOVERRIDES = "poky-tiny:${DISTRO}:mel"
 
-# We can use task-core-boot, but in the future we may need a new task-core-tiny
-#POKY_DEFAULT_EXTRA_RDEPENDS += "task-core-boot"
+# FIXME: consider adding a new "tiny" feature
+#DISTRO_FEATURES_append = " tiny"
+
+# Distro config is evaluated after the machine config, so we have to explicitly
+# set the kernel provider to override a machine config.
+PREFERRED_PROVIDER_virtual/kernel_qemuall = "linux-yocto-tiny"
+PREFERRED_VERSION_linux-yocto-tiny ?= "3.19%"
+
+# We can use packagegroup-core-boot, but in the future we may need a new packagegroup-core-tiny
+#POKY_DEFAULT_EXTRA_RDEPENDS += "packagegroup-core-boot"
 # Drop kernel-module-af-packet from RRECOMMENDS
 POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 
@@ -14,26 +53,18 @@ TCLIBCAPPEND = ""
 
 # Disable wide char support for ncurses as we don't include it in
 # in the LIBC features below.
+# Leave native enable to avoid build failures
 ENABLE_WIDEC = "false"
+ENABLE_WIDEC_class-native = "true"
 
 # Drop native language support. This removes the
 # eglibc->bash->gettext->libc-posix-clang-wchar dependency.
 USE_NLS = "no"
 
-# Since we drop NLS, we shouldn't install locales into the images either
-IMAGE_LINGUAS ?= ""
-
-# Don't use ldconfig
-USE_LDCONFIG ?= "0"
-
-# -dev packages require pkgconfig, but it pulls in glib->dbus->shadow
-# which breaks with tiny's minimal libc.
-# -dev packages are not currently supported on poky-tiny.
-ASSUME_PROVIDED += "pkgconfig$"
-
 # Reconfigure eglibc for a smaller installation
 # Comment out any of the lines below to disable them in the build
 DISTRO_FEATURES_LIBC_TINY = "libc-libm libc-crypt"
+DISTRO_FEATURES_LIBC_TINY_append_x86-64 = " libc-libm-big"
 
 # Required for "who"
 DISTRO_FEATURES_LIBC_MINIMAL = "libc-utmp libc-getlogin"
@@ -63,6 +94,11 @@ DISTRO_FEATURES = "${DISTRO_FEATURES_TINY} \
                    ${DISTRO_FEATURES_LIBC} \
                   "
 
+# Enable LFS - see bug YOCTO #5865
+DISTRO_FEATURES_append_libc-uclibc = " largefile"
+
+DISTRO_FEATURES_class-native = "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${POKY_DEFAULT_DISTRO_FEATURES}"
+
 # Use tmpdevfs and the busybox runtime services
 VIRTUAL-RUNTIME_dev_manager = ""
 VIRTUAL-RUNTIME_login_manager = ""
@@ -70,14 +106,14 @@ VIRTUAL-RUNTIME_init_manager = "tiny-init"
 VIRTUAL-RUNTIME_keymaps = ""
 
 # FIXME: Consider adding "modules" to MACHINE_FEATURES and using that in
-# task-core-base to select modutils-initscripts or not.  Similar with "net" and
+# packagegroup-core-base to select modutils-initscripts or not.  Similar with "net" and
 # netbase.
 
-# By default we only support ext2 and initramfs. We don't build live as that
+# By default we only support initramfs. We don't build live as that
 # pulls in a lot of dependencies for the live image and the installer, like
 # udev, grub, etc.  These pull in gettext, which fails to build with wide
 # character support.
-IMAGE_FSTYPES = "ext2 cpio.gz"
+IMAGE_FSTYPES = "cpio.gz"
 
 # Drop v86d from qemu dependency list (we support serial)
 # Drop grub from meta-intel BSPs
@@ -91,4 +127,22 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = ""
 # this script for the purposes of tiny, remove the dependency from here.
 RDEPENDS_${PN}-mtrace_pn-eglibc = ""
 
-require conf/distro/include/mel.conf
+PNBLACKLIST[build-appliance-image] = "not buildable for tiny"
+PNBLACKLIST[core-image-base] = "not buildable for tiny"
+PNBLACKLIST[core-image-clutter] = "not buildable for tiny"
+PNBLACKLIST[core-image-directfb] = "not buildable for tiny"
+PNBLACKLIST[core-image-full-cmdline] = "not buildable for tiny"
+PNBLACKLIST[core-image-lsb] = "not buildable for tiny"
+PNBLACKLIST[core-image-lsb-dev] = "not buildable for tiny"
+PNBLACKLIST[core-image-lsb-sdk] = "not buildable for tiny"
+PNBLACKLIST[core-image-rt] = "not buildable for tiny"
+PNBLACKLIST[core-image-rt-sdk] = "not buildable for tiny"
+PNBLACKLIST[core-image-sato] = "not buildable for tiny"
+PNBLACKLIST[core-image-sato-dev] = "not buildable for tiny"
+PNBLACKLIST[core-image-sato-sdk] = "not buildable for tiny"
+PNBLACKLIST[core-image-x11] = "not buildable for tiny"
+PNBLACKLIST[qt4e-demo-image] = "not buildable for tiny"
+PNBLACKLIST[core-image-weston] = "not buildable for tiny"
+
+# Disable python usage in opkg-utils since it won't build with tiny config
+PACKAGECONFIG_pn-opkg-utils = ""


### PR DESCRIPTION
This also changes the include order to ensure that mel.conf isn't undoing any
of the things mel-tiny is doing.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>