### PR TITLE
kmod: fix return code

### DIFF
--- a/meta-mel/recipes-kernel/kmod/kmod/fix_return_code_in_error_path.patch
+++ b/meta-mel/recipes-kernel/kmod/kmod/fix_return_code_in_error_path.patch
@@ -1,0 +1,30 @@
+From 114ec87c85c35a2bd3682f9f891e494127be6fb5 Mon Sep 17 00:00:00 2001
+From: Lucas De Marchi <lucas.demarchi@intel.com>
+Date: Sat, 13 Jun 2015 18:29:47 -0300
+Subject: libkmod-module: fix return code in error path
+
+ENOSYS is the wrong errno to return when we don't find a module in
+kmod_module_insert_module(). Why is it there in the first place?  This
+goes back to kmod v1 when we couldn't load modules by names, but we
+should give a path instead.
+
+708624a ("ELF: initial support for modinfo and strip of modversions and
+vermagic.") changed that so we do a lazy-search by the module path in
+this function. Later  f304afe ("Change error message to reflect
+reality") fixed the log message but the return coded remained the same.
+
+diff --git a/libkmod/libkmod-module.c b/libkmod/libkmod-module.c
+index 366308f..50b2ff9 100644
+--- a/libkmod/libkmod-module.c
++++ b/libkmod/libkmod-module.c
+@@ -830,7 +830,7 @@ KMOD_EXPORT int kmod_module_insert_module(struct kmod_module *mod,
+ 	path = kmod_module_get_path(mod);
+ 	if (path == NULL) {
+ 		ERR(mod->ctx, "could not find module by name='%s'\n", mod->name);
+-		return -ENOSYS;
++		return -ENOENT;
+ 	}
+ 
+ 	mod->file = kmod_file_open(mod->ctx, path);
+-- 
+cgit v0.10.2

--- a/meta-mel/recipes-kernel/kmod/kmod_git.bbappend
+++ b/meta-mel/recipes-kernel/kmod/kmod_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://fix_return_code_in_error_path.patch"


### PR DESCRIPTION
Fix the following error seen during boot:
"Failed to insert module 'kdbus': Function not implemented"

See https://github.com/systemd/systemd/issues/203 for details

JIRA: SB-5927

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>