### PR TITLE
cyclone5: add tools to create and modify file-systems

### DIFF
--- a/meta-mel/conf/local.conf.append.cyclone5
+++ b/meta-mel/conf/local.conf.append.cyclone5
@@ -18,6 +18,9 @@ IMAGE_BOOT_FILES += "zImage, zImage-socfpga_cyclone5_sockit.dtb;socfpga.dtb, u-b
 # Include usbhost feature to support various USB devices
 MACHINE_FEATURES_append = " usbhost"
 
+# Add support to create and modify file-systems on the target.
+MACHINE_FEATURES_append = " ext2 vfat"
+
 # Include firmware-wireless package which provides firmwares for commonly 
 # used wireless adapters.
 MACHINE_EXTRA_RRECOMMENDS_append_cyclone5 = " firmware-wireless"


### PR DESCRIPTION
Although we only need to support mounting of already created file-systems,
we are adding tools to create and modify file-systems for consistency with
other BSPs in Cedar release. This should be removed in Dogwood release.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>