### PR TITLE
cyclone5: set preferred providers to quiet notes

### DIFF
--- a/meta-mel/conf/local.conf.append.cyclone5
+++ b/meta-mel/conf/local.conf.append.cyclone5
@@ -32,12 +32,14 @@ MACHINE_EXTRA_RRECOMMENDS_append_cyclone5 = " firmware-wireless"
 #USER_FEATURES += "~x11"
 #DISTRO_FEATURES_append = " wayland"
 
-# Uncomment following to enable JAVA support
-# Supported image types: console-image, core-image-sato, weston-image
+# Uncomment following to enable Java support
+# Supported image types: console-image, core-image-sato
 # Make sure to add path/to/meta-java in BBLAYERS
 #ENABLE_JAVA = "1"
 
-# Set PREFERRED_PROVIDERs for java packages
+# Set PREFERRED_PROVIDERs for Java packages
 PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
 PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
 PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
+PREFERRED_PROVIDER_make-native = "make-native"
+PREFERRED_PROVIDER_openjdk-7-jre = "openjdk-7-jre"


### PR DESCRIPTION
* Set PREFERRED_PROVIDERs for make-native and java2-runtime to
quiet build time NOTEs.

* openjdk-7-jre requries x11 as a distro feature but we disable
it while building weston-image. Update the comment to remove
weston-image from the list of Java supported images.

* Fix typos:
s/JAVA/Java
s/java/Java

JIRA: SB-6820

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>