### PR TITLE
dmidecode: move docs into a subdir of docdir

### DIFF
--- a/meta-mentor-staging/recipes-devtools/dmidecode/dmidecode_3.0.bbappend
+++ b/meta-mentor-staging/recipes-devtools/dmidecode/dmidecode_3.0.bbappend
@@ -1,0 +1,3 @@
+# The upstream buildsystem uses 'docdir' as the path where it puts AUTHORS,
+# README, etc, but we don't want those in the root of our docdir.
+docdir_append_task-install = "/${BPN}"


### PR DESCRIPTION
It was putting its AUTHORS, README, and CHANGELOG in the root of
/usr/share/doc.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>