### PR TITLE
opkg: apply Paul Barker's cache fixes

### DIFF
--- a/meta-mentor-staging/recipes-devtools/opkg/opkg/0001-md5-Add-md5_to_string-function.patch
+++ b/meta-mentor-staging/recipes-devtools/opkg/opkg/0001-md5-Add-md5_to_string-function.patch
@@ -1,0 +1,117 @@
+From a72ec21301c551c44f4a6c13840202f7c809528d Mon Sep 17 00:00:00 2001
+From: Paul Barker <pa...@paulbarker.me.uk>
+Date: Sat, 24 Oct 2015 20:15:17 +0100
+Subject: [PATCH 2/4] md5: Add md5_to_string function
+
+Signed-off-by: Paul Barker <pa...@paulbarker.me.uk>
+---
+ libopkg/file_util.c | 28 +++-------------------------
+ libopkg/md5.c       | 17 +++++++++++++++++
+ libopkg/md5.h       |  3 +++
+ 3 files changed, 23 insertions(+), 25 deletions(-)
+
+diff --git a/libopkg/file_util.c b/libopkg/file_util.c
+index 5eff469..cb3dbf0 100644
+--- a/libopkg/file_util.c
++++ b/libopkg/file_util.c
+@@ -349,27 +349,13 @@ int file_mkdir_hier(const char *path, long mode)
+ 
+ char *file_md5sum_alloc(const char *file_name)
+ {
+-    static const int md5sum_bin_len = 16;
+-    static const int md5sum_hex_len = 32;
+-
+-    static const unsigned char bin2hex[16] = {
+-        '0', '1', '2', '3',
+-        '4', '5', '6', '7',
+-        '8', '9', 'a', 'b',
+-        'c', 'd', 'e', 'f'
+-    };
+-
+-    int i, err;
++    int err;
+     FILE *file;
+-    char *md5sum_hex;
+-    unsigned char md5sum_bin[md5sum_bin_len];
+-
+-    md5sum_hex = xcalloc(1, md5sum_hex_len + 1);
++    unsigned char md5sum_bin[16];
+ 
+     file = fopen(file_name, "r");
+     if (file == NULL) {
+         opkg_perror(ERROR, "Failed to open file %s", file_name);
+-        free(md5sum_hex);
+         return NULL;
+     }
+ 
+@@ -377,20 +363,12 @@ char *file_md5sum_alloc(const char *file_name)
+     if (err) {
+         opkg_msg(ERROR, "Could't compute md5sum for %s.\n", file_name);
+         fclose(file);
+-        free(md5sum_hex);
+         return NULL;
+     }
+ 
+     fclose(file);
+ 
+-    for (i = 0; i < md5sum_bin_len; i++) {
+-        md5sum_hex[i * 2] = bin2hex[md5sum_bin[i] >> 4];
+-        md5sum_hex[i * 2 + 1] = bin2hex[md5sum_bin[i] & 0xf];
+-    }
+-
+-    md5sum_hex[md5sum_hex_len] = '\0';
+-
+-    return md5sum_hex;
++    return md5_to_string(md5sum_bin);
+ }
+ 
+ #ifdef HAVE_SHA256
+diff --git a/libopkg/md5.c b/libopkg/md5.c
+index d476b8b..7138681 100644
+--- a/libopkg/md5.c
++++ b/libopkg/md5.c
+@@ -30,6 +30,8 @@
+ #include <string.h>
+ #include <sys/types.h>
+ 
++#include "xfuncs.h"
++
+ #if USE_UNLOCKED_IO
+ #include "unlocked-io.h"
+ #endif
+@@ -431,3 +433,18 @@ void md5_process_block(const void *buffer, size_t len, struct md5_ctx *ctx)
+     ctx->C = C;
+     ctx->D = D;
+ }
++
++char *md5_to_string(const void *md5sum_bin)
++{
++    int i;
++    const char *src = (const char *)md5sum_bin;
++    char *buf = xmalloc(33);
++
++    /* Print 4 bytes at a time. */
++    for (i = 0; i < 16; i += 4) {
++        sprintf(&buf[2*i], "%02hhx%02hhx%02hhx%02hhx",
++                src[i], src[i+1], src[i+2], src[i+3]);
++    }
++
++    return buf;
++}
+diff --git a/libopkg/md5.h b/libopkg/md5.h
+index 01320f5..2a7274d 100644
+--- a/libopkg/md5.h
++++ b/libopkg/md5.h
+@@ -118,6 +118,9 @@ extern int __md5_stream(FILE * stream, void *resblock) __THROW;
+ extern void *__md5_buffer(const char *buffer, size_t len,
+                           void *resblock) __THROW;
+ 
++/* Convert a binary md5sum value to an ASCII string. */
++char *md5_to_string(const void *md5sum_bin);
++
+ #ifdef __cplusplus
+ }
+ #endif
+-- 
+2.2.1
+

--- a/meta-mentor-staging/recipes-devtools/opkg/opkg/0002-sha256-Add-sha256_to_string-function.patch
+++ b/meta-mentor-staging/recipes-devtools/opkg/opkg/0002-sha256-Add-sha256_to_string-function.patch
@@ -1,0 +1,117 @@
+From 77228cc97136ea863ea3012953bf8c71a563e0b3 Mon Sep 17 00:00:00 2001
+From: Paul Barker <pa...@paulbarker.me.uk>
+Date: Sat, 24 Oct 2015 20:15:18 +0100
+Subject: [PATCH 3/4] sha256: Add sha256_to_string function
+
+Signed-off-by: Paul Barker <pa...@paulbarker.me.uk>
+---
+ libopkg/file_util.c | 28 +++-------------------------
+ libopkg/sha256.c    | 17 +++++++++++++++++
+ libopkg/sha256.h    |  3 +++
+ 3 files changed, 23 insertions(+), 25 deletions(-)
+
+diff --git a/libopkg/file_util.c b/libopkg/file_util.c
+index cb3dbf0..864aedb 100644
+--- a/libopkg/file_util.c
++++ b/libopkg/file_util.c
+@@ -374,27 +374,13 @@ char *file_md5sum_alloc(const char *file_name)
+ #ifdef HAVE_SHA256
+ char *file_sha256sum_alloc(const char *file_name)
+ {
+-    static const int sha256sum_bin_len = 32;
+-    static const int sha256sum_hex_len = 64;
+-
+-    static const unsigned char bin2hex[16] = {
+-        '0', '1', '2', '3',
+-        '4', '5', '6', '7',
+-        '8', '9', 'a', 'b',
+-        'c', 'd', 'e', 'f'
+-    };
+-
+-    int i, err;
++    int err;
+     FILE *file;
+-    char *sha256sum_hex;
+-    unsigned char sha256sum_bin[sha256sum_bin_len];
+-
+-    sha256sum_hex = xcalloc(1, sha256sum_hex_len + 1);
++    unsigned char sha256sum_bin[32];
+ 
+     file = fopen(file_name, "r");
+     if (file == NULL) {
+         opkg_perror(ERROR, "Failed to open file %s", file_name);
+-        free(sha256sum_hex);
+         return NULL;
+     }
+ 
+@@ -402,20 +388,12 @@ char *file_sha256sum_alloc(const char *file_name)
+     if (err) {
+         opkg_msg(ERROR, "Could't compute sha256sum for %s.\n", file_name);
+         fclose(file);
+-        free(sha256sum_hex);
+         return NULL;
+     }
+ 
+     fclose(file);
+ 
+-    for (i = 0; i < sha256sum_bin_len; i++) {
+-        sha256sum_hex[i * 2] = bin2hex[sha256sum_bin[i] >> 4];
+-        sha256sum_hex[i * 2 + 1] = bin2hex[sha256sum_bin[i] & 0xf];
+-    }
+-
+-    sha256sum_hex[sha256sum_hex_len] = '\0';
+-
+-    return sha256sum_hex;
++    return sha256_to_string(sha256sum_bin);
+ }
+ 
+ #endif
+diff --git a/libopkg/sha256.c b/libopkg/sha256.c
+index 0816858..5be0de3 100644
+--- a/libopkg/sha256.c
++++ b/libopkg/sha256.c
+@@ -29,6 +29,8 @@
+ #include <stddef.h>
+ #include <string.h>
+ 
++#include "xfuncs.h"
++
+ #if USE_UNLOCKED_IO
+ #include "unlocked-io.h"
+ #endif
+@@ -517,3 +519,18 @@ void sha256_process_block(const void *buffer, size_t len,
+         h = ctx->state[7] += h;
+     }
+ }
++
++char *sha256_to_string(const void *sha256sum_bin)
++{
++    int i;
++    const char *src = (const char *)sha256sum_bin;
++    char *buf = xmalloc(65);
++
++    /* Print 4 bytes at a time. */
++    for (i = 0; i < 32; i += 4) {
++        sprintf(&buf[2*i], "%02hhx%02hhx%02hhx%02hhx",
++                src[i], src[i+1], src[i+2], src[i+3]);
++    }
++
++    return buf;
++}
+diff --git a/libopkg/sha256.h b/libopkg/sha256.h
+index 734ab54..0d1e9e5 100644
+--- a/libopkg/sha256.h
++++ b/libopkg/sha256.h
+@@ -85,6 +85,9 @@ extern int sha224_stream(FILE * stream, void *resblock);
+ extern void *sha256_buffer(const char *buffer, size_t len, void *resblock);
+ extern void *sha224_buffer(const char *buffer, size_t len, void *resblock);
+ 
++/* Convert a binary sha256sum value to an ASCII string. */
++char *sha256_to_string(const void *sha256sum_bin);
++
+ #ifdef __cplusplus
+ }
+ #endif
+-- 
+2.2.1
+

--- a/meta-mentor-staging/recipes-devtools/opkg/opkg/0003-opkg_download-Use-md5sum-of-src-URI-as-cache-file-na.patch
+++ b/meta-mentor-staging/recipes-devtools/opkg/opkg/0003-opkg_download-Use-md5sum-of-src-URI-as-cache-file-na.patch
@@ -1,0 +1,51 @@
+From e08c52323d1e711ab681ee9c4477e85e3d440f11 Mon Sep 17 00:00:00 2001
+From: Paul Barker <pa...@paulbarker.me.uk>
+Date: Sat, 24 Oct 2015 20:15:19 +0100
+Subject: [PATCH 4/4] opkg_download: Use md5sum of src URI as cache file name
+
+Source URIs can be very long. The cache directory itself may already have a very
+long path, especially if we're installing packages into an offline rootfs.
+Therefore it's not a good idea to simply tag the source URI onto the cache
+directory path to create a cache file name.
+
+To create shorter cache file names which are deterministic and very likely to be
+unique, we use the md5sum of the source URI.
+
+Signed-off-by: Paul Barker <pa...@paulbarker.me.uk>
+---
+ libopkg/opkg_download.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/libopkg/opkg_download.c b/libopkg/opkg_download.c
+index e5a5dbb..0165280 100644
+--- a/libopkg/opkg_download.c
++++ b/libopkg/opkg_download.c
+@@ -29,6 +29,7 @@
+ #include "opkg_verify.h"
+ #include "opkg_utils.h"
+ 
++#include "md5.h"
+ #include "sprintf_alloc.h"
+ #include "file_util.h"
+ #include "xfuncs.h"
+@@ -135,12 +136,12 @@ int opkg_download_internal(const char *src, const char *dest,
+  */
+ char *get_cache_location(const char *src)
+ {
+-    char *cache_name = xstrdup(src);
+-    char *cache_location, *p;
++    unsigned char md5sum_bin[16];
++    char *cache_name;
++    char *cache_location;
+ 
+-    for (p = cache_name; *p; p++)
+-        if (*p == '/')
+-            *p = '_';
++    md5_buffer(src, strlen(src), md5sum_bin);
++    cache_name = md5_to_string(md5sum_bin);
+ 
+     sprintf_alloc(&cache_location, "%s/%s", opkg_config->cache_dir, cache_name);
+     free(cache_name);
+-- 
+2.2.1
+

--- a/meta-mentor-staging/recipes-devtools/opkg/opkg_0.3.0.bbappend
+++ b/meta-mentor-staging/recipes-devtools/opkg/opkg_0.3.0.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "\
+    file://0001-md5-Add-md5_to_string-function.patch \
+    file://0002-sha256-Add-sha256_to_string-function.patch \
+    file://0003-opkg_download-Use-md5sum-of-src-URI-as-cache-file-na.patch \
+"


### PR DESCRIPTION
His patch series from the opkg-devel list changes the package cache to use
checksums rather than the url for the filename, avoiding the filename length
issue.

JIRA: SB-6120

I tested this locally, and it fixed the problem here.