### PR TITLE
canned-wks: reduce the size of rootfs partition

### DIFF
--- a/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-2g.wks
+++ b/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-2g.wks
@@ -3,4 +3,4 @@
 # are located in the first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 64M --extra-space 0
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096 --size 1915391K --extra-space 0 --overhead-factor 1
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096 --size 1710080K --extra-space 0 --overhead-factor 1

--- a/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-4g.wks
+++ b/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-4g.wks
@@ -3,4 +3,4 @@
 # are located in the first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4096 --size 64M --extra-space 0
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4 --size 3782M --overhead-factor 1 --extra-space 0
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4 --size 3600M --overhead-factor 1 --extra-space 0

--- a/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-8g.wks
+++ b/meta-mel/scripts/lib/wic/canned-wks/sdimage-bootpart-8g.wks
@@ -3,4 +3,4 @@
 # are located in the first vfat partition.
 
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --align 4 --size 64M --extra-space 0
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4 --size 7564M --overhead-factor 1 --extra-space 0
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4 --size 7500M --overhead-factor 1 --extra-space 0


### PR DESCRIPTION
Certain SD-Cards have less actual capacity than what they claim, so reduce
the size of rootfs partition so that we may not run out of space.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>