### PR TITLE
minnowmax: install required compression command

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -13,7 +13,7 @@ MACHINE_EXTRA_RRECOMMENDS_append_intel-corei7-64 = " firmware-wireless"
 MACHINE_FEATURES_append_intel-corei7-64 = " vfat"
 
 # Install WIC dependency for partitioning
-IMAGE_DEPENDS_ext4_append = " parted-native"
+IMAGE_DEPENDS_ext4_append = " parted-native pbzip2-native"
 
 # WKS Files for 4GB/8GB microSD
 WKS_FILE ?= "minnowmax-sd-4g.wks"


### PR DESCRIPTION
Since we are using wic.bz2, sysroot needs the pbzip2
command for compression of wic image.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>