### PR TITLE
u-boot-qoriq: add dependency virtual/${TARGET_PREFIX}gcc

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2015.01.bb
+++ b/meta-mentor-staging/fsl-ppc/recipes-bsp/u-boot/u-boot-qoriq_2015.01.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = " \
 PV_append = "+fslgit"
 INHIBIT_DEFAULT_DEPS = "1"
 TOOLCHAIN ?= "external-fsl"
-DEPENDS = "boot-format-native libgcc ${@base_contains('TCMODE', '${TOOLCHAIN}', '', 'virtual/${TARGET_PREFIX}gcc', d)}"
+DEPENDS = "boot-format-native libgcc virtual/${TARGET_PREFIX}gcc"
 
 inherit deploy
 


### PR DESCRIPTION
Make u-boot-qoriq dependent upon virtual/${TARGET_PREFIX}gcc
unconditionally as it is required for all ppc targets irrespective
of the contents of ${TOOLCHAIN}.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>