### PR TITLE
toaster_configuration: Create sym link to downloads folder

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -161,6 +161,11 @@ POKYDIR=$(configured_layers | while read layer; do
           echo "$POKYDIR"
     fi
 done)
+
+if [ -d "${BUILDDIR}/../downloads" ]; then
+  ln -sf "${BUILDDIR}/../downloads" "${BUILDDIR}/"
+fi
+
    cat <<EOF > "$BUILDDIR"/toaster-setup-environment
 export TOASTER_CONF=$BUILDDIR/toasterconf.json
 $POKYDIR/bitbake/bin/toaster


### PR DESCRIPTION
Toaster is not following the DL_DIR in local.conf. Hence
creating symlink of downloads folder if available outside
build directory.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>