### PR TITLE
setup-mel-builddir: set EXTERNAL_TOOLCHAIN here

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -205,12 +205,6 @@ prepare_templates () {
     if [ -n "${DISTRO}" ]; then
         sed -i 's,^DISTRO =.*,DISTRO = "${DISTRO}",' local.conf.sample
     fi
-    sed -i 's,^#\?EXTERNAL_TOOLCHAIN.*,EXTERNAL_TOOLCHAIN ?= "$,' local.conf.sample
-    if [ "${DISTRO}" = "mel-lite" ]; then
-        sed -i 's,^\(EXTERNAL_TOOLCHAIN ?= "\$\),\1{MELDIR}/../../codebench-lite",' local.conf.sample
-    else
-        sed -i 's,^\(EXTERNAL_TOOLCHAIN ?= "\$\),\1{MELDIR}/../../codebench",' local.conf.sample
-    fi
 
     sourcery_version="$(echo ${SOURCERY_VERSION} | sed 's/-.*$//')"
     if [ -n "$sourcery_version" ]; then

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -239,6 +239,10 @@ setup_builddir () {
         echo "You had no local.conf file. This configuration file has therefore been"
         echo "created for you with some default values."
 
+        if [ -d "$MELDIR/../../codebench" ]; then
+            sed -i -e 's,^#\?EXTERNAL_TOOLCHAIN.*,EXTERNAL_TOOLCHAIN ?= "${MELDIR}/../../codebench",' "$BUILDDIR/conf/local.conf"
+        fi
+
         (
             JOBS_FACTOR="2"
             THREADS_FACTOR="3 / 2"
@@ -309,4 +313,7 @@ fi
 MEL_DISTRO="${MEL_DISTRO:-mel}"
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$MEL_DISTRO\'/" $BUILDDIR/conf/local.conf
+    if [ -d "$MELDIR/../../codebench-lite" ]; then
+        sed -i -e 's,^#\?EXTERNAL_TOOLCHAIN.*,EXTERNAL_TOOLCHAIN ?= "${MELDIR}/../../codebench-lite",' "$BUILDDIR/conf/local.conf"
+    fi
 fi


### PR DESCRIPTION
Rather than relying on it being set in the templates coming out of
archive-release, we can just check to see if the codebench path actually
exists, and if so, adjust it when creating local.conf from local.conf.sample
in our setup scripts.

This fixes EXTERNAL_TOOLCHAIN not being set correctly for the qemu machines.

JIRA: SB-6115

Signed-off-by: Christopher Larson <chris_larson@mentor.com>