### PR TITLE
Switch to use of nss myhostname

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -143,6 +143,10 @@ FEATURE_PACKAGES_tools-benchmark ?= "packagegroup-tools-benchmark"
 
 # Analogous to the nfs-server group
 FEATURE_PACKAGES_samba-server    ?= "samba swat"
+
+# Include nss-myhostname for sysvinit, so the hostname resolves. systemd
+# includes myhostname itself.
+DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
 ## }}}1
 ## Workarounds & Overrides {{{1
 # We need vfat support for PPC targets as well

--- a/meta-mentor-staging/recipes-core/netbase/netbase_%.bbappend
+++ b/meta-mentor-staging/recipes-core/netbase/netbase_%.bbappend
@@ -1,3 +1,0 @@
-do_install_append() {
-   echo 127.0.1.1 "		"${MACHINE} >> ${D}${sysconfdir}/hosts
-}

--- a/meta-mentor-staging/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mentor-staging/recipes-core/systemd/systemd_%.bbappend
@@ -11,6 +11,18 @@ do_install_append() {
 	install -m 0644 ${WORKDIR}/01-create-run-lock.conf ${D}${sysconfdir}/tmpfiles.d/
 }
 
+pkg_postinst_${PN} () {
+	sed -e '/^hosts:/s/\s*\<myhostname\>//' \
+		-e 's/\(^hosts:.*\)\(\<files\>\)\(.*\)\(\<dns\>\)\(.*\)/\1\2 myhostname \3\4\5/' \
+		-i $D${sysconfdir}/nsswitch.conf
+}
+
+pkg_prerm_${PN} () {
+	sed -e '/^hosts:/s/\s*\<myhostname\>//' \
+		-e '/^hosts:/s/\s*myhostname//' \
+		-i $D${sysconfdir}/nsswitch.conf
+}
+
 pkg_postinst_udev-hwdb () {
 	if test -n "$D"; then
 		${@qemu_run_binary(d, '$D', '${base_bindir}/udevadm')} hwdb --update \


### PR DESCRIPTION
Rather than hardcoding our hostname in /etc/hosts to ensure it resolves, we
can use the nss service/library via nsswitch.conf. systemd includes it
already, but needed to enable it, and the nss-myhostname package provides it
for sysvinit images. This is cleaner, more flexible, and avoids the assumption
that the hostname is always the MACHINE, which our netbase bbappend was
making.