### PR TITLE
linux-qoriq: module.c: change load_module() optimization to 0

### DIFF
--- a/meta-mel/fsl-ppc/recipes-kernel/linux/files/0001-kernel-module-change-the-optimization-level-of-load_.patch
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/files/0001-kernel-module-change-the-optimization-level-of-load_.patch
@@ -1,0 +1,30 @@
+From 9316120e6271a919278b7c66c4b75d3623dd1d57 Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Wed, 25 Nov 2015 16:17:50 +0500
+Subject: [PATCH] kernel/module: change the optimization level of load_module
+
+This will provide a stable debug symbol with GCC-5.2.
+
+Based on commit d00d5284f8095a5b0df6bc040719bec058c319ea in meta-mx6
+by Srikanth Krishnakar.
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ kernel/module.c |    1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/module.c b/kernel/module.c
+index f3c612e..5a42143 100644
+--- a/kernel/module.c
++++ b/kernel/module.c
+@@ -3216,6 +3216,7 @@ static int unknown_module_param_cb(char *param, char *val, const char *modname)
+ 
+ /* Allocate and load the module: note that size of section 0 is always
+    zero, and we rely on this for optional sections. */
++__attribute__((optimize(0)))
+ static int load_module(struct load_info *info, const char __user *uargs,
+ 		       int flags)
+ {
+-- 
+1.7.9.5
+

--- a/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq_3.12.bbappend
+++ b/meta-mel/fsl-ppc/recipes-kernel/linux/linux-qoriq_3.12.bbappend
@@ -8,7 +8,8 @@ SRC_URI_append = " file://nbd.cfg \
                    file://autofs.cfg \
                    file://lttng.cfg \
                    file://autofs.cfg \
-                   file://ext4.cfg"
+                   file://ext4.cfg \
+                   file://0001-kernel-module-change-the-optimization-level-of-load_.patch"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_append = ":${@os.path.dirname(bb.utils.which(BBPATH, 'files/lttng.cfg') or '')}"


### PR DESCRIPTION
This will provide a stable debug symbol with GCC-5.2.

JiraID: SB-5400

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>