### PR TITLE
toaster-configuration: Fix downloads dir

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -162,8 +162,8 @@ POKYDIR=$(configured_layers | while read layer; do
     fi
 done)
 
-if [ -d "${BUILDDIR}/../downloads" ]; then
-  ln -sf "${BUILDDIR}/../downloads" "${BUILDDIR}/"
+if [ -d "${MELDIR}/downloads" ]; then
+  ln -sf "${MELDIR}/downloads" "${BUILDDIR}/"
 fi
 
    cat <<EOF > "$BUILDDIR"/toaster-setup-environment


### PR DESCRIPTION
Earlier download dir was referred from the BUILDDIR. Now
it has been referred from MELDIR. So if user creates build dir
in any location, the downloads dir will be created with reference
of MELDIR.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>