### PR TITLE
python: ensure usage of native modules while cross compiling

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python/0001-ensure-usage-of-native-modules-while-cross-compiling.patch
+++ b/meta-mentor-staging/recipes-devtools/python/python/0001-ensure-usage-of-native-modules-while-cross-compiling.patch
@@ -1,0 +1,31 @@
+From 4eb30173f2d254f19d5ef18fabed3bdb2e5c1182 Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Fri, 30 Oct 2015 17:47:07 +0500
+Subject: [PATCH] ensure usage of native modules while cross compiling
+
+The PYTHONPATH variable augments the default search path and
+is prepended to it. We need to make sure that host modules
+are used while cross compiling otherwise an illegal instruction
+error is generated if the modules built for target are imported.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 87a4f02..fa9e0dd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -33,7 +33,7 @@ if test "$cross_compiling" = yes; then
+ 	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])
+ 	fi
+         AC_MSG_RESULT($interp)
+-	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) '$interp
++	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(CROSSPYTHONPATH):$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) '$interp
+     fi
+ elif test "$cross_compiling" = maybe; then
+     AC_MSG_ERROR([Cross compiling required --host=HOST-TUPLE and --build=ARCH])
+-- 
+1.9.1
+

--- a/meta-mentor-staging/recipes-devtools/python/python_2.7.9.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python_2.7.9.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI_append = " file://0001-ensure-usage-of-native-modules-while-cross-compiling.patch"


### PR DESCRIPTION
During build of shared modules the interpreter is trying to
import modules from the freshly built target side directories.
This fails where the generated module code is target architecture
specific and the build fails with an illegal instruction error.
The issue can be reproduced for any machine by adding the
-march=bdver4 flag inserted in the TUNE_CC_ARGS which generates
quite target specific code.
We fix this by modifying the PYTHONPATH variable which augments
the default search path.

Signed-off-by: Awais Belal <awais_belal@mentor.com>