### PR TITLE
mel: export path vars into the devshell

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -61,6 +61,11 @@ BB_GIT_SHALLOW_mel-dra7xx-evm_pn-linux-mel = "6c180de"
 BB_GIT_SHALLOW_ALL_BRANCHES_pn-linux-yocto = "1"
 BB_GENERATE_SHALLOW_TARBALLS ?= "1"
 
+# Export path variables into the devshell for convenience
+OE_TOPDIR = "${TOPDIR}"
+OE_WORKDIR = "${WORKDIR}"
+OE_TERMINAL_EXPORTS += "OE_TOPDIR OE_WORKDIR COREBASE"
+
 ## Distro Features & Recipe Configuration {{{1
 # The user can enable ptest from local.conf, and wayland is not yet supported
 POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest wayland"


### PR DESCRIPTION
Export COREBASE, TOPDIR as OE_TOPDIR, and WORKDIR as OE_WORKDIR into the
devshell. This makes it easier to copy files back out of the devshell to your
layers or build directory.

[YOCTO #7670]

Signed-off-by: Christopher Larson <chris_larson@mentor.com>