### PR TITLE
image_types_wic: add class to fix IMAGE_CMD_wic

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -85,7 +85,7 @@ require conf/distro/include/sstate.inc
 LOCALE_SECTION = "locale"
 
 # Additional filesystem types, ade support
-IMAGE_CLASSES += "image_types_uboot image_types_mentor ${ADE_IMAGE_CLASS}"
+IMAGE_CLASSES += "image_types_uboot image_types_mentor image_types_wic ${ADE_IMAGE_CLASS}"
 
 # If meta-mentor-private is available, pull in the populate-ade class
 ADE_IMAGE_CLASS = "${@'populate_ade' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"

--- a/meta-mentor-staging/classes/image_types_wic.bbclass
+++ b/meta-mentor-staging/classes/image_types_wic.bbclass
@@ -1,0 +1,11 @@
+IMAGE_WKS_FILE ?= "${FILE_DIRNAME}/${IMAGE_BASENAME}.${MACHINE}.wks"
+
+IMAGE_CMD_wic () {
+	out="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}"
+	wks="${IMAGE_WKS_FILE}"
+	[ -e $wks ] || wks="${FILE_DIRNAME}/${IMAGE_BASENAME}.wks"
+	[ -e $wks ] || bbfatal "Kickstart file $wks doesn't exist"
+	BUILDDIR=${TOPDIR} wic create $wks --vars ${STAGING_DIR_TARGET}/imgdata/ -e ${IMAGE_BASENAME} -o $out/
+	mv $out/build/$(basename "${wks%.wks}")*.direct $out.rootfs.wic
+	rm -rf $out/
+}


### PR DESCRIPTION
The upstream function hardcodes the wks path, making foolish assumptions and
really not aligning with how things are done in the layering scheme. This
alters it, as a start, to use a variable for the path. I have a local
prototype of a version that leverages a file:// wks URI to find it in the
FILESPATH rather than hardcoding a full path, as well, but am working out some
kinks in that method before merging it. This will work in the meantime, as one
can use inline python to get the wks path by searching BBLAYERS.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>