### PR TITLE
linux-qoriq: powerpc/module: avoid memmove() in dedotify()

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-kernel/linux/files/0001-powerpc-module-avoid-memmove-in-dedotify.patch
+++ b/meta-mentor-staging/fsl-ppc/recipes-kernel/linux/files/0001-powerpc-module-avoid-memmove-in-dedotify.patch
@@ -1,0 +1,37 @@
+From 1cf52ca70faafc340620b90a5900c76ab88813c4 Mon Sep 17 00:00:00 2001
+From: Cedric Hombourger <Cedric_Hombourger@mentor.com>
+Date: Fri, 6 Nov 2015 15:50:46 +0100
+Subject: [PATCH] powerpc/module: avoid memmove() in dedotify()
+
+memmove() is essentially a memcpy() on powerpc64. dedotify() does
+a memmove() to remove the leading dot from undefined symbol names
+it is simply more efficient to offset st_name and arguably more
+correct (other ELF objects could be pointing to this string). At
+some point, a correct memmove() implementation is needed for power
+(especially for cases like this where the source and destination
+overlap). There are indeed other memmove() calls in the kernel...
+
+Upstream-Status: Pending
+
+Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ arch/powerpc/kernel/module_64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/powerpc/kernel/module_64.c b/arch/powerpc/kernel/module_64.c
+index 6838451..e77dbae 100644
+--- a/arch/powerpc/kernel/module_64.c
++++ b/arch/powerpc/kernel/module_64.c
+@@ -335,7 +335,7 @@ static void dedotify(Elf64_Sym *syms, unsigned int numsyms, char *strtab)
+ 		if (syms[i].st_shndx == SHN_UNDEF) {
+ 			char *name = strtab + syms[i].st_name;
+ 			if (name[0] == '.')
+-				memmove(name, name+1, strlen(name));
++				syms[i].st_name++;
+ 		}
+ 	}
+ }
+-- 
+1.9.1
+

--- a/meta-mentor-staging/fsl-ppc/recipes-kernel/linux/linux-qoriq_3.12.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-kernel/linux/linux-qoriq_3.12.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://powerpc_align_TOC_to_256_bytes.patch"
+
+SRC_URI_append_t4240rdb-64b = " file://0001-powerpc-module-avoid-memmove-in-dedotify.patch"


### PR DESCRIPTION
memmove() is essentially a memcpy() on powerpc64. dedotify() does
a memmove() to remove the leading dot from undefined symbol names
it is simply more efficient to offset st_name and arguably more
correct (other ELF objects could be pointing to this string). At
some point, a correct memmove() implementation is needed for power
(especially for cases like this where the source and destination
overlap). There are indeed other memmove() calls in the kernel...

Upstream-Status: Pending

JIRA: SB-6226

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>
Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>