### PR TITLE
weston: fix build-deps qa issues

### DIFF
--- a/meta-mel/meta-altera/recipes-graphics/wayland/weston_1.8.0.bbappend
+++ b/meta-mel/meta-altera/recipes-graphics/wayland/weston_1.8.0.bbappend
@@ -1,5 +1,4 @@
-# rdp-compositor depends on freerdp
-DEPENDS_cyclone5 += "freerdp"
+DEPENDS_cyclone5 += "freerdp libevdev libinput"
 
 # Enable building of rdp-compositor
 EXTRA_OECONF_cyclone5 := "${@oe_filter_out('--disable-rdp-compositor', '${EXTRA_OECONF}', d)}"


### PR DESCRIPTION
Add missing dependencies libevdev and libinput to fix
build-deps QA Issues.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>