### PR TITLE
mel: fix $layer/downloads PREMIRROR

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -198,7 +198,7 @@ LAYERDIR_UNKNOWN = 'UNKNOWN'
 # Support pulling downloads and sstate from inside individual layers. This
 # will let us ship self contained layers to a release without risking file
 # conflicts between them.
-PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERDIR}/downloads\n' if '${RECIPE_LAYERDIR}' != 'UNKNOWN' else ''}"
+PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERDIR}/downloads \\n' if '${RECIPE_LAYERDIR}' != 'UNKNOWN' else ''}"
 LAYER_SSTATE_MIRRORS = "${@" ".join('file://%s' % sl for sl in ('%s/sstate-cache' % l for l in '${BBLAYERS}'.split()) if os.path.exists(sl))}"
 SSTATE_MIRROR_SITES_prepend = "${LAYER_SSTATE_MIRRORS} "
 


### PR DESCRIPTION
	This actually does not break usage of $layer/downloads
	as premirror, but the next premirror because python
	expands the \n, so just escape ht backslash