### PR TITLE
ipsec-demo: fix host contamination

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-connectivity/ipsec-demo/ipsec-demo_0.1.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-connectivity/ipsec-demo/ipsec-demo_0.1.bbappend
@@ -1,0 +1,3 @@
+do_install_append() {
+    chown -R root:root ${D}${datadir}/test_setkey
+}


### PR DESCRIPTION
All files in the test_setkey directory are being copied with
ownership preserved (cp -a).

* Change ownership of all files in test_setkey directory to
  root:root

* JIRA: SB-5562

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>