### PR TITLE
mesa: Add GLES3 headers to libgles2-mesa-dev

### DIFF
--- a/meta-mel/intel/recipes-graphics/mesa/mesa_10.6.3.bbappend
+++ b/meta-mel/intel/recipes-graphics/mesa/mesa_10.6.3.bbappend
@@ -1,0 +1,2 @@
+# Adding GLES3 headers to libgles2-mesa-dev package
+FILES_libgles2-mesa-dev += "${includedir}/GLES3"


### PR DESCRIPTION
Adding GLES3 headers to libgles2-mesa-dev solves
the problem when user tries to verify Qt5 examples
using Qt Creator.

JIRA: SB-6993

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>