### PR TITLE
linux-qoriq: backport patch to fix toc alignment

### DIFF
--- a/meta-mentor-staging/recipes-kernel/linux/files/powerpc_align_TOC_to_256_bytes.patch
+++ b/meta-mentor-staging/recipes-kernel/linux/files/powerpc_align_TOC_to_256_bytes.patch
@@ -1,0 +1,37 @@
+From 5e95235ccd5442d4a4fe11ec4eb99ba1b7959368 Mon Sep 17 00:00:00 2001
+From: Anton Blanchard <anton@samba.org>
+Date: Thu, 14 May 2015 14:45:40 +1000
+Subject: powerpc: Align TOC to 256 bytes
+
+Recent toolchains force the TOC to be 256 byte aligned. We need
+to enforce this alignment in our linker script, otherwise pointers
+to our TOC variables (__toc_start, __prom_init_toc_start) could
+be incorrect.
+
+If they are bad, we die a few hundred instructions into boot.
+
+Cc: stable@vger.kernel.org
+Signed-off-by: Anton Blanchard <anton@samba.org>
+Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
+
+Upstream-Status: Backport
+
+This is a backport of commit id 5e95235 from mainline kernel repo.
+(git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git)
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+
+diff --git a/arch/powerpc/kernel/vmlinux.lds.S b/arch/powerpc/kernel/vmlinux.lds.S
+index f096e72..1db6851 100644
+--- a/arch/powerpc/kernel/vmlinux.lds.S
++++ b/arch/powerpc/kernel/vmlinux.lds.S
+@@ -213,6 +213,7 @@ SECTIONS
+ 		*(.opd)
+ 	}
+ 
++	. = ALIGN(256);
+ 	.got : AT(ADDR(.got) - LOAD_OFFSET) {
+ 		__toc_start = .;
+ #ifndef CONFIG_RELOCATABLE
+-- 
+cgit v0.10.2

--- a/meta-mentor-staging/recipes-kernel/linux/linux-qoriq_3.12.bbappend
+++ b/meta-mentor-staging/recipes-kernel/linux/linux-qoriq_3.12.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://powerpc_align_TOC_to_256_bytes.patch"


### PR DESCRIPTION
Backport commit id 5e95235 from mainline kernel to fix hang
caused by TOC misalignment.

Recent toolchains force the TOC to be 256 byte aligned. We need
to enforce this alignment in our linker script, otherwise pointers
to our TOC variables (__toc_start, __prom_init_toc_start) could
be incorrect

JIRA: SB-6017

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>