### PR TITLE
mesa-demos: disable GLX demos

### DIFF
--- a/meta-mel-support/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
+++ b/meta-mel-support/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_remove_mel = " glx"

--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0002-only-build-GLX-demos-if-needed.patch
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos/0002-only-build-GLX-demos-if-needed.patch
@@ -1,0 +1,61 @@
+From 322af294390a7f4e1524c5a79312be6cbebce988 Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Wed, 11 Nov 2015 17:22:12 +0500
+Subject: [PATCH] only build GLX demos if needed
+
+There are platforms that default to EGL only configurations
+in which case the GLX applications are not required
+at all. Allow the user to control generation of these
+demos as needed through a configure switch.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+---
+ configure.ac    | 9 +++++++++
+ src/Makefile.am | 6 +++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f8ec7e3..1a4d96d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,11 @@ if test "x$enable_glu" = xyes; then
+     DEMO_LIBS="$DEMO_LIBS $GLU_LIBS"
+ fi
+ 
++AC_ARG_ENABLE([glx-demos],
++    [AS_HELP_STRING([--enable-glx-demos],
++        [enable GLX demos @<:@default=auto@:>@])],
++    [glx_demos_enabled="$enableval"],
++    [glx_demos_enabled=yes])
+ AC_ARG_ENABLE([egl],
+     [AS_HELP_STRING([--enable-egl],
+         [enable EGL library @<:@default=auto@:>@])],
+@@ -325,6 +333,7 @@ AC_SUBST([WAYLAND_LIBS])
+ 
+ AM_CONDITIONAL(HAVE_GLU, test "x$glu_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLEW, test "x$glew_enabled" = "xyes")
++AM_CONDITIONAL(HAVE_GLX, test "x$glx_demos_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_EGL, test "x$egl_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV1, test "x$glesv1_enabled" = "xyes")
+ AM_CONDITIONAL(HAVE_GLESV2, test "x$glesv2_enabled" = "xyes")
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8b89dee..a4d7e8f 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -44,8 +44,12 @@ SUBDIRS = \
+ 	slang \
+ 	tests \
+ 	tools \
+-	wgl \
++	wgl
++
++if HAVE_GLX
++SUBDIRS += \
+ 	xdemos
++endif
+ 
+ if HAVE_GLEW
+ SUBDIRS += \
+-- 
+1.9.1
+

--- a/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa-demos_8.2.0.bbappend
@@ -1,2 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI_append = " file://0001-drop-demos-dependant-on-obsolete-MESA_screen_surface.patch"
+SRC_URI += "file://0001-drop-demos-dependant-on-obsolete-MESA_screen_surface.patch \
+            file://0002-only-build-GLX-demos-if-needed.patch"
+PACKAGECONFIG[glx] = "--enable-glx-demos,--disable-glx-demos"
+PACKAGECONFIG += "glx"


### PR DESCRIPTION
We do not support GLX on MEL rather we use EGL. Although
some of the GLX demos still work but we should remove
these to clearly cleanup things that are irrelevant for
our distro.

JIRA Ticket: INTAMDDET-1047

Signed-off-by: Awais Belal <awais_belal@mentor.com>