### PR TITLE
pull in fsl-networking by default for mel ppc bsps

### DIFF
--- a/pre-setup.p1010rdb
+++ b/pre-setup.p1010rdb
@@ -1,0 +1,1 @@
+OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"

--- a/pre-setup.p1020rdb
+++ b/pre-setup.p1020rdb
@@ -1,0 +1,1 @@
+OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"

--- a/pre-setup.p2020rdb
+++ b/pre-setup.p2020rdb
@@ -1,0 +1,1 @@
+OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"

--- a/pre-setup.t4240rdb-64b
+++ b/pre-setup.t4240rdb-64b
@@ -1,0 +1,1 @@
+OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"


### PR DESCRIPTION
Pull in meta-fsl-networking for all four PPC BSPs currently
supported by MEL i.e p1010rdb, p1020rdb, p2020rdb and t4240rdb-64b

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>