### PR TITLE
systemd: drop optimization workaround

### DIFF
--- a/meta-mel/recipes-core/systemd/systemd_225.bbappend
+++ b/meta-mel/recipes-core/systemd/systemd_225.bbappend
@@ -15,7 +15,3 @@ EXTRA_OECONF := "${@oe_filter_out('--with-sysvrcnd=${sysconfdir}' if 'mel' in OV
 PACKAGECONFIG[sysvcompat] = "--with-sysvrcnd-path=${sysconfdir},--with-sysvinit-path= --with-sysvrcnd-path=,"
 
 RRECOMMENDS_udev += "udev-extraconf"
-
-# Workaround for GCC 5.2 builds on ARM
-FULL_OPTIMIZATION_remove_arm = "-O2"
-FULL_OPTIMIZATION_arm =+ "-O1"


### PR DESCRIPTION
oe-core has this worked around with more specific arguments.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>