### PR TITLE
ls1021: Add simple asound.conf to select default sound card

### DIFF
--- a/meta-mel/fsl-arm/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/meta-mel/fsl-arm/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,4 @@
+# Append path for freescale layer to include alsa-state asound.conf
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+PACKAGE_ARCH_ls1021atwr = "${MACHINE_ARCH}"

--- a/meta-mel/fsl-arm/recipes-bsp/alsa-state/alsa-state/ls1021atwr/asound.conf
+++ b/meta-mel/fsl-arm/recipes-bsp/alsa-state/alsa-state/ls1021atwr/asound.conf
@@ -1,0 +1,9 @@
+pcm.!default {
+	type hw
+	card 0
+}
+
+ctl.!default {
+	type hw
+	card 0
+}


### PR DESCRIPTION
This will avoid card selection via alsa-mixer before playing
audio.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>