### PR TITLE
metadata_scm.bbclass: restore capture of stderr

### DIFF
--- a/meta-mentor-staging/classes/metadata_scm.bbclass
+++ b/meta-mentor-staging/classes/metadata_scm.bbclass
@@ -1,0 +1,83 @@
+METADATA_BRANCH ?= "${@base_detect_branch(d)}"
+METADATA_REVISION ?= "${@base_detect_revision(d)}"
+
+def base_detect_revision(d):
+    path = base_get_scmbasepath(d)
+
+    scms = [base_get_metadata_git_revision, \
+            base_get_metadata_svn_revision]
+
+    for scm in scms:
+        rev = scm(path, d)
+        if rev != "<unknown>":
+            return rev
+
+    return "<unknown>"
+
+def base_detect_branch(d):
+    path = base_get_scmbasepath(d)
+
+    scms = [base_get_metadata_git_branch]
+
+    for scm in scms:
+        rev = scm(path, d)
+        if rev != "<unknown>":
+            return rev.strip()
+
+    return "<unknown>"
+
+def base_get_scmbasepath(d):
+    return d.getVar( 'COREBASE', True)
+
+def base_get_metadata_monotone_branch(path, d):
+    monotone_branch = "<unknown>"
+    try:
+        with open("%s/_MTN/options" % path) as f:
+            monotone_branch = f.read().strip()
+            if monotone_branch.startswith( "database" ):
+                monotone_branch_words = monotone_branch.split()
+                monotone_branch = monotone_branch_words[ monotone_branch_words.index( "branch" )+1][1:-1]
+    except:
+        pass
+    return monotone_branch
+
+def base_get_metadata_monotone_revision(path, d):
+    monotone_revision = "<unknown>"
+    try:
+        with open("%s/_MTN/revision" % path) as f:
+            monotone_revision = f.read().strip()
+            if monotone_revision.startswith( "format_version" ):
+                monotone_revision_words = monotone_revision.split()
+                monotone_revision = monotone_revision_words[ monotone_revision_words.index( "old_revision" )+1][1:-1]
+    except IOError:
+        pass
+    return monotone_revision
+
+def base_get_metadata_svn_revision(path, d):
+    # This only works with older subversion. For newer versions 
+    # this function will need to be fixed by someone interested
+    revision = "<unknown>"
+    try:
+        with open("%s/.svn/entries" % path) as f:
+            revision = f.readlines()[3].strip()
+    except (IOError, IndexError):
+        pass
+    return revision
+
+def base_get_metadata_git_branch(path, d):
+    import subprocess
+
+    try:
+        return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                                       cwd=path).strip()
+    except:
+        return "<unknown>"
+
+def base_get_metadata_git_revision(path, d):
+    import subprocess
+
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                       cwd=path).strip()
+    except:
+        return "<unknown>"

--- a/meta-mentor-staging/classes/metadata_scm.bbclass
+++ b/meta-mentor-staging/classes/metadata_scm.bbclass
@@ -69,7 +69,7 @@ def base_get_metadata_git_branch(path, d):
 
     try:
         return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                                       cwd=path).strip()
+                                       cwd=path, stderr=subprocess.STDOUT).strip()
     except:
         return "<unknown>"
 
@@ -78,6 +78,6 @@ def base_get_metadata_git_revision(path, d):
 
     try:
         return subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                       cwd=path).strip()
+                                       cwd=path, stderr=subprocess.STDOUT).strip()
     except:
         return "<unknown>"


### PR DESCRIPTION
We don't want the user to see errors from the git commands run by
metadata_scm on their console, so we need to capture or suppress stderr as
well as stdout. This was the case prior to the rewrite of the git hash
logic, but the 2>&1 was lost when it was reworked. Bring it back to avoid
messages like this in builds with non-git layers:

    fatal: Not a git repository (or any of the parent directories): .git

JIRA: SB-6295