### PR TITLE
intel-corei7-64: wic: install parted-native tool

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -11,3 +11,6 @@ MACHINE_EXTRA_RRECOMMENDS_append_intel-corei7-64 = " firmware-wireless"
 
 #vfat support required for minnowmax
 MACHINE_FEATURES_append_intel-corei7-64 = " vfat"
+
+# Install WIC dependency for partitioning
+IMAGE_DEPENDS_ext4_append = " parted-native"


### PR DESCRIPTION
JIRA: SB-6703

This is needed for partitioning media device on
host while formatting and preparing a device.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>