### PR TITLE
MinnowMAX: Add default xorg.conf

### DIFF
--- a/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xf86-config/intel-corei7-64/xorg.conf
+++ b/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xf86-config/intel-corei7-64/xorg.conf
@@ -1,0 +1,36 @@
+Section "Module"                                       
+        Load    "extmod"                                
+        Load    "dbe"                           
+        Load    "glx"                                           
+        Load    "freetype"                             
+        Load    "type1"                        
+        Load    "record"                    
+        Load    "dri"                       
+EndSection                            
+
+Section "Monitor"                                                                    
+        Identifier      "Builtin Default Monitor"
+EndSection                                       
+
+Section "Device"                                  
+        Identifier      "Builtin Default fbdev Device 0"
+        Driver  "fbdev"
+EndSection                                                
+
+Section "Screen"                                        
+        Identifier      "Builtin Default fbdev Screen 0"     
+        Device  "Builtin Default fbdev Device 0"            
+        Monitor "Builtin Default Monitor"               
+EndSection                                              
+
+Section "ServerLayout"                                 
+        Identifier      "Builtin Default Layout"                                     
+        Screen  "Builtin Default fbdev Screen 0"        
+EndSection
+
+Section "ServerFlags"
+        Option          "BlankTime"     "0"
+        Option          "StandbyTime"   "0"
+        Option          "SuspendTime"   "0"
+        Option          "OffTime"       "0"
+EndSection 

--- a/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/meta-mel/intel/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
JIRA: SB-6507

This will allow default modules to be loaded and lets
display stay online without going into stand-by mode.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>