### PR TITLE
Fix wic image type with bootimg images

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -153,6 +153,9 @@ FEATURE_PACKAGES_samba-server    ?= "samba swat"
 DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
 ## }}}1
 ## Workarounds & Overrides {{{1
+# Add missing dep from do_image_wic on do_bootimg when both are used
+IMAGE_CLASSES += "bootimg-wic"
+
 # We need vfat support for PPC targets as well
 MACHINE_FEATURES_append_powerpc = " vfat"
 

--- a/meta-mentor-staging/classes/bootimg-wic.bbclass
+++ b/meta-mentor-staging/classes/bootimg-wic.bbclass
@@ -1,0 +1,4 @@
+python () {
+    if oe.utils.inherits(d, 'bootimg') and d.getVar('do_image_wic', False):
+        bb.build.addtask('do_image_wic', '', 'do_bootimg', d)
+}


### PR DESCRIPTION
do_image_wic needs to depend upon do_bootimg when both are used.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>