### PR TITLE
intel-corei7-64: Replace linux-firmware with firmware-wireless

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -3,3 +3,8 @@ BASELIB_x86-64 = "lib64"
 
 # Work around failure in 'perf' due to use of ld rather than gcc to link
 LDEMULATION_x86-64 = "elf_${TARGET_ARCH}"
+
+# Override intel-corei7-64's inclusion of linux-firmware in favor of a minimal subset
+# which holds just the wireless firmware
+MACHINE_EXTRA_RRECOMMENDS_remove_intel-corei7-64 = "linux-firmware"
+MACHINE_EXTRA_RRECOMMENDS_append_intel-corei7-64 = " firmware-wireless"


### PR DESCRIPTION
JIRA: SB-6722

This will pull only minimal subset of wireless firmware
instead of all available firmware files.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>