### PR TITLE
python-lxml: bring back the fix for now

### DIFF
--- a/meta-mentor-staging/meta-python/recipes-devtools/python/python-lxml_%.bbappend
+++ b/meta-mentor-staging/meta-python/recipes-devtools/python/python-lxml_%.bbappend
@@ -1,0 +1,4 @@
+do_configure_prepend () {
+    # xml-config takes --version, but we want --modversion for pkg-config
+    sed -i -e 's/--version/--modversion/' setupinfo.py
+}


### PR DESCRIPTION
Apparently the fix is on master-next, not master, at the moment.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>