### PR TITLE
Cyclone5 u boot fixes

### DIFF
--- a/meta-mel/meta-altera/recipes-bsp/u-boot/u-boot-socfpga_2013.01.01.bbappend
+++ b/meta-mel/meta-altera/recipes-bsp/u-boot/u-boot-socfpga_2013.01.01.bbappend
@@ -19,10 +19,6 @@ do_deploy_append () {
 	install ${WORKDIR}/u-boot.scr ${DEPLOYDIR}/
 
 	# Remove additional files that are un-wanted
-	rm -f ${DEPLOYDIR}/u-boot-${MACHINE}-${PV}-${PR} \
-	      ${DEPLOYDIR}/u-boot-${MACHINE} \
-	      ${DEPLOYDIR}/u-boot-spl-${MACHINE} \
-	      ${DEPLOYDIR}/u-boot-spl-${MACHINE}.bin \
-	      ${DEPLOYDIR}/u-boot-spl-${MACHINE}-${PV}-${PR} \
+	rm -f ${DEPLOYDIR}/u-boot-spl-${MACHINE}.bin \
 	      ${DEPLOYDIR}/u-boot-spl-${MACHINE}-${PV}-${PR}.bin
 }

--- a/meta-mel/scripts/mk-cyclone5-boot-part.sh
+++ b/meta-mel/scripts/mk-cyclone5-boot-part.sh
@@ -11,7 +11,7 @@ VERSION="0.1"
 SELF=$(basename $0)
 SELFPATH=$(dirname $0)
 
-binary="./u-boot-with-spl-dtb.sfp"
+binary="./u-boot-spl-mkpimage.bin"
 
 BOOT_PT_NUM="3"
 BOOT_PT_TYPE="a2"


### PR DESCRIPTION
* Preserve the u-boot ELF files in deploy folder.
* Correct the SPL binary file-name in sd-card preparation script.