### PR TITLE
ls1021atwr: add spaces between file-names in IMAGE_BOOT_FILES

### DIFF
--- a/meta-mel/conf/local.conf.append.ls1021atwr
+++ b/meta-mel/conf/local.conf.append.ls1021atwr
@@ -8,12 +8,12 @@ EXTRA_IMAGES_ARCHIVE_RELEASE = "rcw boot"
 DISTRO_FEATURES_remove = "pulseaudio"
 
 # Add file names to go into Boot directory of Sd-card used by wic
-IMAGE_BOOT_FILES =  "uImage\
-                     uImage-ls1021a-twr.dtb\
-                     u-boot-nor.bin\
-                     u-boot-lpuart.bin\
-                     rcw/ls1021atwr/RSR_PPS_70/rcw_1000.bin\
-                     rcw/ls1021atwr/SSR_PPN_20/rcw_1000_lpuart.bin\
+IMAGE_BOOT_FILES =  "uImage \
+                     uImage-ls1021a-twr.dtb \
+                     u-boot-nor.bin \
+                     u-boot-lpuart.bin \
+                     rcw/ls1021atwr/RSR_PPS_70/rcw_1000.bin \
+                     rcw/ls1021atwr/SSR_PPN_20/rcw_1000_lpuart.bin \
                     "
 
 # Install all available kernel modules


### PR DESCRIPTION
The resulting value of IMAGE_BOOT_FILES variable was being computed without
spaces between each of the file names, so add an extra space at the end of
each file-name.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>