### PR TITLE
python-lxml: fix version check for xml/xslt

### DIFF
--- a/meta-mentor-staging/meta-python/recipes-devtools/python/python-lxml_%.bbappend
+++ b/meta-mentor-staging/meta-python/recipes-devtools/python/python-lxml_%.bbappend
@@ -1,0 +1,4 @@
+do_configure_prepend () {
+    # xml-config takes --version, but we want --modversion for pkg-config
+    sed -i -e 's/--version/--modversion/' setupinfo.py
+}


### PR DESCRIPTION
The setupinfo.py code was written for xml-config/xslt-config, but we're
passing in pkg-config. To get the version of the package, the former want
--version, but the latter needs --modversion. Fix this in setupinfo.py.

This fixes a build failure encountered while building the ADE.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>