### PR TITLE
udev-rules-qoriq: avoid conflict with udev-extraconf

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-core/udev/udev-rules-qoriq.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-core/udev/udev-rules-qoriq.bbappend
@@ -1,0 +1,4 @@
+do_install () {
+    install -d ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/${RULE} ${D}${sysconfdir}/udev/rules.d/
+}


### PR DESCRIPTION
udev-extraconf installs file mount.blacklist too.

commit id 874231a5063b1888cd25e5bb27da55b440bb4bb8 in upstream
meta-fsl-ppc layer fixes this file conflict. Once MEL has been
updated to that commit, this bbappend should be removed.

JIRA: SB-5483

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>