### PR TITLE
local.conf.append.intel-corei7-64: Add vfat support

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -8,3 +8,6 @@ LDEMULATION_x86-64 = "elf_${TARGET_ARCH}"
 # which holds just the wireless firmware
 MACHINE_EXTRA_RRECOMMENDS_remove_intel-corei7-64 = "linux-firmware"
 MACHINE_EXTRA_RRECOMMENDS_append_intel-corei7-64 = " firmware-wireless"
+
+#vfat support required for minnowmax
+MACHINE_FEATURES_append_intel-corei7-64 = " vfat"


### PR DESCRIPTION
Add vfat support in MACHINE_FEATURES

JIRA: SB-6727

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>