### PR TITLE
1021atwr: remove redundant change of PA exclusion

### DIFF
--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -6,7 +6,6 @@ EXTRA_IMAGES_ARCHIVE_RELEASE = "rcw boot"
 
 # Do not build/deploy pulseaudio for networking board TWR-LS1021A
 DISTRO_FEATURES_remove = "pulseaudio"
-RDEPENDS_packagegroup-base-bluetooth_remove = "pulseaudio pulseaudio-server"
 
 # Add file names to go into Boot directory of Sd-card used by wic
 IMAGE_BOOT_FILES =  "uImage\


### PR DESCRIPTION
This has been fixed in meta-mentor commit:
Commit ID: 7e80f58cc56498485b8ed37a55871fd66292a71f

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>