### PR TITLE
MinnowMAX: linux-yocto: Add git shallow support

### DIFF
--- a/meta-mel/intel/recipes-kernel/linux/linux-yocto_4.1.bbappend
+++ b/meta-mel/intel/recipes-kernel/linux/linux-yocto_4.1.bbappend
@@ -16,3 +16,7 @@ SRC_URI_append_intel-corei7-64 = " \
 	file://wireless.cfg \
 	file://kernel.cfg \
 	"
+
+# Add Shallow support for mirror tarballs
+BB_GIT_SHALLOW_machine = "v4.1"
+BB_GIT_SHALLOW_meta = ""


### PR DESCRIPTION
This adds git shallow mirror tarball support.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>