### PR TITLE
mel: don't prepend UNKNOWN/downloads to PREMIRRORS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -186,7 +186,7 @@ LAYERDIR_UNKNOWN = 'UNKNOWN'
 # Support pulling downloads and sstate from inside individual layers. This
 # will let us ship self contained layers to a release without risking file
 # conflicts between them.
-PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERDIR}/downloads\n' if '${RECIPE_LAYERDIR}' != 'None' else ''}"
+PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERDIR}/downloads\n' if '${RECIPE_LAYERDIR}' != 'UNKNOWN' else ''}"
 LAYER_SSTATE_MIRRORS = "${@" ".join('file://%s' % sl for sl in ('%s/sstate-cache' % l for l in '${BBLAYERS}'.split()) if os.path.exists(sl))}"
 SSTATE_MIRROR_SITES_prepend = "${LAYER_SSTATE_MIRRORS} "
 ## }}}1


### PR DESCRIPTION
We had logic to avoid prepending when RECIPE_LAYERDIR wasn't valid, but our
logic for creating RECIPE_LAYERDIR has changed, so that logic no longer
worked. Update it to work again.