### PR TITLE
mkefidisk.sh: Fix bashism when writing to startup.nsh

### DIFF
--- a/meta-mel/intel/scripts/mkefidisk.sh
+++ b/meta-mel/intel/scripts/mkefidisk.sh
@@ -441,7 +441,13 @@ if [ -d $ROOTFS_MNT/etc/udev/ ] ; then
 fi
 
 # Add startup.nsh script for automated boot
-echo "fs0:\EFI\BOOT\bootx64.efi" > $BOOTFS_MNT/startup.nsh
+if [ -L /bin/sh ]; then
+   if [ $(ls -l /bin/sh | awk {'print $11'}) = "dash" ]; then
+        $(which echo) -E "fs0:\EFI\BOOT\bootx64.efi" > $BOOTFS_MNT/startup.nsh
+   else
+        echo "fs0:\EFI\BOOT\bootx64.efi" > $BOOTFS_MNT/startup.nsh
+   fi
+fi
 
 # Call cleanup to unmount devices and images and remove the TMPDIR
 cleanup


### PR DESCRIPTION
Fix bashism when writing to startup.nsh. The back slash
are not taken care on dash. With this change it is taken
care.

JIRA: SB-6725

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>