### PR TITLE
mesa: Move GLES3 headers to libgles2-mesa-dev package

### DIFF
--- a/meta-mentor-staging/recipes-graphics/mesa/mesa_11.0.4.bb
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa_11.0.4.bb
@@ -15,3 +15,6 @@ do_install_append() {
 
 # EGL from Mesa 10.6.3 isn't functional with GCC-5.2 on ARMv7 platforms
 COMPATIBLE_MACHINE = "(ls1021atwr|zc702-zynq7-mel|zedboard-zynq7-mel)"
+
+# Adding GLES3 headers to libgles2-mesa-dev package
+FILES_libgles2-mesa-dev += "${includedir}/GLES3"


### PR DESCRIPTION
Moving GLES3 headers to libgles2-mesa-dev package fixes the build
issue caused by Qt Creator while building Qt examples in ADE.

SB-6330

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>