### PR TITLE
u-boot-ls1: Fix compilation issue and pick correct rcw

### DIFF
--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -12,7 +12,7 @@ IMAGE_BOOT_FILES =  "uImage\
                      uImage-ls1021a-twr.dtb\
                      u-boot-nor.bin\
                      u-boot-lpuart.bin\
-                     rcw/ls1021atwr/SSR_PPN_20/rcw_1000.bin\
+                     rcw/ls1021atwr/RSR_PPS_70/rcw_1000.bin\
                      rcw/ls1021atwr/SSR_PPN_20/rcw_1000_lpuart.bin\
                     "
 

--- a/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2015.01.bbappend
+++ b/meta-mel/fsl-arm/recipes-bsp/u-boot/u-boot-ls1_2015.01.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 # Fix crash issues and kernel lockup issues with GCC-4.9.x
 SRC_URI += "file://0001-ls102xa-LS1021-ARM-Generic-Timer-CompareValue-Set-64.patch"
 
-UBOOT_CONFIG_append = "lpuart"
+UBOOT_CONFIG_append = " lpuart"
 
 do_deploy () {
    install -m 0755 ${S}/ls1021atwr_nor_config/u-boot.bin  ${DEPLOY_DIR_IMAGE}/u-boot-nor.bin


### PR DESCRIPTION
To UBOOT_CONFIG_append for adding lpuart space was missing
and it will throw the compliation error, also made change
to pick freescale suggested rcw for nor booting.

Signed-off-by: arun-khandavalli <arun_khandavalli@mentor.com>