### PR TITLE
systemd: arm: disable -O2 optimization when built with GCC-5.x

### DIFF
--- a/meta-mel/recipes-core/systemd/systemd_225.bbappend
+++ b/meta-mel/recipes-core/systemd/systemd_225.bbappend
@@ -15,3 +15,7 @@ EXTRA_OECONF := "${@oe_filter_out('--with-sysvrcnd=${sysconfdir}' if 'mel' in OV
 PACKAGECONFIG[sysvcompat] = "--with-sysvrcnd-path=${sysconfdir},--with-sysvinit-path= --with-sysvrcnd-path=,"
 
 RRECOMMENDS_udev += "udev-extraconf"
+
+# Workaround for GCC 5.2 builds on ARM
+FULL_OPTIMIZATION_remove_arm = "-O2"
+FULL_OPTIMIZATION_arm =+ "-O1"


### PR DESCRIPTION
There are systemd unit failures observed on multiple platforms
when built with GCC-5.x toolchain, bug reported in yocto:

https://bugzilla.yoctoproject.org/show_bug.cgi?id=8291

Workaround Will remain here until we get fix for #8291 bug.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>