### PR TITLE
udev-rules-qoriq: remove bbappend

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-core/udev/udev-rules-qoriq.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-core/udev/udev-rules-qoriq.bbappend
@@ -1,4 +1,0 @@
-do_install () {
-    install -d ${D}${sysconfdir}/udev/rules.d/
-    install -m 0644 ${WORKDIR}/${RULE} ${D}${sysconfdir}/udev/rules.d/
-}


### PR DESCRIPTION
Remove udev-rules-qoriq.bbappend as fixes in this file
have been merged in upstream meta-fsl-ppc as of 874231a

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>