### PR TITLE
mesa-demos: drop obsolete demos

### DIFF
--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0001-drop-demos-dependant-on-obsolete-MESA_screen_surface.patch
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0001-drop-demos-dependant-on-obsolete-MESA_screen_surface.patch
@@ -1,0 +1,1590 @@
+commit 74443c6ee79f3251f643ea05e94df58183e37d0d
+Author: Matt Turner <mattst88@gmail.com>
+Date:   Fri Aug 28 15:57:38 2015 -0700
+
+    egl: Remove demos using EGL_MESA_screen_surface.
+    
+    The remnants of the extension were removed from Mesa in commit 7a58262e.
+    
+    Reviewed-by: Andreas Boll <andreas.boll.dev@gmail.com>
+    Tested-by: Andreas Boll <andreas.boll.dev@gmail.com>
+    Reviewed-by: Marek Olšák <marek.olsak@amd.com>
+
+diff --git a/src/egl/eglut/Makefile.am b/src/egl/eglut/Makefile.am
+index 2d2f2af..b765069 100644
+--- a/src/egl/eglut/Makefile.am
++++ b/src/egl/eglut/Makefile.am
+@@ -33,17 +33,12 @@ if HAVE_WAYLAND
+ eglut_wayland = libeglut_wayland.la
+ endif
+ 
+-noinst_LTLIBRARIES = libeglut_screen.la $(eglut_x11) $(eglut_wayland)
++noinst_LTLIBRARIES = $(eglut_x11) $(eglut_wayland)
+ endif
+ 
+-libeglut_screen_la_SOURCES = \
+-	eglut.c \
+-	eglut.h \
+-	eglutint.h \
+-	eglut_screen.c
+-
+ libeglut_x11_la_SOURCES = \
+ 	eglut.c \
++	eglut.h \
+ 	eglutint.h \
+ 	eglut_x11.c
+ libeglut_x11_la_CFLAGS = $(X11_CFLAGS) $(EGL_CFLAGS)
+@@ -52,6 +47,7 @@ libeglut_x11_la_LIBADD = $(X11_LIBS) $(EGL_LIBS)
+ 
+ libeglut_wayland_la_SOURCES = \
+ 	eglut.c \
++	eglut.h \
+ 	eglutint.h \
+ 	eglut_wayland.c
+ 
+diff --git a/src/egl/eglut/eglut.c b/src/egl/eglut/eglut.c
+index f6a2ad4..58b354a 100644
+--- a/src/egl/eglut/eglut.c
++++ b/src/egl/eglut/eglut.c
+@@ -176,9 +176,6 @@ _eglutCreateWindow(const char *title, int x, int y, int w, int h)
+             win->config, win->native.u.pixmap, NULL);
+       break;
+    case EGL_PBUFFER_BIT:
+-#ifdef EGL_MESA_screen_surface
+-   case EGL_SCREEN_BIT_MESA:
+-#endif
+       win->surface = win->native.u.surface;
+       break;
+    default:
+@@ -292,11 +289,7 @@ eglutDestroyWindow(int win)
+    if (window->index != win)
+       return;
+ 
+-#ifdef EGL_MESA_screen_surface
+-   /* XXX it causes some bug in st/egl KMS backend */
+-   if ( _eglut->surface_type != EGL_SCREEN_BIT_MESA)
+-#endif
+-      eglMakeCurrent(_eglut->dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
++   eglMakeCurrent(_eglut->dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+ 
+    _eglutDestroyWindow(_eglut->current);
+ }
+diff --git a/src/egl/eglut/eglut_screen.c b/src/egl/eglut/eglut_screen.c
+deleted file mode 100644
+index 094a4e2..0000000
+--- a/src/egl/eglut/eglut_screen.c
++++ /dev/null
+@@ -1,194 +0,0 @@
+-/*
+- * Copyright (C) 2010 LunarG Inc.
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining a
+- * copy of this software and associated documentation files (the "Software"),
+- * to deal in the Software without restriction, including without limitation
+- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+- * and/or sell copies of the Software, and to permit persons to whom the
+- * Software is furnished to do so, subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be included
+- * in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+- * DEALINGS IN THE SOFTWARE.
+- *
+- * Authors:
+- *    Chia-I Wu <olv@lunarg.com>
+- */
+-
+-#include <stdio.h>
+-#include <string.h>
+-#include <sys/time.h>
+-
+-#define EGL_EGLEXT_PROTOTYPES
+-#include "EGL/egl.h"
+-#include "EGL/eglext.h"
+-
+-#include "eglutint.h"
+-
+-#define MAX_MODES 100
+-
+-#ifdef EGL_MESA_screen_surface
+-static EGLScreenMESA kms_screen;
+-static EGLModeMESA kms_mode;
+-static EGLint kms_width, kms_height;
+-#endif
+-
+-void
+-_eglutNativeInitDisplay(void)
+-{
+-#ifdef EGL_MESA_screen_surface
+-   _eglut->native_dpy = EGL_DEFAULT_DISPLAY;
+-   _eglut->surface_type = EGL_SCREEN_BIT_MESA;
+-#endif
+-}
+-
+-void
+-_eglutNativeFiniDisplay(void)
+-{
+-#ifdef EGL_MESA_screen_surface
+-   kms_screen = 0;
+-   kms_mode = 0;
+-   kms_width = 0;
+-   kms_height = 0;
+-#endif
+-}
+-
+-#ifdef EGL_MESA_screen_surface
+-static void
+-init_kms(void)
+-{
+-   EGLModeMESA modes[MAX_MODES];
+-   EGLint num_screens, num_modes;
+-   EGLint width, height, best_mode;
+-   EGLint i;
+-
+-   if (!eglGetScreensMESA(_eglut->dpy, &kms_screen, 1, &num_screens) ||
+-         !num_screens)
+-      _eglutFatal("eglGetScreensMESA failed\n");
+-
+-   if (!eglGetModesMESA(_eglut->dpy, kms_screen,
+-            modes, MAX_MODES, &num_modes) || !num_modes)
+-      _eglutFatal("eglGetModesMESA failed!\n");
+-
+-   printf("Found %d modes:\n", num_modes);
+-
+-   best_mode = 0;
+-   width = 0;
+-   height = 0;
+-   for (i = 0; i < num_modes; i++) {
+-      EGLint w, h;
+-      eglGetModeAttribMESA(_eglut->dpy, modes[i], EGL_WIDTH, &w);
+-      eglGetModeAttribMESA(_eglut->dpy, modes[i], EGL_HEIGHT, &h);
+-      printf("%3d: %d x %d\n", i, w, h);
+-      if (w > width && h > height) {
+-         width = w;
+-         height = h;
+-         best_mode = i;
+-      }
+-   }
+-
+-   printf("Will use screen size: %d x %d\n", width, height);
+-
+-   kms_mode = modes[best_mode];
+-   kms_width = width;
+-   kms_height = height;
+-}
+-#endif
+-
+-void
+-_eglutNativeInitWindow(struct eglut_window *win, const char *title,
+-                       int x, int y, int w, int h)
+-{
+-#ifdef EGL_MESA_screen_surface
+-   EGLint surf_attribs[16];
+-   EGLint i;
+-#endif
+-   const char *exts;
+-
+-   exts = eglQueryString(_eglut->dpy, EGL_EXTENSIONS);
+-   if (!exts || !strstr(exts, "EGL_MESA_screen_surface"))
+-      _eglutFatal("EGL_MESA_screen_surface is not supported\n");
+-
+-#ifdef EGL_MESA_screen_surface
+-   init_kms();
+-
+-   i = 0;
+-   surf_attribs[i++] = EGL_WIDTH;
+-   surf_attribs[i++] = kms_width;
+-   surf_attribs[i++] = EGL_HEIGHT;
+-   surf_attribs[i++] = kms_height;
+-   surf_attribs[i++] = EGL_NONE;
+-
+-   /* create surface */
+-   win->native.u.surface = eglCreateScreenSurfaceMESA(_eglut->dpy,
+-         win->config, surf_attribs);
+-   if (win->native.u.surface == EGL_NO_SURFACE)
+-      _eglutFatal("eglCreateScreenSurfaceMESA failed\n");
+-
+-   if (!eglShowScreenSurfaceMESA(_eglut->dpy, kms_screen,
+-            win->native.u.surface, kms_mode))
+-      _eglutFatal("eglShowScreenSurfaceMESA failed\n");
+-
+-   win->native.width = kms_width;
+-   win->native.height = kms_height;
+-#endif
+-}
+-
+-void
+-_eglutNativeFiniWindow(struct eglut_window *win)
+-{
+-#ifdef EGL_MESA_screen_surface
+-   eglShowScreenSurfaceMESA(_eglut->dpy,
+-         kms_screen, EGL_NO_SURFACE, 0);
+-   eglDestroySurface(_eglut->dpy, win->native.u.surface);
+-#endif
+-}
+-
+-void
+-_eglutNativeEventLoop(void)
+-{
+-   int start = _eglutNow();
+-   int frames = 0;
+-
+-   _eglut->redisplay = 1;
+-
+-   while (1) {
+-      struct eglut_window *win = _eglut->current;
+-      int now = _eglutNow();
+-
+-      if (now - start > 5000) {
+-         double elapsed = (double) (now - start) / 1000.0;
+-
+-         printf("%d frames in %3.1f seconds = %6.3f FPS\n",
+-               frames, elapsed, frames / elapsed);
+-         fflush(stdout);
+-
+-         start = now;
+-         frames = 0;
+-
+-         /* send escape */
+-         if (win->keyboard_cb)
+-            win->keyboard_cb(27);
+-      }
+-
+-      if (_eglut->idle_cb)
+-         _eglut->idle_cb();
+-
+-      if (_eglut->redisplay) {
+-         _eglut->redisplay = 0;
+-
+-         if (win->display_cb)
+-            win->display_cb();
+-         eglSwapBuffers(_eglut->dpy, win->surface);
+-         frames++;
+-      }
+-   }
+-}
+diff --git a/src/egl/opengl/Makefile.am b/src/egl/opengl/Makefile.am
+index 87b2f1a..3e48141 100644
+--- a/src/egl/opengl/Makefile.am
++++ b/src/egl/opengl/Makefile.am
+@@ -51,20 +51,12 @@ endif
+ 
+ if HAVE_EGL
+ bin_PROGRAMS = \
+-	demo1 \
+-	demo2 \
+-	demo3 \
+ 	eglinfo \
+-	eglgears_screen \
+-	egltri_screen \
+ 	peglgears \
+ 	$(EGL_DRM_DEMOS) \
+ 	$(EGL_X11_DEMOS)
+ endif
+ 
+-egltri_screen_SOURCES = egltri.c
+-eglgears_screen_SOURCES = eglgears.c
+-
+ egltri_x11_SOURCES = egltri.c
+ eglgears_x11_SOURCES = eglgears.c
+ 
+@@ -73,9 +65,6 @@ egltri_x11_LDFLAGS = $(AM_LDFLAGS) $(X11_LIBS)
+ xeglgears_LDFLAGS = $(AM_LDFLAGS) $(X11_LIBS)
+ xeglthreads_LDFLAGS = $(AM_LDFLAGS) $(X11_LIBS) -pthread
+ 
+-eglgears_screen_LDADD = ../eglut/libeglut_screen.la
+-egltri_screen_LDADD = ../eglut/libeglut_screen.la
+-
+ eglgears_x11_LDADD = ../eglut/libeglut_x11.la
+ egltri_x11_LDADD = ../eglut/libeglut_x11.la
+ 
+diff --git a/src/egl/opengl/demo1.c b/src/egl/opengl/demo1.c
+deleted file mode 100644
+index 06e2138..0000000
+--- a/src/egl/opengl/demo1.c
++++ /dev/null
+@@ -1,155 +0,0 @@
+-/*
+- * Exercise EGL API functions
+- */
+-
+-#define EGL_EGLEXT_PROTOTYPES
+-
+-#include <EGL/egl.h>
+-#include <EGL/eglext.h>
+-#include <assert.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-
+-
+-/**
+- * Test EGL_MESA_screen_surface functions
+- */
+-static void
+-TestScreens(EGLDisplay dpy)
+-{
+-#ifdef EGL_MESA_screen_surface
+-#define MAX 8
+-   EGLScreenMESA screens[MAX];
+-   EGLint numScreens;
+-   EGLint i;
+-
+-   eglGetScreensMESA(dpy, screens, MAX, &numScreens);
+-   printf("Found %d screens\n", numScreens);
+-   for (i = 0; i < numScreens; i++) {
+-      printf(" Screen %d handle: %d\n", i, (int) screens[i]);
+-   }
+-#endif
+-}
+-
+-/**
+- * Print table of all available configurations.
+- */
+-static void
+-PrintConfigs(EGLDisplay d, EGLConfig *configs, EGLint numConfigs)
+-{
+-   EGLint i;
+-
+-   printf("Configurations:\n");
+-   printf("     bf lv d st colorbuffer dp st   supported \n");
+-   printf("  id sz  l b ro  r  g  b  a th cl   surfaces  \n");
+-   printf("----------------------------------------------\n");
+-   for (i = 0; i < numConfigs; i++) {
+-      EGLint id, size, level;
+-      EGLint red, green, blue, alpha;
+-      EGLint depth, stencil;
+-      EGLint surfaces;
+-      EGLint doubleBuf = 1, stereo = 0;
+-      char surfString[100] = "";
+-
+-      eglGetConfigAttrib(d, configs[i], EGL_CONFIG_ID, &id);
+-      eglGetConfigAttrib(d, configs[i], EGL_BUFFER_SIZE, &size);
+-      eglGetConfigAttrib(d, configs[i], EGL_LEVEL, &level);
+-
+-      eglGetConfigAttrib(d, configs[i], EGL_RED_SIZE, &red);
+-      eglGetConfigAttrib(d, configs[i], EGL_GREEN_SIZE, &green);
+-      eglGetConfigAttrib(d, configs[i], EGL_BLUE_SIZE, &blue);
+-      eglGetConfigAttrib(d, configs[i], EGL_ALPHA_SIZE, &alpha);
+-      eglGetConfigAttrib(d, configs[i], EGL_DEPTH_SIZE, &depth);
+-      eglGetConfigAttrib(d, configs[i], EGL_STENCIL_SIZE, &stencil);
+-      eglGetConfigAttrib(d, configs[i], EGL_SURFACE_TYPE, &surfaces);
+-
+-      if (surfaces & EGL_WINDOW_BIT)
+-         strcat(surfString, "win,");
+-      if (surfaces & EGL_PBUFFER_BIT)
+-         strcat(surfString, "pb,");
+-      if (surfaces & EGL_PIXMAP_BIT)
+-         strcat(surfString, "pix,");
+-      if (strlen(surfString) > 0)
+-         surfString[strlen(surfString) - 1] = 0;
+-
+-      printf("0x%02x %2d %2d %c  %c %2d %2d %2d %2d %2d %2d   %-12s\n",
+-             id, size, level,
+-             doubleBuf ? 'y' : '.',
+-             stereo ? 'y' : '.',
+-             red, green, blue, alpha,
+-             depth, stencil, surfString);
+-   }
+-}
+-
+-
+-
+-int
+-main(int argc, char *argv[])
+-{
+-   int maj, min;
+-   EGLContext ctx;
+-   EGLSurface pbuffer;
+-   EGLConfig *configs;
+-   EGLint numConfigs;
+-   EGLBoolean b;
+-   const EGLint pbufAttribs[] = {
+-      EGL_WIDTH, 500,
+-      EGL_HEIGHT, 500,
+-      EGL_NONE
+-   };
+-
+-   EGLDisplay d = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+-   assert(d);
+-
+-   if (!eglInitialize(d, &maj, &min)) {
+-      printf("demo: eglInitialize failed\n");
+-      exit(1);
+-   }
+-
+-   printf("EGL version = %d.%d\n", maj, min);
+-   printf("EGL_VENDOR = %s\n", eglQueryString(d, EGL_VENDOR));
+-
+-   if (!strstr(eglQueryString(d, EGL_EXTENSIONS),
+-               "EGL_MESA_screen_surface")) {
+-      printf("EGL_MESA_screen_surface is not supported\n");
+-      exit(1);
+-   }
+-
+-   eglGetConfigs(d, NULL, 0, &numConfigs);
+-   configs = malloc(sizeof(*configs) *numConfigs);
+-   eglGetConfigs(d, configs, numConfigs, &numConfigs);
+-
+-   PrintConfigs(d, configs, numConfigs);
+-
+-   eglBindAPI(EGL_OPENGL_API);
+-   ctx = eglCreateContext(d, configs[0], EGL_NO_CONTEXT, NULL);
+-   if (ctx == EGL_NO_CONTEXT) {
+-      printf("failed to create context\n");
+-      return 0;
+-   }
+-
+-   pbuffer = eglCreatePbufferSurface(d, configs[0], pbufAttribs);
+-   if (pbuffer == EGL_NO_SURFACE) {
+-      printf("failed to create pbuffer\n");
+-      return 0;
+-   }
+-
+-   free(configs);
+-
+-   b = eglMakeCurrent(d, pbuffer, pbuffer, ctx);
+-   if (!b) {
+-      printf("make current failed\n");
+-      return 0;
+-   }
+-
+-   b = eglMakeCurrent(d, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+-
+-   TestScreens(d);
+-
+-   eglDestroySurface(d, pbuffer);
+-   eglDestroyContext(d, ctx);
+-   eglTerminate(d);
+-
+-   return 0;
+-}
+diff --git a/src/egl/opengl/demo2.c b/src/egl/opengl/demo2.c
+deleted file mode 100644
+index bfef59e..0000000
+--- a/src/egl/opengl/demo2.c
++++ /dev/null
+@@ -1,221 +0,0 @@
+-/*
+- * Exercise EGL API functions
+- */
+-
+-#define EGL_EGLEXT_PROTOTYPES
+-
+-#include <assert.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <unistd.h>
+-
+-#include <EGL/egl.h>
+-#include <EGL/eglext.h>
+-#include "gl_wrap.h"
+-
+-/*#define FRONTBUFFER*/
+-
+-#ifdef EGL_MESA_screen_surface
+-static void _subset_Rectf(GLfloat x1, GLfloat y1, GLfloat x2, GLfloat y2,
+-                          GLfloat r, GLfloat g, GLfloat b)
+-{
+-   GLfloat v[4][2], c[4][4];
+-   int i;
+-
+-   v[0][0] = x1;   v[0][1] = y1;
+-   v[1][0] = x2;   v[1][1] = y1;
+-   v[2][0] = x2;   v[2][1] = y2;
+-   v[3][0] = x1;   v[3][1] = y2;
+-
+-   for (i = 0; i < 4; i++) {
+-      c[i][0] = r;
+-      c[i][1] = g;
+-      c[i][2] = b;
+-      c[i][3] = 1.0;
+-   }
+-
+-   glVertexPointer(2, GL_FLOAT, 0, v);
+-   glColorPointer(4, GL_FLOAT, 0, c);
+-   glEnableClientState(GL_VERTEX_ARRAY);
+-   glEnableClientState(GL_COLOR_ARRAY);
+-
+-   glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+-
+-   glDisableClientState(GL_VERTEX_ARRAY);
+-   glDisableClientState(GL_COLOR_ARRAY);
+-}
+-
+-
+-static void redraw(EGLDisplay dpy, EGLSurface surf, int rot)
+-{
+-   GLfloat r, g, b;
+-
+-   printf("Redraw event\n");
+-
+-   glClearColor( rand()/(float)RAND_MAX, 
+-		 rand()/(float)RAND_MAX, 
+-		 rand()/(float)RAND_MAX,
+-		 1);
+-
+-   glClear( GL_COLOR_BUFFER_BIT ); 
+-
+-   r = rand()/(float)RAND_MAX;
+-   g = rand()/(float)RAND_MAX;
+-   b = rand()/(float)RAND_MAX;
+-
+-   glPushMatrix();
+-   glRotatef(rot, 0, 0, 1);
+-   glScalef(.5, .5, .5);
+-   _subset_Rectf( -1, -1, 1, 1, r, g, b );
+-   glPopMatrix();
+-
+-#ifdef FRONTBUFFER
+-   glFlush();
+-#else
+-   eglSwapBuffers( dpy, surf ); 
+-#endif
+-   glFinish();
+-}
+-
+-
+-/**
+- * Test EGL_MESA_screen_surface functions
+- */
+-static void
+-TestScreens(EGLDisplay dpy)
+-{
+-#define MAX 8
+-   EGLScreenMESA screens[MAX];
+-   EGLint numScreens;
+-   EGLint i;
+-
+-   eglGetScreensMESA(dpy, screens, MAX, &numScreens);
+-   printf("Found %d screens\n", numScreens);
+-   for (i = 0; i < numScreens; i++) {
+-      printf(" Screen %d handle: %d\n", i, (int) screens[i]);
+-   }
+-}
+-#endif
+-
+-int
+-main(int argc, char *argv[])
+-{
+-   int maj, min;
+-#ifdef EGL_MESA_screen_surface
+-   EGLContext ctx;
+-   EGLSurface pbuffer, screen_surf;
+-   EGLConfig configs[10];
+-   EGLint numConfigs, i;
+-   EGLBoolean b;
+-   const EGLint pbufAttribs[] = {
+-      EGL_WIDTH, 500,
+-      EGL_HEIGHT, 500,
+-      EGL_NONE
+-   };
+-   EGLint screenAttribs[32];
+-   EGLModeMESA mode;
+-   EGLScreenMESA screen;
+-   EGLint count;
+-#endif
+-
+-   EGLDisplay d = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+-   assert(d);
+-
+-   if (!eglInitialize(d, &maj, &min)) {
+-      printf("demo: eglInitialize failed\n");
+-      exit(1);
+-   }
+-
+-   printf("EGL version = %d.%d\n", maj, min);
+-   printf("EGL_VENDOR = %s\n", eglQueryString(d, EGL_VENDOR));
+-   if (!strstr(eglQueryString(d, EGL_EXTENSIONS),
+-               "EGL_MESA_screen_surface")) {
+-      printf("EGL_MESA_screen_surface is not supported\n");
+-      exit(1);
+-   }
+-
+-#ifdef EGL_MESA_screen_surface
+-   eglGetConfigs(d, configs, 10, &numConfigs);
+-   printf("Got %d EGL configs:\n", numConfigs);
+-   for (i = 0; i < numConfigs; i++) {
+-      EGLint id, red, depth;
+-      eglGetConfigAttrib(d, configs[i], EGL_CONFIG_ID, &id);
+-      eglGetConfigAttrib(d, configs[i], EGL_RED_SIZE, &red);
+-      eglGetConfigAttrib(d, configs[i], EGL_DEPTH_SIZE, &depth);
+-      printf("%2d:  Red Size = %d  Depth Size = %d\n", id, red, depth);
+-   }
+-   
+-   eglGetScreensMESA(d, &screen, 1, &count);
+-   eglGetModesMESA(d, screen, &mode, 1, &count);
+-
+-   eglBindAPI(EGL_OPENGL_API);
+-   ctx = eglCreateContext(d, configs[0], EGL_NO_CONTEXT, NULL);
+-   if (ctx == EGL_NO_CONTEXT) {
+-      printf("failed to create context\n");
+-      return 0;
+-   }
+-
+-   pbuffer = eglCreatePbufferSurface(d, configs[0], pbufAttribs);
+-   if (pbuffer == EGL_NO_SURFACE) {
+-      printf("failed to create pbuffer\n");
+-      return 0;
+-   }
+-
+-   b = eglMakeCurrent(d, pbuffer, pbuffer, ctx);
+-   if (!b) {
+-      printf("make current failed\n");
+-      return 0;
+-   }
+-
+-   b = eglMakeCurrent(d, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+-
+-   i = 0;
+-   screenAttribs[i++] = EGL_WIDTH;
+-   eglGetModeAttribMESA(d, mode, EGL_WIDTH, &screenAttribs[i++]);
+-   screenAttribs[i++] = EGL_HEIGHT;
+-   eglGetModeAttribMESA(d, mode, EGL_HEIGHT, &screenAttribs[i++]);
+-   screenAttribs[i] = EGL_NONE;
+-
+-   screen_surf = eglCreateScreenSurfaceMESA(d, configs[0], screenAttribs);
+-   if (screen_surf == EGL_NO_SURFACE) {
+-      printf("failed to create screen surface\n");
+-      return 0;
+-   }
+-   
+-   eglShowScreenSurfaceMESA(d, screen, screen_surf, mode);
+-
+-   b = eglMakeCurrent(d, screen_surf, screen_surf, ctx);
+-   if (!b) {
+-      printf("make current failed\n");
+-      return 0;
+-   }
+-
+-   glViewport(0, 0, 1024, 768);
+-
+-   glClearColor( 0, 
+-		 1.0, 
+-		 0,
+-		 1);
+-
+-   glClear( GL_COLOR_BUFFER_BIT ); 
+-   
+-      
+-   TestScreens(d);
+-
+-   glShadeModel( GL_FLAT );
+-   
+-   for (i = 0; i < 6; i++) {
+-      redraw(d, screen_surf, i*10 );
+-
+-      printf("sleep(1)\n");   
+-      sleep(1);  
+-   }
+-
+-   eglDestroySurface(d, pbuffer);
+-   eglDestroyContext(d, ctx);
+-   eglTerminate(d);
+-#endif
+-
+-   return 0;
+-}
+diff --git a/src/egl/opengl/demo3.c b/src/egl/opengl/demo3.c
+deleted file mode 100644
+index 31b5d8b..0000000
+--- a/src/egl/opengl/demo3.c
++++ /dev/null
+@@ -1,652 +0,0 @@
+-/*
+- * Exercise EGL API functions
+- */
+-
+-#define EGL_EGLEXT_PROTOTYPES
+-
+-#include <EGL/egl.h>
+-#include <EGL/eglext.h>
+-#include "gl_wrap.h"
+-#include <assert.h>
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include <unistd.h>
+-
+-
+-
+-#define PIXEL_CENTER(x) ((long)(x) + 0.5)
+-
+-#define GAP 10
+-#define ROWS 3
+-#define COLS 4
+-
+-#define OPENGL_WIDTH 48
+-#define OPENGL_HEIGHT 13
+-
+-
+-GLenum rgb, doubleBuffer, windType;
+-GLint windW, windH;
+-
+-GLenum mode1, mode2;
+-GLint boxW, boxH;
+-GLubyte OpenGL_bits[] = {
+-   0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 
+-   0x7f, 0xfb, 0xff, 0xff, 0xff, 0x01,
+-   0x7f, 0xfb, 0xff, 0xff, 0xff, 0x01, 
+-   0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
+-   0x3e, 0x8f, 0xb7, 0xf9, 0xfc, 0x01, 
+-   0x63, 0xdb, 0xb0, 0x8d, 0x0d, 0x00,
+-   0x63, 0xdb, 0xb7, 0x8d, 0x0d, 0x00, 
+-   0x63, 0xdb, 0xb6, 0x8d, 0x0d, 0x00,
+-   0x63, 0x8f, 0xf3, 0xcc, 0x0d, 0x00, 
+-   0x63, 0x00, 0x00, 0x0c, 0x4c, 0x0a,
+-   0x63, 0x00, 0x00, 0x0c, 0x4c, 0x0e, 
+-   0x63, 0x00, 0x00, 0x8c, 0xed, 0x0e,
+-   0x3e, 0x00, 0x00, 0xf8, 0x0c, 0x00, 
+-};
+-
+-#ifdef EGL_MESA_screen_surface
+-static void Init(void)
+-{
+-
+-    mode1 = GL_TRUE;
+-    mode2 = GL_TRUE;
+-}
+-
+-static void Reshape(int width, int height)
+-{
+-
+-    windW = (GLint)width;
+-    windH = (GLint)height;
+-}
+-
+-#if 0
+-static void RotateColorMask(void)
+-{
+-    static GLint rotation = 0;
+-    
+-    rotation = (rotation + 1) & 0x3;
+-    switch (rotation) {
+-      case 0:
+-	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+-	glIndexMask( 0xff );
+-	break;
+-      case 1:
+-	glColorMask(GL_FALSE, GL_TRUE, GL_TRUE, GL_TRUE);
+-	glIndexMask(0xFE);
+-	break;
+-      case 2:
+-	glColorMask(GL_TRUE, GL_FALSE, GL_TRUE, GL_TRUE);
+-	glIndexMask(0xFD);
+-	break;
+-      case 3:
+-	glColorMask(GL_TRUE, GL_TRUE, GL_FALSE, GL_TRUE);
+-	glIndexMask(0xFB);
+-	break;
+-    }
+-}
+-#endif
+-
+-static void Viewport(GLint row, GLint column)
+-{
+-    GLint x, y;
+-
+-    boxW = (windW - (COLS + 1) * GAP) / COLS;
+-    boxH = (windH - (ROWS + 1) * GAP) / ROWS;
+-
+-    x = GAP + column * (boxW + GAP);
+-    y = GAP + row * (boxH + GAP);
+-
+-    glViewport(x, y, boxW, boxH);
+-
+-    glMatrixMode(GL_PROJECTION);
+-    glLoadIdentity();
+-    glOrtho(-boxW/2, boxW/2, -boxH/2, boxH/2, 0.0, 1.0);
+-    glMatrixMode(GL_MODELVIEW);
+-
+-    glEnable(GL_SCISSOR_TEST);
+-    glScissor(x, y, boxW, boxH);
+-}
+-
+-enum {
+-    COLOR_BLACK = 0,
+-    COLOR_RED,
+-    COLOR_GREEN,
+-    COLOR_YELLOW,
+-    COLOR_BLUE,
+-    COLOR_MAGENTA,
+-    COLOR_CYAN,
+-    COLOR_WHITE
+-};
+-
+-static float RGBMap[9][3] = {
+-    {0, 0, 0},
+-    {1, 0, 0},
+-    {0, 1, 0},
+-    {1, 1, 0},
+-    {0, 0, 1},
+-    {1, 0, 1},
+-    {0, 1, 1},
+-    {1, 1, 1},
+-    {0.5, 0.5, 0.5}
+-};
+-
+-static void SetColor(int c)
+-{
+-     glColor3fv(RGBMap[c]);
+-}
+-
+-static void Point(void)
+-{
+-    GLint i;
+-
+-    glBegin(GL_POINTS);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(0, 0);
+-	for (i = 1; i < 8; i++) {
+-	    GLint j = i * 2;
+-	    SetColor(COLOR_BLACK+i);
+-	    glVertex2i(-j, -j);
+-	    glVertex2i(-j, 0);
+-	    glVertex2i(-j, j);
+-	    glVertex2i(0, j);
+-	    glVertex2i(j, j);
+-	    glVertex2i(j, 0);
+-	    glVertex2i(j, -j);
+-	    glVertex2i(0, -j);
+-	}
+-    glEnd();
+-}
+-
+-static void Lines(void)
+-{
+-    GLint i;
+-
+-    glPushMatrix();
+-
+-    glTranslatef(-12, 0, 0);
+-    for (i = 1; i < 8; i++) {
+-	SetColor(COLOR_BLACK+i);
+-	glBegin(GL_LINES);
+-	    glVertex2i(-boxW/4, -boxH/4);
+-	    glVertex2i(boxW/4, boxH/4);
+-	glEnd();
+-	glTranslatef(4, 0, 0);
+-    }
+-
+-    glPopMatrix();
+-
+-    glBegin(GL_LINES);
+-	glVertex2i(0, 0);
+-    glEnd();
+-}
+-
+-static void LineStrip(void)
+-{
+-
+-    glBegin(GL_LINE_STRIP);
+-	SetColor(COLOR_RED);
+-	glVertex2f(PIXEL_CENTER(-boxW/4), PIXEL_CENTER(-boxH/4));
+-	SetColor(COLOR_GREEN);
+-	glVertex2f(PIXEL_CENTER(-boxW/4), PIXEL_CENTER(boxH/4));
+-	SetColor(COLOR_BLUE);
+-	glVertex2f(PIXEL_CENTER(boxW/4), PIXEL_CENTER(boxH/4));
+-	SetColor(COLOR_WHITE);
+-	glVertex2f(PIXEL_CENTER(boxW/4), PIXEL_CENTER(-boxH/4));
+-    glEnd();
+-
+-    glBegin(GL_LINE_STRIP);
+-	glVertex2i(0, 0);
+-    glEnd();
+-}
+-
+-static void LineLoop(void)
+-{
+-
+-    glBegin(GL_LINE_LOOP);
+-	SetColor(COLOR_RED);
+-	glVertex2f(PIXEL_CENTER(-boxW/4), PIXEL_CENTER(-boxH/4));
+-	SetColor(COLOR_GREEN);
+-	glVertex2f(PIXEL_CENTER(-boxW/4), PIXEL_CENTER(boxH/4));
+-	SetColor(COLOR_BLUE);
+-	glVertex2f(PIXEL_CENTER(boxW/4), PIXEL_CENTER(boxH/4));
+-	SetColor(COLOR_WHITE);
+-	glVertex2f(PIXEL_CENTER(boxW/4), PIXEL_CENTER(-boxH/4));
+-    glEnd();
+-
+-    glEnable(GL_LOGIC_OP);
+-    glLogicOp(GL_XOR);
+-
+-    glEnable(GL_BLEND);
+-    glBlendFunc(GL_ONE, GL_ONE);
+-
+-    SetColor(COLOR_MAGENTA);
+-    glBegin(GL_LINE_LOOP);
+-	glVertex2f(PIXEL_CENTER(-boxW/8), PIXEL_CENTER(-boxH/8));
+-	glVertex2f(PIXEL_CENTER(-boxW/8), PIXEL_CENTER(boxH/8));
+-    glEnd();
+-    glBegin(GL_LINE_LOOP);
+-	glVertex2f(PIXEL_CENTER(-boxW/8), PIXEL_CENTER(boxH/8+5));
+-	glVertex2f(PIXEL_CENTER(boxW/8), PIXEL_CENTER(boxH/8+5));
+-    glEnd();
+-    glDisable(GL_LOGIC_OP);
+-    glDisable(GL_BLEND);
+-
+-    SetColor(COLOR_GREEN);
+-    glBegin(GL_POINTS);
+-	glVertex2i(0, 0);
+-    glEnd();
+-
+-    glBegin(GL_LINE_LOOP);
+-	glVertex2i(0, 0);
+-    glEnd();
+-}
+-
+-static void Bitmap(void)
+-{
+-
+-    glBegin(GL_LINES);
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/2, 0);
+-	glVertex2i(boxW/2, 0);
+-	glVertex2i(0, -boxH/2);
+-	glVertex2i(0, boxH/2);
+-	SetColor(COLOR_RED);
+-	glVertex2i(0, -3);
+-	glVertex2i(0, -3+OPENGL_HEIGHT);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(0, -3);
+-	glVertex2i(OPENGL_WIDTH, -3);
+-    glEnd();
+-
+-    SetColor(COLOR_GREEN);
+-
+-    glPixelStorei(GL_UNPACK_LSB_FIRST, GL_TRUE);
+-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+-
+-    glRasterPos2i(0, 0);
+-    glBitmap(OPENGL_WIDTH, OPENGL_HEIGHT, 0, 3, 0.0, 0.0, OpenGL_bits);
+-}
+-
+-static void Triangles(void)
+-{
+-
+-    glBegin(GL_TRIANGLES);
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, -boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/8, -boxH/16);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(boxW/8, -boxH/16);
+-
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/8, boxH/16);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(boxW/8, boxH/16);
+-    glEnd();
+-
+-    glBegin(GL_TRIANGLES);
+-	glVertex2i(0, 0);
+-	glVertex2i(-100, 100);
+-    glEnd();
+-}
+-
+-static void TriangleStrip(void)
+-{
+-
+-    glBegin(GL_TRIANGLE_STRIP);
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, -boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/4, boxH/4);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(0, -boxH/4);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(0, boxH/4);
+-	SetColor(COLOR_CYAN);
+-	glVertex2i(boxW/4, -boxH/4);
+-	SetColor(COLOR_YELLOW);
+-	glVertex2i(boxW/4, boxH/4);
+-    glEnd();
+-
+-    glBegin(GL_TRIANGLE_STRIP);
+-	glVertex2i(0, 0);
+-	glVertex2i(-100, 100);
+-    glEnd();
+-}
+-
+-static void TriangleFan(void)
+-{
+-    GLint vx[8][2];
+-    GLint x0, y0, x1, y1, x2, y2, x3, y3;
+-    GLint i;
+-
+-    y0 = -boxH/4;
+-    y1 = y0 + boxH/2/3;
+-    y2 = y1 + boxH/2/3;
+-    y3 = boxH/4;
+-    x0 = -boxW/4;
+-    x1 = x0 + boxW/2/3;
+-    x2 = x1 + boxW/2/3;
+-    x3 = boxW/4;
+-
+-    vx[0][0] = x0; vx[0][1] = y1;
+-    vx[1][0] = x0; vx[1][1] = y2;
+-    vx[2][0] = x1; vx[2][1] = y3;
+-    vx[3][0] = x2; vx[3][1] = y3;
+-    vx[4][0] = x3; vx[4][1] = y2;
+-    vx[5][0] = x3; vx[5][1] = y1;
+-    vx[6][0] = x2; vx[6][1] = y0;
+-    vx[7][0] = x1; vx[7][1] = y0;
+-
+-    glBegin(GL_TRIANGLE_FAN);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(0, 0);
+-	for (i = 0; i < 8; i++) {
+-	    SetColor(COLOR_WHITE-i);
+-	    glVertex2iv(vx[i]);
+-	}
+-    glEnd();
+-
+-    glBegin(GL_TRIANGLE_FAN);
+-	glVertex2i(0, 0);
+-	glVertex2i(-100, 100);
+-    glEnd();
+-}
+-
+-static void Rect(void)
+-{
+-
+-    SetColor(COLOR_GREEN);
+-    glRecti(-boxW/4, -boxH/4, boxW/4, boxH/4);
+-}
+-
+-static void PolygonFunc(void)
+-{
+-    GLint vx[8][2];
+-    GLint x0, y0, x1, y1, x2, y2, x3, y3;
+-    GLint i;
+-
+-    y0 = -boxH/4;
+-    y1 = y0 + boxH/2/3;
+-    y2 = y1 + boxH/2/3;
+-    y3 = boxH/4;
+-    x0 = -boxW/4;
+-    x1 = x0 + boxW/2/3;
+-    x2 = x1 + boxW/2/3;
+-    x3 = boxW/4;
+-
+-    vx[0][0] = x0; vx[0][1] = y1;
+-    vx[1][0] = x0; vx[1][1] = y2;
+-    vx[2][0] = x1; vx[2][1] = y3;
+-    vx[3][0] = x2; vx[3][1] = y3;
+-    vx[4][0] = x3; vx[4][1] = y2;
+-    vx[5][0] = x3; vx[5][1] = y1;
+-    vx[6][0] = x2; vx[6][1] = y0;
+-    vx[7][0] = x1; vx[7][1] = y0;
+-
+-    glBegin(GL_POLYGON);
+-	for (i = 0; i < 8; i++) {
+-	    SetColor(COLOR_WHITE-i);
+-	    glVertex2iv(vx[i]);
+-	}
+-    glEnd();
+-
+-    glBegin(GL_POLYGON);
+-	glVertex2i(0, 0);
+-	glVertex2i(100, 100);
+-    glEnd();
+-}
+-
+-static void Quads(void)
+-{
+-
+-    glBegin(GL_QUADS);
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, -boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/8, -boxH/16);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(boxW/8, -boxH/16);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(boxW/4, -boxH/4);
+-
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/8, boxH/16);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(boxW/8, boxH/16);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(boxW/4, boxH/4);
+-    glEnd();
+-
+-    glBegin(GL_QUADS);
+-	glVertex2i(0, 0);
+-	glVertex2i(100, 100);
+-	glVertex2i(-100, 100);
+-    glEnd();
+-}
+-
+-static void QuadStrip(void)
+-{
+-
+-    glBegin(GL_QUAD_STRIP);
+-	SetColor(COLOR_GREEN);
+-	glVertex2i(-boxW/4, -boxH/4);
+-	SetColor(COLOR_RED);
+-	glVertex2i(-boxW/4, boxH/4);
+-	SetColor(COLOR_BLUE);
+-	glVertex2i(0, -boxH/4);
+-	SetColor(COLOR_WHITE);
+-	glVertex2i(0, boxH/4);
+-	SetColor(COLOR_CYAN);
+-	glVertex2i(boxW/4, -boxH/4);
+-	SetColor(COLOR_YELLOW);
+-	glVertex2i(boxW/4, boxH/4);
+-    glEnd();
+-
+-    glBegin(GL_QUAD_STRIP);
+-	glVertex2i(0, 0);
+-	glVertex2i(100, 100);
+-	glVertex2i(-100, 100);
+-    glEnd();
+-}
+-
+-static void Draw(EGLDisplay dpy, EGLSurface surf)
+-{
+-
+-    glViewport(0, 0, windW, windH);
+-    glDisable(GL_SCISSOR_TEST);
+-
+-    glPushAttrib(GL_COLOR_BUFFER_BIT);
+-
+-    glColorMask(1, 1, 1, 1);
+-    glIndexMask(~0);
+-
+-    glClearColor(0.0, 0.0, 0.0, 0.0);
+-    glClear(GL_COLOR_BUFFER_BIT);
+-
+-    glPopAttrib();
+-
+-    if (mode1) {
+-	glShadeModel(GL_SMOOTH);
+-    } else {
+-	glShadeModel(GL_FLAT);
+-    }
+-
+-    if (mode2) {
+-	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+-    } else {
+-	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+-    }
+-
+-    Viewport(0, 0); Point();
+-    Viewport(0, 1); Lines();
+-    Viewport(0, 2); LineStrip();
+-    Viewport(0, 3); LineLoop();
+-
+-    Viewport(1, 0); Bitmap();
+-
+-    Viewport(1, 1); TriangleFan();
+-    Viewport(1, 2); Triangles();
+-    Viewport(1, 3); TriangleStrip();
+-
+-    Viewport(2, 0); Rect();
+-    Viewport(2, 1); PolygonFunc();
+-    Viewport(2, 2); Quads();
+-    Viewport(2, 3); QuadStrip();
+-
+-    glFlush();
+-
+-    if (doubleBuffer) {
+-	eglSwapBuffers(dpy, surf);
+-    }
+-}
+-
+-static void
+-write_ppm(const char *filename, const GLubyte *buffer, int width, int height)
+-{
+-   const int binary = 0;
+-   FILE *f = fopen( filename, "w" );
+-   if (f) {
+-      int i, x, y;
+-      const GLubyte *ptr = buffer;
+-      if (binary) {
+-         fprintf(f,"P6\n");
+-         fprintf(f,"# ppm-file created by osdemo.c\n");
+-         fprintf(f,"%i %i\n", width,height);
+-         fprintf(f,"255\n");
+-         fclose(f);
+-         f = fopen( filename, "ab" );  /* reopen in binary append mode */
+-         for (y=height-1; y>=0; y--) {
+-            for (x=0; x<width; x++) {
+-               i = (y*width + x) * 4;
+-               fputc(ptr[i], f);   /* write red */
+-               fputc(ptr[i+1], f); /* write green */
+-               fputc(ptr[i+2], f); /* write blue */
+-            }
+-         }
+-      }
+-      else {
+-         /*ASCII*/
+-         int counter = 0;
+-         fprintf(f,"P3\n");
+-         fprintf(f,"# ascii ppm file created by osdemo.c\n");
+-         fprintf(f,"%i %i\n", width, height);
+-         fprintf(f,"255\n");
+-         for (y=height-1; y>=0; y--) {
+-            for (x=0; x<width; x++) {
+-               i = (y*width + x) * 4;
+-               fprintf(f, " %3d %3d %3d", ptr[i], ptr[i+1], ptr[i+2]);
+-               counter++;
+-               if (counter % 5 == 0)
+-                  fprintf(f, "\n");
+-            }
+-         }
+-      }
+-      fclose(f);
+-   }
+-}
+-#endif
+-
+-int
+-main(int argc, char *argv[])
+-{
+-   int maj, min;
+-#ifdef EGL_MESA_screen_surface
+-   EGLContext ctx;
+-   EGLSurface screen_surf;
+-   EGLConfig configs[10];
+-   EGLScreenMESA screen;
+-   EGLModeMESA mode;
+-   EGLint numConfigs, count;
+-   EGLBoolean b;
+-   const GLubyte *bitmap;
+-   EGLint screenAttribs[32];
+-   EGLint i;
+-#endif
+-
+-   EGLDisplay d = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+-   assert(d);
+-
+-   if (!eglInitialize(d, &maj, &min)) {
+-      printf("demo: eglInitialize failed\n");
+-      exit(1);
+-   }
+-
+-   printf("EGL version = %d.%d\n", maj, min);
+-   printf("EGL_VENDOR = %s\n", eglQueryString(d, EGL_VENDOR));
+-   if (!strstr(eglQueryString(d, EGL_EXTENSIONS),
+-               "EGL_MESA_screen_surface")) {
+-      printf("EGL_MESA_screen_surface is not supported\n");
+-      exit(1);
+-   }
+-
+-#ifdef EGL_MESA_screen_surface
+-   eglGetConfigs(d, configs, 10, &numConfigs);
+-   eglGetScreensMESA(d, &screen, 1, &count);
+-   eglGetModesMESA(d, screen, &mode, 1, &count);
+-
+-   eglBindAPI(EGL_OPENGL_API);
+-   ctx = eglCreateContext(d, configs[0], EGL_NO_CONTEXT, NULL);
+-   if (ctx == EGL_NO_CONTEXT) {
+-      printf("failed to create context\n");
+-      return 0;
+-   }
+-
+-   i = 0;
+-   screenAttribs[i++] = EGL_WIDTH;
+-   eglGetModeAttribMESA(d, mode, EGL_WIDTH, &screenAttribs[i++]);
+-   screenAttribs[i++] = EGL_HEIGHT;
+-   eglGetModeAttribMESA(d, mode, EGL_HEIGHT, &screenAttribs[i++]);
+-   screenAttribs[i] = EGL_NONE;
+-
+-   screen_surf = eglCreateScreenSurfaceMESA(d, configs[0], screenAttribs);
+-   if (screen_surf == EGL_NO_SURFACE) {
+-      printf("failed to create screen surface\n");
+-      return 0;
+-   }
+-
+-   eglShowScreenSurfaceMESA(d, screen, screen_surf, mode);
+-
+-   b = eglMakeCurrent(d, screen_surf, screen_surf, ctx);
+-   if (!b) {
+-      printf("make current failed\n");
+-      return 0;
+-   }
+-   glViewport(0, 0, 1024, 768);
+-
+-
+-   Init();
+-   Reshape(1024, 768);
+-
+-   /* some drivers crash when rendering to front buffer */
+-#if 0
+-   glDrawBuffer( GL_FRONT );
+-   glClearColor( 0, 1.0, 0, 1);
+-
+-   glClear( GL_COLOR_BUFFER_BIT );
+-#endif
+-
+-   doubleBuffer = 1;
+-   glDrawBuffer( GL_BACK );
+-
+-   Draw(d, screen_surf);
+-   sleep(2);
+-
+-   /* TODO EGL_KHR_lock_surface */
+-   bitmap = NULL;
+-   if (bitmap)
+-      write_ppm("dump.ppm", bitmap, 1024, 768);
+-
+-   eglDestroySurface(d, screen_surf);
+-   eglDestroyContext(d, ctx);
+-   eglTerminate(d);
+-#endif
+-
+-   return 0;
+-}
+diff --git a/src/egl/opengl/eglinfo.c b/src/egl/opengl/eglinfo.c
+index 8e82e73..1f79fef 100644
+--- a/src/egl/opengl/eglinfo.c
++++ b/src/egl/opengl/eglinfo.c
+@@ -93,10 +93,6 @@ PrintConfigs(EGLDisplay d)
+          strcat(surfString, "pb,");
+       if (surfaces & EGL_PIXMAP_BIT)
+          strcat(surfString, "pix,");
+-#ifdef EGL_MESA_screen_surface
+-      if (surfaces & EGL_SCREEN_BIT_MESA)
+-         strcat(surfString, "scrn,");
+-#endif
+       if (strlen(surfString) > 0)
+          surfString[strlen(surfString) - 1] = 0;
+ 
+@@ -117,45 +113,6 @@ PrintConfigs(EGLDisplay d)
+ }
+ 
+ 
+-/**
+- * Print table of all available configurations.
+- */
+-static void
+-PrintModes(EGLDisplay d)
+-{
+-#ifdef EGL_MESA_screen_surface
+-   const char *extensions = eglQueryString(d, EGL_EXTENSIONS);
+-   if (strstr(extensions, "EGL_MESA_screen_surface")) {
+-      EGLScreenMESA screens[MAX_SCREENS];
+-      EGLint numScreens = 1, scrn;
+-      EGLModeMESA modes[MAX_MODES];
+-
+-      eglGetScreensMESA(d, screens, MAX_SCREENS, &numScreens);
+-      printf("Number of Screens: %d\n\n", numScreens);
+-
+-      for (scrn = 0; scrn < numScreens; scrn++) {
+-         EGLint numModes, i;
+-
+-         eglGetModesMESA(d, screens[scrn], modes, MAX_MODES, &numModes);
+-
+-         printf("Screen %d Modes:\n", scrn);
+-         printf("  id  width height refresh  name\n");
+-         printf("-----------------------------------------\n");
+-         for (i = 0; i < numModes; i++) {
+-            EGLint id, w, h, r;
+-            const char *str;
+-            eglGetModeAttribMESA(d, modes[i], EGL_MODE_ID_MESA, &id);
+-            eglGetModeAttribMESA(d, modes[i], EGL_WIDTH, &w);
+-            eglGetModeAttribMESA(d, modes[i], EGL_HEIGHT, &h);
+-            eglGetModeAttribMESA(d, modes[i], EGL_REFRESH_RATE_MESA, &r);
+-            str = eglQueryModeStringMESA(d, modes[i]);
+-            printf("0x%02x %5d  %5d   %.3f  %s\n", id, w, h, r / 1000.0, str);
+-         }
+-      }
+-   }
+-#endif
+-}
+-
+ static void
+ PrintExtensions(EGLDisplay d)
+ {
+@@ -215,8 +172,6 @@ main(int argc, char *argv[])
+ 
+    PrintConfigs(d);
+ 
+-   PrintModes(d);
+-
+    eglTerminate(d);
+ 
+    return 0;
+diff --git a/src/egl/opengles1/Makefile.am b/src/egl/opengles1/Makefile.am
+index 516e516..1cc2e1f 100644
+--- a/src/egl/opengles1/Makefile.am
++++ b/src/egl/opengles1/Makefile.am
+@@ -38,24 +38,6 @@ AM_LDFLAGS = \
+ 
+ bin_PROGRAMS =
+ 
+-if HAVE_EGL
+-if HAVE_GLESV1
+-bin_PROGRAMS += \
+-	drawtex_screen \
+-	gears_screen \
+-	torus_screen \
+-	tri_screen
+-
+-drawtex_screen_SOURCES = drawtex.c
+-gears_screen_SOURCES = gears.c
+-torus_screen_SOURCES = torus.c
+-tri_screen_SOURCES = tri.c
+-
+-drawtex_screen_LDADD = ../eglut/libeglut_screen.la
+-gears_screen_LDADD = ../eglut/libeglut_screen.la
+-torus_screen_LDADD = ../eglut/libeglut_screen.la
+-tri_screen_LDADD = ../eglut/libeglut_screen.la
+-
+ if HAVE_X11
+ bin_PROGRAMS += \
+ 	clear \
+@@ -94,5 +76,3 @@ gears_x11_LDADD = ../eglut/libeglut_x11.la
+ torus_x11_LDADD = ../eglut/libeglut_x11.la
+ tri_x11_LDADD = ../eglut/libeglut_x11.la
+ endif
+-endif
+-endif
+diff --git a/src/egl/opengles2/Makefile.am b/src/egl/opengles2/Makefile.am
+index 74af460..422cb03 100644
+--- a/src/egl/opengles2/Makefile.am
++++ b/src/egl/opengles2/Makefile.am
+@@ -33,13 +33,7 @@ AM_LDFLAGS = \
+ 	$(EGL_LIBS) \
+ 	-lm
+ 
+-if HAVE_EGL
+-if HAVE_GLESV2
+-bin_PROGRAMS = \
+-	es2gears_screen
+-
+-es2gears_screen_SOURCES = es2gears.c
+-es2gears_screen_LDADD = ../eglut/libeglut_screen.la
++bin_PROGRAMS =
+ 
+ if HAVE_WAYLAND
+ bin_PROGRAMS += es2gears_wayland
+@@ -59,6 +53,4 @@ es2gears_x11_SOURCES = es2gears.c
+ es2gears_x11_LDADD = ../eglut/libeglut_x11.la
+ es2tri_LDADD = $(X11_LIBS)
+ endif
+-endif
+-endif
+ 
+diff --git a/src/egl/openvg/Makefile.am b/src/egl/openvg/Makefile.am
+index b545225..5fd1cf8 100644
+--- a/src/egl/openvg/Makefile.am
++++ b/src/egl/openvg/Makefile.am
+@@ -50,21 +50,13 @@ endif
+ if HAVE_EGL
+ if HAVE_VG
+ bin_PROGRAMS = \
+-	lion_screen \
+-	sp_screen \
+ 	$(EGL_X11_DEMOS)
+ endif
+ endif
+ 
+-lion_screen_SOURCES = lion.c lion-render.c lion-render.h
+-sp_screen_SOURCES = sp.c
+-
+ lion_x11_SOURCES = lion.c lion-render.c lion-render.h
+ sp_x11_SOURCES = sp.c
+ 
+-lion_screen_LDADD = ../eglut/libeglut_screen.la
+-sp_screen_LDADD = ../eglut/libeglut_screen.la
+-
+ lion_x11_LDADD = ../eglut/libeglut_x11.la
+ sp_x11_LDADD = ../eglut/libeglut_x11.la
+ 
+diff --git a/src/egl/openvg/Makefile.in b/src/egl/openvg/Makefile.in
+index 99e9288..3652fbb 100644
+--- a/src/egl/openvg/Makefile.in
++++ b/src/egl/openvg/Makefile.in
+@@ -108,8 +108,6 @@ host_triplet = @host@
+ @HAVE_FREETYPE2_TRUE@@HAVE_X11_TRUE@am__append_1 = \
+ @HAVE_FREETYPE2_TRUE@@HAVE_X11_TRUE@	text
+ 
+-@HAVE_EGL_TRUE@@HAVE_VG_TRUE@noinst_PROGRAMS = lion_screen$(EXEEXT) \
+-@HAVE_EGL_TRUE@@HAVE_VG_TRUE@	sp_screen$(EXEEXT) \
+ @HAVE_EGL_TRUE@@HAVE_VG_TRUE@	$(am__EXEEXT_2)
+ subdir = src/egl/openvg
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+@@ -128,9 +126,6 @@ CONFIG_CLEAN_VPATH_FILES =
+ @HAVE_X11_TRUE@am__EXEEXT_2 = lion_x11$(EXEEXT) sp_x11$(EXEEXT) \
+ @HAVE_X11_TRUE@	$(am__EXEEXT_1)
+ PROGRAMS = $(noinst_PROGRAMS)
+-am_lion_screen_OBJECTS = lion.$(OBJEXT) lion-render.$(OBJEXT)
+-lion_screen_OBJECTS = $(am_lion_screen_OBJECTS)
+-lion_screen_DEPENDENCIES = ../eglut/libeglut_screen.la
+ AM_V_lt = $(am__v_lt_@AM_V@)
+ am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
+ am__v_lt_0 = --silent
+@@ -138,9 +133,6 @@ am__v_lt_1 =
+ am_lion_x11_OBJECTS = lion.$(OBJEXT) lion-render.$(OBJEXT)
+ lion_x11_OBJECTS = $(am_lion_x11_OBJECTS)
+ lion_x11_DEPENDENCIES = ../eglut/libeglut_x11.la
+-am_sp_screen_OBJECTS = sp.$(OBJEXT)
+-sp_screen_OBJECTS = $(am_sp_screen_OBJECTS)
+-sp_screen_DEPENDENCIES = ../eglut/libeglut_screen.la
+ am_sp_x11_OBJECTS = sp.$(OBJEXT)
+ sp_x11_OBJECTS = $(am_sp_x11_OBJECTS)
+ sp_x11_DEPENDENCIES = ../eglut/libeglut_x11.la
+@@ -184,10 +176,10 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
+ am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
+ am__v_CCLD_0 = @echo "  CCLD    " $@;
+ am__v_CCLD_1 = 
+-SOURCES = $(lion_screen_SOURCES) $(lion_x11_SOURCES) \
+-	$(sp_screen_SOURCES) $(sp_x11_SOURCES) $(text_SOURCES)
+-DIST_SOURCES = $(lion_screen_SOURCES) $(lion_x11_SOURCES) \
+-	$(sp_screen_SOURCES) $(sp_x11_SOURCES) $(text_SOURCES)
++SOURCES = $(lion_x11_SOURCES) \
++	$(sp_x11_SOURCES) $(text_SOURCES)
++DIST_SOURCES = $(lion_x11_SOURCES) \
++	$(sp_x11_SOURCES) $(text_SOURCES)
+ RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
+ 	ctags-recursive dvi-recursive html-recursive info-recursive \
+ 	install-data-recursive install-dvi-recursive \
+@@ -423,12 +415,8 @@ AM_LDFLAGS = \
+ 	-lm
+ 
+ @HAVE_X11_TRUE@EGL_X11_DEMOS = lion_x11 sp_x11 $(am__append_1)
+-lion_screen_SOURCES = lion.c lion-render.c lion-render.h
+-sp_screen_SOURCES = sp.c
+ lion_x11_SOURCES = lion.c lion-render.c lion-render.h
+ sp_x11_SOURCES = sp.c
+-lion_screen_LDADD = ../eglut/libeglut_screen.la
+-sp_screen_LDADD = ../eglut/libeglut_screen.la
+ lion_x11_LDADD = ../eglut/libeglut_x11.la
+ sp_x11_LDADD = ../eglut/libeglut_x11.la
+ text_SOURCES = text.c
+@@ -481,18 +469,10 @@ clean-noinstPROGRAMS:
+ 	echo " rm -f" $$list; \
+ 	rm -f $$list
+ 
+-lion_screen$(EXEEXT): $(lion_screen_OBJECTS) $(lion_screen_DEPENDENCIES) $(EXTRA_lion_screen_DEPENDENCIES) 
+-	@rm -f lion_screen$(EXEEXT)
+-	$(AM_V_CCLD)$(LINK) $(lion_screen_OBJECTS) $(lion_screen_LDADD) $(LIBS)
+-
+ lion_x11$(EXEEXT): $(lion_x11_OBJECTS) $(lion_x11_DEPENDENCIES) $(EXTRA_lion_x11_DEPENDENCIES) 
+ 	@rm -f lion_x11$(EXEEXT)
+ 	$(AM_V_CCLD)$(LINK) $(lion_x11_OBJECTS) $(lion_x11_LDADD) $(LIBS)
+ 
+-sp_screen$(EXEEXT): $(sp_screen_OBJECTS) $(sp_screen_DEPENDENCIES) $(EXTRA_sp_screen_DEPENDENCIES) 
+-	@rm -f sp_screen$(EXEEXT)
+-	$(AM_V_CCLD)$(LINK) $(sp_screen_OBJECTS) $(sp_screen_LDADD) $(LIBS)
+-
+ sp_x11$(EXEEXT): $(sp_x11_OBJECTS) $(sp_x11_DEPENDENCIES) $(EXTRA_sp_x11_DEPENDENCIES) 
+ 	@rm -f sp_x11$(EXEEXT)
+ 	$(AM_V_CCLD)$(LINK) $(sp_x11_OBJECTS) $(sp_x11_LDADD) $(LIBS)
+

--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI_append = " file://0010-sharedtex_mt-fix-rendering-thread-hang.patch"
+SRC_URI_append = " file://0010-sharedtex_mt-fix-rendering-thread-hang.patch \
+				   file://0001-drop-demos-dependant-on-obsolete-MESA_screen_surface.patch"


### PR DESCRIPTION
mesa-demos using EGL_MESA_screen_surface should be dropped
as the mentioned surface extension has been obsoleted in
mesa and the demos do not work.

Patch imported and backported from
http://cgit.freedesktop.org/mesa/demos/commit/?id=74443c6ee79f3251f643ea05e94df58183e37d0d

Signed-off-by: Awais Belal <awais_belal@mentor.com>