### PR TITLE
local.conf.append.cyclone5: Add comment about u-boot

### DIFF
--- a/meta-mel/conf/local.conf.append.cyclone5
+++ b/meta-mel/conf/local.conf.append.cyclone5
@@ -1,3 +1,7 @@
+# The u-boot-socfpga from meta-altera doesn't produce a signed SPL image
+# that is require to boot Altera Cyclone V target. Support for signing 
+# u-boot SPL binary has recently been added to the mainline u-boot, so
+# want to use that.
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
 UBOOT_MACHINE = "socfpga_cyclone5_defconfig"
 


### PR DESCRIPTION
Since this snippet gets appended to local.conf, where the user/customer
will see it, it would be appropriate to add this comment so they know
why it's being done.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>