### PR TITLE
libtevent, libtdb, talloc: Fix build-deps warnings

### DIFF
--- a/meta-mentor-staging/recipes-support/libtdb/libtdb_1.3.0.bbappend
+++ b/meta-mentor-staging/recipes-support/libtdb/libtdb_1.3.0.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "attr"

--- a/meta-mentor-staging/recipes-support/libtevent/libtevent_0.9.21.bbappend
+++ b/meta-mentor-staging/recipes-support/libtevent/libtevent_0.9.21.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "attr"

--- a/meta-mentor-staging/recipes-support/talloc/talloc_2.1.1.bbappend
+++ b/meta-mentor-staging/recipes-support/talloc/talloc_2.1.1.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "attr"


### PR DESCRIPTION
Fix following warnings:

WARNING: QA Issue: libtevent rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: python-tevent rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: tdb-tools rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: libtdb rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: python-tdb rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: pytalloc rdepends on libattr, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: libtalloc rdepends on libattr, but it isn't a build dependency? [build-deps]

JIRA: SB-6141

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>