### PR TITLE
add java support for console and core-image-sato for cyclone5

### DIFF
--- a/meta-mel/conf/local.conf.append.cyclone5
+++ b/meta-mel/conf/local.conf.append.cyclone5
@@ -31,3 +31,13 @@ MACHINE_EXTRA_RRECOMMENDS_append_cyclone5 = " firmware-wireless"
 # To build weston-image, uncomment following two lines.
 #USER_FEATURES += "~x11"
 #DISTRO_FEATURES_append = " wayland"
+
+# Uncomment following to enable JAVA support
+# Supported image types: console-image, core-image-sato, weston-image
+# Make sure to add path/to/meta-java in BBLAYERS
+#ENABLE_JAVA = "1"
+
+# Set PREFERRED_PROVIDERs for java packages
+PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
+PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
+PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"

--- a/meta-mel/meta-altera/recipes-core/images/console-image.bbappend
+++ b/meta-mel/meta-altera/recipes-core/images/console-image.bbappend
@@ -1,0 +1,5 @@
+# Install OpenJDK 7 JRE if ENABLE_JAVA is set to "1"
+python () {
+    if d.getVar("ENABLE_JAVA", True) == "1":
+        d.setVar('IMAGE_INSTALL_append', ' openjdk-7-jre')
+}

--- a/meta-mel/meta-altera/recipes-sato/images/core-image-sato.bbappend
+++ b/meta-mel/meta-altera/recipes-sato/images/core-image-sato.bbappend
@@ -3,3 +3,9 @@ IMAGE_INSTALL_append_cyclone5 = " xserver-xorg-xvfb \
 				  mesa-megadriver \
 				  xserver-xorg-extension-glx \
 				"
+
+# Install OpenJDK 7 JRE if ENABLE_JAVA is set to "1"
+python () {
+    if d.getVar("ENABLE_JAVA", True) == "1":
+        d.setVar('IMAGE_INSTALL_append', ' openjdk-7-jre')
+}


### PR DESCRIPTION
Conditionally add Java support to console image or
core-image-sato if ENABLE_JAVA is set to "1" in local.conf.

JIRA: SB-6588

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>