### PR TITLE
bootimg-wic: remove the do_image_wic check

### DIFF
--- a/meta-mentor-staging/classes/bootimg-wic.bbclass
+++ b/meta-mentor-staging/classes/bootimg-wic.bbclass
@@ -1,4 +1,4 @@
 python () {
-    if oe.utils.inherits(d, 'bootimg') and d.getVar('do_image_wic', False):
+    if oe.utils.inherits(d, 'bootimg'):
         bb.build.addtask('do_image_wic', '', 'do_bootimg', d)
 }


### PR DESCRIPTION
Rather than relying on the order of anonymous python executions meeting our
expectations, avoid the do_image_wic existance check entirely. It's not
needed, as running the addtask when the task doesn't exist isn't actually
harmful.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>