### PR TITLE
ti-ipc: specify platform and daemon for DRA7xx

### DIFF
--- a/meta-mel/meta-ti/recipes-ti/ipc/ti-ipc_git.bbappend
+++ b/meta-mel/meta-ti/recipes-ti/ipc/ti-ipc_git.bbappend
@@ -1,0 +1,5 @@
+# specify platform and daemon for DRA7xx using MEL machine name as an override 
+PLATFORM_mel-dra7xx-evm = "DRA7XX"
+DAEMON_mel-dra7xx-evm = "lad_dra7xx"
+
+B = "${WORKDIR}/git"


### PR DESCRIPTION
Machine name for DRA7xx is different in MEL so we need to modify
recipe to make use of MEL machine name as an override

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>