### PR TITLE
talloc: do_configure needs to be updated to work with toaster

### DIFF
--- a/meta-mentor-staging/recipes-support/talloc/talloc_2.1.1.bbappend
+++ b/meta-mentor-staging/recipes-support/talloc/talloc_2.1.1.bbappend
@@ -1,1 +1,29 @@
 DEPENDS += "attr"
+
+do_configure_p1010rdb() {
+    qemu_binary="${@qemu_target_binary(d)}"
+    if [ ${qemu_binary} == "qemu-allarch" ]; then
+        qemu_binary="qemuwrapper"
+    fi
+
+    libdir_qemu="${STAGING_DIR_HOST}/${libdir}"
+    base_libdir_qemu="${STAGING_DIR_HOST}/${base_libdir}"
+
+    CROSS_EXEC="${qemu_binary} \
+                -L ${STAGING_DIR_HOST} \
+                -E LD_LIBRARY_PATH=${libdir_qemu}:${base_libdir_qemu}"
+
+    if [ ${qemu_binary} != "qemuwrapper" ]; then
+        CROSS_EXEC="${CROSS_EXEC} ${QEMU_OPTIONS}  ${QEMU_EXTRAOPTIONS}"
+    fi
+
+    export BUILD_SYS=${BUILD_SYS}
+    export HOST_SYS=${HOST_SYS}
+    export BUILD_ARCH=${BUILD_ARCH}
+    export HOST_ARCH=${HOST_ARCH}
+    export STAGING_LIBDIR=${STAGING_LIBDIR}
+    export STAGING_INCDIR=${STAGING_INCDIR}
+    export PYTHONPATH=${STAGING_DIR_HOST}${PYTHON_SITEPACKAGES_DIR}
+
+    ./configure ${CONFIGUREOPTS} ${EXTRA_OECONF} --cross-compile --cross-execute="${CROSS_EXEC}"
+}


### PR DESCRIPTION
Toaster is not taking the layer priorities appropriately and
hence do_configure in waf-samba.bbclass is not taken. So the
only work around is to bring the do_configure into the bbappend
of talloc.

JIRA: SB-6364

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>