### PR TITLE
mesa-demos: fix deadlock in sharedtex_mt

### DIFF
--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0010-sharedtex_mt-fix-rendering-thread-hang.patch
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0010-sharedtex_mt-fix-rendering-thread-hang.patch
@@ -1,0 +1,43 @@
+From 525fa9ded72d22b53c5eb366f61e2ac1d407a2db Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Thu, 8 Oct 2015 13:49:31 +0500
+Subject: [PATCH] sharedtex_mt: fix rendering thread hang
+
+XNextEvent is a blocking call which locks up the display mutex
+this causes the rendering threads to hang when they try call
+glXSwapBuffers() as that tries to take the same mutex in
+underlying calls through XCopyArea().
+So we only go to XNextEvent when it has at least one event
+and we wouldn't lock indefinitely.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+
+Upstream-Status: Submitted [https://patchwork.freedesktop.org/patch/61350/]
+---
+ src/xdemos/sharedtex_mt.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/xdemos/sharedtex_mt.c b/src/xdemos/sharedtex_mt.c
+index a90903a..1d503c4 100644
+--- a/src/xdemos/sharedtex_mt.c
++++ b/src/xdemos/sharedtex_mt.c
+@@ -420,9 +420,14 @@ Resize(struct window *h, unsigned int width, unsigned int height)
+ static void
+ EventLoop(void)
+ {
++   int i;
++   XEvent event;
+    while (1) {
+-      int i;
+-      XEvent event;
++      /* Do we have an event? */
++      if (XPending(gDpy) == 0) {
++         usleep(10000);
++         continue;
++      }
+       XNextEvent(gDpy, &event);
+       for (i = 0; i < NumWindows; i++) {
+ 	 struct window *h = &Windows[i];
+-- 
+1.9.1
+

--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI_append = " file://0010-sharedtex_mt-fix-rendering-thread-hang.patch"


### PR DESCRIPTION
This patch fixes a deadlock that occurs between the main
thread and rendering threads of the sharedtex_mt demo.
This patch has been submitted upstream to mesa-demos
and will probably appear in >8.2.0. A submission has
been made to the poky as well.
http://patchwork.openembedded.org/patch/105011/

JIRA Ticket: INTAMDDET-957

Signed-off-by: Awais Belal <awais_belal@mentor.com>