### PR TITLE
ctdb: disable servcie at startup

### DIFF
--- a/meta-mentor-staging/recipes-support/ctdb/ctdb_2.5.1.bbappend
+++ b/meta-mentor-staging/recipes-support/ctdb/ctdb_2.5.1.bbappend
@@ -1,1 +1,3 @@
 RDEPENDS_${PN} += "bash"
+
+SYSTEMD_AUTO_ENABLE = "disable"


### PR DESCRIPTION
Since recipe does not provide configuration files needed to
start the service successfully, disable the service to
quiet failure message.

JIRA: SB-6335

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>