### PR TITLE
intel-corei7-64: bundle wic image in release-artifacts

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -18,3 +18,6 @@ IMAGE_DEPENDS_ext4_append = " parted-native pbzip2-native"
 # WKS Files for 4GB/8GB microSD
 WKS_FILE ?= "minnowmax-sd-4g.wks"
 #WKS_FILE ?= "minnowmax-sd-8g.wks"
+
+# Deploy wic image in release artifacts
+IMAGE_FSTYPES_append_pn-archive-release = " wic.bz2"


### PR DESCRIPTION
JIRA: SB-6983

Since we have different mechanism employed for WIC
image creation for minnowmax due to processing method
involved in generating live boot image, deploy the
WIC image exclusively in release artifacts so that
we have bootable rootfs in binary folder.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>