### PR TITLE
linux-ls1: kernel/module: Remove optimization for complete_formation

### DIFF
--- a/meta-mel/fsl-arm/recipes-kernel/linux/files/0005-kernel-module.c-Remove-optimization-for-complete_for.patch
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/files/0005-kernel-module.c-Remove-optimization-for-complete_for.patch
@@ -1,0 +1,28 @@
+From 7dec24e81c8192495f920680220ccb8d467280dd Mon Sep 17 00:00:00 2001
+From: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+Date: Thu, 10 Dec 2015 21:53:27 +0530
+Subject: [PATCH 5/5] kernel/module.c: Remove optimization for
+ complete_formation
+
+We need this to retain local variable in the context.
+
+Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>
+---
+ kernel/module.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/module.c b/kernel/module.c
+index bb8cef4..aa403d8 100644
+--- a/kernel/module.c
++++ b/kernel/module.c
+@@ -3147,6 +3147,7 @@ out_unlocked:
+ 	return err;
+ }
+ 
++__attribute__((optimize(0)))
+ static int complete_formation(struct module *mod, struct load_info *info)
+ {
+ 	int err;
+-- 
+1.9.1
+

--- a/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1_3.12.bbappend
+++ b/meta-mel/fsl-arm/recipes-kernel/linux/linux-ls1_3.12.bbappend
@@ -24,6 +24,7 @@ SRC_URI += "\
     file://0002-serial-fsl_lpuart-Remove-unneeded-registration-messa.patch \
     file://0003-tty-serial-fsl_lpuart-clear-receive-flag-on-FIFO-flu.patch \
     file://0001-module.c-change-the-load_module-optimization-to-0.patch \
+    file://0005-kernel-module.c-Remove-optimization-for-complete_for.patch \
     \
     file://kgdb.cfg \
     file://configs.cfg \


### PR DESCRIPTION
JIRA: CB-5785

This will disable optimization for complete_formation function and
will retain local variable in contexts.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>