### PR TITLE
linux-ls1: Fix LPUART RX flag on FIFO Flush

### DIFF
--- a/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0001-serial-fsl_lpuart-Remove-unneeded-check-for-res.patch
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0001-serial-fsl_lpuart-Remove-unneeded-check-for-res.patch
@@ -1,0 +1,41 @@
+From b6b14347de5d973016175f156f9898cb27d4bd0e Mon Sep 17 00:00:00 2001
+From: Fabio Estevam <fabio.estevam@freescale.com>
+Date: Fri, 7 Nov 2014 00:23:13 -0200
+Subject: [PATCH 1/3] serial: fsl_lpuart: Remove unneeded check for 'res'
+
+'res' will be automatically checked inside devm_ioremap_resource(), so there is
+no need to explicitly perform a NULL check.
+
+Signed-off-by: Fabio Estevam <fabio.estevam@freescale.com>
+Acked-by: Jingchang Lu <jingchang.lu@freescale.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+---
+ drivers/tty/serial/fsl_lpuart.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/tty/serial/fsl_lpuart.c b/drivers/tty/serial/fsl_lpuart.c
+index 05a8235..f34d67d 100644
+--- a/drivers/tty/serial/fsl_lpuart.c
++++ b/drivers/tty/serial/fsl_lpuart.c
+@@ -1382,15 +1382,13 @@ static int lpuart_probe(struct platform_device *pdev)
+ 	}
+ 	sport->port.line = ret;
+ 	sport->lpuart32 = of_device_is_compatible(np, "fsl,ls1021a-lpuart");
+-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+-	if (!res)
+-		return -ENODEV;
+ 
+-	sport->port.mapbase = res->start;
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+ 	sport->port.membase = devm_ioremap_resource(&pdev->dev, res);
+ 	if (IS_ERR(sport->port.membase))
+ 		return PTR_ERR(sport->port.membase);
+ 
++	sport->port.mapbase = res->start;
+ 	sport->port.dev = &pdev->dev;
+ 	sport->port.type = PORT_LPUART;
+ 	sport->port.iotype = UPIO_MEM;
+-- 
+1.9.1
+

--- a/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0002-serial-fsl_lpuart-Remove-unneeded-registration-messa.patch
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0002-serial-fsl_lpuart-Remove-unneeded-registration-messa.patch
@@ -1,0 +1,42 @@
+From 89c44f92c730cb7436ae841234397ac500e1495f Mon Sep 17 00:00:00 2001
+From: Fabio Estevam <fabio.estevam@freescale.com>
+Date: Fri, 7 Nov 2014 00:23:14 -0200
+Subject: [PATCH 2/3] serial: fsl_lpuart: Remove unneeded registration message
+
+There is no real value in displaying "serial: Freescale lpuart driver" in every
+boot.
+
+The uart_register_driver() can fail and even so the "serial: Freescale lpuart
+driver" will be displayed, which is not really helpful.
+
+This is particularly annoying when booting multi_v7_defconfig kernel on a SoC
+that is not a Vybrid/Layerscape and even though this message gets displayed.
+
+Signed-off-by: Fabio Estevam <fabio.estevam@freescale.com>
+Acked-by: Jingchang Lu <jingchang.lu@freescale.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+---
+ drivers/tty/serial/fsl_lpuart.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/drivers/tty/serial/fsl_lpuart.c b/drivers/tty/serial/fsl_lpuart.c
+index f34d67d..f93c63b 100644
+--- a/drivers/tty/serial/fsl_lpuart.c
++++ b/drivers/tty/serial/fsl_lpuart.c
+@@ -1515,11 +1515,8 @@ static struct platform_driver lpuart_driver = {
+ 
+ static int __init lpuart_serial_init(void)
+ {
+-	int ret;
+-
+-	pr_info("serial: Freescale lpuart driver\n");
++	int ret = uart_register_driver(&lpuart_reg);
+ 
+-	ret = uart_register_driver(&lpuart_reg);
+ 	if (ret)
+ 		return ret;
+ 
+-- 
+1.9.1
+

--- a/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0003-tty-serial-fsl_lpuart-clear-receive-flag-on-FIFO-flu.patch
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1/0003-tty-serial-fsl_lpuart-clear-receive-flag-on-FIFO-flu.patch
@@ -1,0 +1,44 @@
+From c7a3fdfe6a22fa2a65495c699c6edbc7a50e2f9f Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 13 Mar 2015 14:51:51 +0100
+Subject: [PATCH 3/3] tty: serial: fsl_lpuart: clear receive flag on FIFO flush
+
+When the receiver was enabled during startup, a character could
+have been in the FIFO when the UART get initially used. The
+driver configures the (receive) watermark level, and flushes the
+FIFO. However, the receive flag (RDRF) could still be set at that
+stage (as mentioned in the register description of UARTx_RWFIFO).
+This leads to an interrupt which won't be handled properly in
+interrupt mode: The receive interrupt function lpuart_rxint checks
+the FIFO count, which is 0 at that point (due to the flush
+during initialization). The problem does not manifest when using
+DMA to receive characters.
+
+Fix this situation by explicitly read the status register, which
+leads to clearing of the RDRF flag. Due to the flush just after
+the status flag read, a explicit data read is not to required.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Cc: stable <stable@vger.kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/fsl_lpuart.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/tty/serial/fsl_lpuart.c b/drivers/tty/serial/fsl_lpuart.c
+index f93c63b..4b3eff6 100644
+--- a/drivers/tty/serial/fsl_lpuart.c
++++ b/drivers/tty/serial/fsl_lpuart.c
+@@ -678,6 +678,9 @@ static void lpuart_setup_watermark(struct lpuart_port *sport)
+ 	writeb(val | UARTPFIFO_TXFE | UARTPFIFO_RXFE,
+ 			sport->port.membase + UARTPFIFO);
+ 
++	/* explicitly clear RDRF */
++	readb(sport->port.membase + UARTSR1);
++
+ 	/* flush Tx and Rx FIFO */
+ 	writeb(UARTCFIFO_TXFLUSH | UARTCFIFO_RXFLUSH,
+ 			sport->port.membase + UARTCFIFO);
+-- 
+1.9.1
+

--- a/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1_3.12.bbappend
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1_3.12.bbappend
@@ -20,6 +20,9 @@ python () {
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "\
     file://unionfs-2.6_for_3.12.26.patch \
+    file://0001-serial-fsl_lpuart-Remove-unneeded-check-for-res.patch \
+    file://0002-serial-fsl_lpuart-Remove-unneeded-registration-messa.patch \
+    file://0003-tty-serial-fsl_lpuart-clear-receive-flag-on-FIFO-flu.patch \
     \
     file://kgdb.cfg \
     file://configs.cfg \


### PR DESCRIPTION
JIRA: SB-6248

The receive interrupt function lpuart_rxint checks the
FIFO count, which is 0 at that point (due to the flush
during initialization). The problem does not manifest
when using DMA to receive characters.

Explicitly read the status register, which leads to
clearing of the RDRF flag.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>