### PR TITLE
pulseaudio: include missing bluetooth modules

### DIFF
--- a/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio_6.0.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/pulseaudio/pulseaudio_6.0.bbappend
@@ -1,6 +1,6 @@
 RDEPENDS_pulseaudio-module-systemd-login += "systemd"
 RDEPENDS_pulseaudio-server += "\
     ${@base_contains('PACKAGECONFIG', 'systemd', 'pulseaudio-module-systemd-login', '', d)} \
-    ${@base_contains('PACKAGECONFIG', 'bluez4', 'pulseaudio-module-bluetooth-discover', '', d)} \
-    ${@base_contains('PACKAGECONFIG', 'bluez5', 'pulseaudio-module-bluez5-discover pulseaudio-module-bluez5-device', '', d)} \
+    ${@base_contains('PACKAGECONFIG', 'bluez4', 'pulseaudio-module-bluetooth-discover pulseaudio-module-bluez4-discover', '', d)} \
+    ${@base_contains('PACKAGECONFIG', 'bluez5', 'pulseaudio-module-bluetooth-discover pulseaudio-module-bluez5-discover pulseaudio-module-bluez5-device', '', d)} \
 "


### PR DESCRIPTION
We need the pulseaudio-module-bluetooth-discover even in the case of bluez5
because it in turn loads the correct version of bluez-discover module. And
in case of bluez5, installing just pulseaudio-module-bluetooth-discover is
not sufficient, we need pulseaudio-module-bluez4-discover as well in that
case.

Jira: http://jira.alm.mentorg.com:8080/browse/SB-6280

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>