### PR TITLE
toaster: Fix layers created in toasterconf.json file

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -68,7 +68,14 @@ cat <<EOF > "$BUILDDIR"/toasterconf.json
           "layers": [
 EOF
 
-configured_layers | while read layer; do
+LAYER_PATHS=""
+LAYER_PATHS=$(configured_layers | while read layer; do
+    LAYER_PATHS="\"$layer\",$LAYER_PATHS"
+    echo "$LAYER_PATHS"
+done)
+LAYER_PATHS=$(echo "$LAYER_PATHS" | sed -n '$p' | sed 's:,: :g'| sed 's:"::g')
+
+for layer in $LAYER_PATHS; do
    name=
    layername=$(basename "$layer")
    cd $layer
@@ -138,10 +145,10 @@ DEFAULTLAYERS=$(configured_layers | while read -r layer; do
     if [ "$layername" = "meta" ]; then
           layername="openembedded-core"
     fi
-    DEFAULTLAYERS="$DEFAULTLAYERS \"$layername\","
+    DEFAULTLAYERS="\"$layername\", $DEFAULTLAYERS"
     echo "$DEFAULTLAYERS"
 done)
-DEFAULTLAYERS=$(echo "$DEFAULTLAYERS" | sed -n '$p' | sed '$ s/,$//')
+DEFAULTLAYERS=$(echo "$DEFAULTLAYERS" | sed -n '$p' | sed 's/, $//')
 
 cat <<EOF >> "$BUILDDIR"/toasterconf.json
             "defaultlayers": [ $DEFAULTLAYERS ],


### PR DESCRIPTION
The layer information in toasterconf.json file is in the reverse
order compared to bblayers.conf. Hence toaster creates BBLAYERS
in the reverse order. This was the root cause for SB-6364.

JIRA: SB-6372

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>