### PR TITLE
samba: fix build-deps qa warnings

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/samba/samba_4.1.12.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/samba/samba_4.1.12.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "avahi libaio"


### PR DESCRIPTION
Add missing dependency avahi to fix following warnings:
WARNING: QA Issue: samba rdepends on libavahi-common, but it isn't a build dependency? [build-deps]
WARNING: QA Issue: samba rdepends on libavahi-client, but it isn't a build dependency? [build-deps]

Add missing dependency libaio to fix following warning:
WARNING: QA Issue: samba rdepends on libaio, but it isn't a build dependency? [build-deps]

JIRA: SB-6141

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>