### PR TITLE
gobject-introspection: fix floating dep on python-mako

### DIFF
--- a/meta-mentor-staging/recipes-gnome/gobject-introspection/gobject-introspection_1.46.0.bbappend
+++ b/meta-mentor-staging/recipes-gnome/gobject-introspection/gobject-introspection_1.46.0.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[doctool] = "--enable-doctool,--disable-doctool,python-mako,"


### PR DESCRIPTION
This was resulting in non-deterministic builds where g-ir-doc-tool may or may
not exist depending on whether python-mako was built previously. Add
a PACKAGECONFIG so the dependency is explicit.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>