### PR TITLE
weston: fix build failure due to wrong syntax

### DIFF
--- a/meta-mel/meta-altera/recipes-graphics/wayland/weston_1.8.0.bbappend
+++ b/meta-mel/meta-altera/recipes-graphics/wayland/weston_1.8.0.bbappend
@@ -1,4 +1,4 @@
-DEPENDS_cyclone5 += "freerdp libevdev libinput"
+DEPENDS_append_cyclone5 = " freerdp"
 
 # Enable building of rdp-compositor
 EXTRA_OECONF_cyclone5 := "${@oe_filter_out('--disable-rdp-compositor', '${EXTRA_OECONF}', d)}"


### PR DESCRIPTION
Use correct conditional syntax for appending to the DEPENDS
variable. Earlier syntax was overriding the items previously
assigned to DEPENDS thus causing build-deps warnings and build
failures resulting from missing dependencies.

libinput, which also pulls in libevdev, is already in DEPENDS
in the main recipe, so no need to add these packages here
again.

JIRA: SB-6825

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>