### PR TITLE
Use DISTRO_EXTRA_RRECOMMENDS for udev-extraconf

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -10,6 +10,9 @@ POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch"
 POKY_DEFAULT_EXTRA_RDEPENDS = ""
 POKY_DEFAULT_EXTRA_RRECOMMENDS = ""
 
+# We want media to auto-mount
+DISTRO_EXTRA_RRECOMMENDS += "udev-extraconf"
+
 # Paths
 MELDIR ?= "${COREBASE}/.."
 

--- a/meta-mel/recipes-core/systemd/systemd_225.bbappend
+++ b/meta-mel/recipes-core/systemd/systemd_225.bbappend
@@ -13,5 +13,3 @@ PACKAGECONFIG[defaultval] .= "${@' sysvcompat' if 'mel' in OVERRIDES.split(':') 
 
 EXTRA_OECONF := "${@oe_filter_out('--with-sysvrcnd=${sysconfdir}' if 'mel' in OVERRIDES.split(':') else '', EXTRA_OECONF, d)}"
 PACKAGECONFIG[sysvcompat] = "--with-sysvrcnd-path=${sysconfdir},--with-sysvinit-path= --with-sysvrcnd-path=,"
-
-RRECOMMENDS_udev += "udev-extraconf"


### PR DESCRIPTION
Automount is a distro decision, so it should be done in the distro, not hardcoded in the bbappend in our layer.