### PR TITLE
image_types_wic: inherit image_types

### DIFF
--- a/meta-mentor-staging/classes/image_types_wic.bbclass
+++ b/meta-mentor-staging/classes/image_types_wic.bbclass
@@ -1,3 +1,5 @@
+inherit image_types
+
 WKS_FILE ?= "${FILE_DIRNAME}/${IMAGE_BASENAME}.${MACHINE}.wks"
 WKS_SEARCH_PATH ?= "\
     ${COREBASE}/scripts/lib/wic/canned-wks \


### PR DESCRIPTION
We override its method, so the parse order is important. Without this, our
IMAGE_CMD_wic wasn't being used.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>