### PR TITLE
Improve priority override handling

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -14,10 +14,12 @@ override_default = 'openembedded-layer=1'
 
 
 class Terminate(BaseException):
+    """Exception raised if we receive a SIGTERM"""
     pass
 
 
 def sigterm_exception(signum, stackframe):
+    """Raise Terminate exception if we receive a SIGTERM"""
     raise Terminate()
 
 

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -10,9 +10,7 @@ from collections import defaultdict
 
 glob_default = './*/:./*/*/:{scriptdir}/../../*/:{scriptdir}/../../*/*/'
 layers_default = 'core yocto mentor'
-priority_overrides = {
-    'openembedded-layer': 1,
-}
+override_default = 'openembedded-layer=1'
 
 
 class Terminate(BaseException):
@@ -81,6 +79,40 @@ class StatusDisplay(object):
 status = StatusDisplay
 
 
+class DictArgument(object):
+    def __init__(self, listsep=None, valuesep='=', keytype=None, valuetype=None):
+        self.listsep = listsep
+        self.valuesep = valuesep
+        self.keytype = keytype
+        self.valuetype = valuetype
+
+    def __call__(self, string):
+        d = {}
+        for o in string.split(self.listsep):
+            try:
+                k, v = o.rsplit(self.valuesep, 1)
+            except ValueError:
+                raise argparse.ArgumentTypeError('invalid entry `{0}`'.format(o))
+
+            if self.keytype is not None:
+                try:
+                    k = self.keytype(k)
+                except ValueError:
+                    raise argparse.ArgumentTypeError('invalid key `{0}` for type `{1}`'.format(k, self.keytype.__name__))
+
+            if self.valuetype is not None:
+                try:
+                    v = self.valuetype(v)
+                except ValueError:
+                    raise argparse.ArgumentTypeError('invalid value `{0}` for type `{1}`'.format(v, self.valuetype.__name__))
+
+            d[k] = v
+        return d
+
+    def __repr__(self):
+        return 'DictArgument(listsep={0}, valuesep={1}, keytype={2}, valuetype={3})'.format(repr(self.listsep), repr(self.valuesep), repr(self.keytype), repr(self.valuetype))
+
+
 def process_arguments(cmdline_args):
     parser = argparse.ArgumentParser(description='Determine the bitbake layers to use for a given machine, with sanity checks')
     parser.add_argument('-l', '--layers', default=layers_default,
@@ -91,6 +123,9 @@ def process_arguments(cmdline_args):
             help='extra layers to include. space separated. These layers are expected to exist, but are only included if their dependencies are already included in the configuration.')
     parser.add_argument('-x', '--excluded-layers', default='',
             help='explicit layers to excluded. space separated.')
+    parser.add_argument('-O', '--override-layer-priorities', default=override_default,
+            type=DictArgument(valuetype=int),
+            help='override the priority of one or more layers. space separated list of layername=priority values. default: `{0}`'.format(override_default))
     parser.add_argument('-g', '--globs', default=glob_default,
             help='wildcard patterns to locate layers. colon separated. default: `{0}`'.format(glob_default))
     parser.add_argument('-p', '--paths',
@@ -300,7 +335,7 @@ def print_layers(cmdline_opts):
     all_layers = set(filter(lambda layer:layer.name not in args.excluded_layers, all_layers))
 
     for layer in all_layers:
-        priority_override = priority_overrides.get(layer.name)
+        priority_override = args.override_layer_priorities.get(layer.name)
         if priority_override is not None:
             layer.priority = priority_override
 

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
+import argparse
 import glob
-import optparse
 import os
 import signal
 import sys
@@ -82,48 +82,43 @@ status = StatusDisplay
 
 
 def process_arguments(cmdline_args):
-    parser = optparse.OptionParser(description='Determine the bitbake layers to use for a given machine, with sanity checks')
-    parser.add_option('-l', '--layers', default=layers_default,
-            help='base layers to include. space separated. default="{0}"'.format(layers_default))
-    parser.add_option('-o', '--optional-layers', default='',
-            help='optional layers to include. space separated. These layers are included if they and their dependencies are available, but are silently left out otherwise.')
-    parser.add_option('-e', '--extra-layers', default='',
+    parser = argparse.ArgumentParser(description='Determine the bitbake layers to use for a given machine, with sanity checks')
+    parser.add_argument('-l', '--layers', default=layers_default,
+            help='base layers to include. space separated. default: `{0}`'.format(layers_default))
+    parser.add_argument('-o', '--optional-layers', default='',
+            help='optional layers to include. space separated.')
+    parser.add_argument('-e', '--extra-layers', default='',
             help='extra layers to include. space separated. These layers are expected to exist, but are only included if their dependencies are already included in the configuration.')
-    parser.add_option('-x', '--excluded-layers', default='',
+    parser.add_argument('-x', '--excluded-layers', default='',
             help='explicit layers to excluded. space separated.')
-    parser.add_option('-g', '--globs', default=glob_default,
-            help='wildcard patterns to locate layers. colon separated. default="{0}"'.format(glob_default))
-    parser.add_option('-p', '--paths',
+    parser.add_argument('-g', '--globs', default=glob_default,
+            help='wildcard patterns to locate layers. colon separated. default: `{0}`'.format(glob_default))
+    parser.add_argument('-p', '--paths',
             help='paths to search recursively to find layers. colon separated. equivalent to the "find" command', default='')
+    parser.add_argument('machine', help='machine to use when selecting bsp layers')
 
     scriptdir = os.path.dirname(__file__)
-    opts, args = parser.parse_args(cmdline_args)
+    args = parser.parse_args(cmdline_args)
 
-    opts.layers = opts.layers.split()
-    opts.optional_layers = opts.optional_layers.split()
-    opts.excluded_layers = opts.excluded_layers.split()
-    opts.extra_layers = opts.extra_layers.split()
+    args.layers = args.layers.split()
+    args.optional_layers = args.optional_layers.split()
+    args.excluded_layers = args.excluded_layers.split()
+    args.extra_layers = args.extra_layers.split()
 
     new_globs = []
-    for pattern in opts.globs.split(':'):
+    for pattern in args.globs.split(':'):
         pattern = os.path.abspath(pattern.format(scriptdir=scriptdir))
         new_globs.append(pattern)
-    opts.globs = new_globs
+    args.globs = new_globs
 
     new_paths = []
-    if opts.paths:
-        for path in opts.paths.split(':'):
+    if args.paths:
+        for path in args.paths.split(':'):
             path = os.path.abspath(path.format(scriptdir=scriptdir))
             new_paths.append(path)
-    opts.paths = new_paths
+    args.paths = new_paths
 
-    if len(args) < 1:
-        parser.print_help()
-        sys.exit(2)
-
-    opts.machine = args[0]
-
-    return opts
+    return args
 
 
 class LayerError(Exception):
@@ -265,7 +260,7 @@ def get_configured_layers(all_layers, base_layer_names, optional_layer_names, ex
 
 
 def print_layers(cmdline_opts):
-    opts = process_arguments(cmdline_opts)
+    args = process_arguments(cmdline_opts)
 
     setup_command_import('bitbake')
     try:
@@ -282,14 +277,14 @@ def print_layers(cmdline_opts):
     all_layers = set()
     with status('Locating layers and parsing layer.conf files'):
         layer_paths = set()
-        for pattern in opts.globs:
+        for pattern in args.globs:
             paths = glob.glob(pattern)
             for path in paths:
                 layerconf_path = os.path.join(path, 'conf', 'layer.conf')
                 if os.path.exists(layerconf_path):
                     layer_paths.add(os.path.realpath(path))
 
-        for path in opts.paths:
+        for path in args.paths:
             for subpath in find(path):
                 if subpath.endswith('/conf/layer.conf'):
                     layer_paths.add(os.path.realpath(subpath))
@@ -302,7 +297,7 @@ def print_layers(cmdline_opts):
             else:
                 all_layers |= set(layers)
 
-    all_layers = set(filter(lambda layer:layer.name not in opts.excluded_layers, all_layers))
+    all_layers = set(filter(lambda layer:layer.name not in args.excluded_layers, all_layers))
 
     for layer in all_layers:
         priority_override = priority_overrides.get(layer.name)
@@ -321,9 +316,9 @@ def print_layers(cmdline_opts):
 
         missing_deps = resolve_dependencies(layers_by_name)
 
-    with status("Determining layers to include for MACHINE '{0}'".format(opts.machine)) as s:
+    with status("Determining layers to include for MACHINE '{0}'".format(args.machine)) as s:
         try:
-            configured_layers, optional = get_configured_layers(all_layers, opts.layers, opts.optional_layers, opts.extra_layers, missing_deps, opts.machine)
+            configured_layers, optional = get_configured_layers(all_layers, args.layers, args.optional_layers, args.extra_layers, missing_deps, args.machine)
         except Exception as exc:
             sys.exit('ERROR: {0}'.format(exc))
         else:

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -8,6 +8,8 @@
 
 OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
 EXTRAMELLAYERS="${EXTRAMELLAYERS:-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery}"
+layer_priority_overrides="openembedded-layer=1"
+
 
 usage () {
     cat >&2 <<END
@@ -102,7 +104,7 @@ configure_for_machine () {
 
 
     sed -i -e"s/^#*MACHINE *?*=.*/MACHINE ??= \"$MACHINE\"/" $BUILDDIR/conf/local.conf
-    sed -n -i -e "s|##COREBASE##|$OEROOT|g" -e '/^BBLAYERS /{ :start; /\\$/{n; b start}; d; }; p' $BUILDDIR/conf/bblayers.conf
+    sed -n -i -e "s|##COREBASE##|$OEROOT|g" -e '/^BBLAYERS /{ :start; /\\$/{n; b start}; d; }; p' -e "/BBFILE_PRIORITY/d" $BUILDDIR/conf/bblayers.conf
 
     echo 'BBLAYERS = "\' >> $BUILDDIR/conf/bblayers.conf
     layersfile=$(mktemp setup-mel-builddir.XXXXXX)
@@ -127,7 +129,7 @@ configure_for_machine () {
         updatelayernames="$updatelayernames $layer"
     done
 
-    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "core mel mel-support mentor-staging $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" "$@" $MACHINE >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "core mel mel-support mentor-staging $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" "$@" $MACHINE >$layersfile
     if [ $? -ne 0 ]; then
         rm -f $layersfile
         echo >&2 "Error in execution of bb-determine-layers, aborting"
@@ -137,6 +139,11 @@ configure_for_machine () {
     rm -f $layersfile
     echo '"' >> $BUILDDIR/conf/bblayers.conf
     unset layersfile
+
+    echo "$layer_priority_overrides" | tr " " "\n" | \
+        while IFS== read -r layer priority; do
+            printf 'BBFILE_PRIORITY_%s_%s = "%d"\n' "$layer" "$MEL_DISTRO" "$priority" >> $BUILDDIR/conf/bblayers.conf
+        done
 }
 
 process_arguments () {
@@ -311,11 +318,12 @@ scriptsdir="$(cd $(dirname $0) && pwd)"
 scriptsdir="$(abspath $scriptsdir)"
 layerdir="${scriptsdir%/*}"
 
-setup_builddir "$@" || exit $?
 if [ -e $layerdir/../.mel-lite ]; then
     MEL_DISTRO="mel-lite"
 fi
 MEL_DISTRO="${MEL_DISTRO:-mel}"
+
+setup_builddir "$@" || exit $?
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$MEL_DISTRO\'/" $BUILDDIR/conf/local.conf
     if [ -d "$MELDIR/../../codebench-lite" ]; then


### PR DESCRIPTION
Previously, rng-tools 4 from meta-oe was used in preference to oe-core's 5. This isn't ideal, to handle the priority consistently. Technically there is a reason one might want to use meta-oe as higher priority than oe-core even with it just being a pool of extra recipes, and that reason is that those extra recipes may require specific versions of things, but I think we can deal with that theoretical possibility if and when it comes up, and we want to track oe-core as closely as possible.