### PR TITLE
Setup script improvements

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 import argparse
+import collections
+import contextlib
 import glob
 import os
 import signal
 import sys
-from collections import defaultdict
 
 
 glob_default = './*/:./*/*/:{scriptdir}/../../*/:{scriptdir}/../../*/*/'
@@ -200,13 +201,13 @@ class Layer(object):
             raise LayerError(exc)
         ldata.expandVarref('LAYERDIR')
 
-        collections = (ldata.getVar('BBFILE_COLLECTIONS', True) or '').split()
-        if not collections:
+        bbfile_collections = (ldata.getVar('BBFILE_COLLECTIONS', True) or '').split()
+        if not bbfile_collections:
             name = os.path.basename(layer_path)
             l = Layer(layer_path, lconf, name, 0, None, set())
             layers.append(l)
 
-        for name in collections:
+        for name in bbfile_collections:
             pattern = ldata.getVar('BBFILE_PATTERN_%s' % name, True)
             priority = ldata.getVar('BBFILE_PRIORITY_%s' % name, True) or 0
             depends = ldata.getVar('LAYERDEPENDS_%s' % name, True) or ''
@@ -218,8 +219,52 @@ class Layer(object):
             return layers
 
 
+class Layers(collections.MutableSet):
+    def __init__(self, iterable=None):
+        self.layers = set()
+        self.by_path = {}
+        self.by_name = {}
+
+        if iterable is not None:
+            self |= iterable
+
+    def add(self, layer):
+        if layer.name in self.by_name:
+            raise Exception("Layer name '{0}' found more than once", layer.name)
+
+        if layer.path in self.by_path:
+            return
+
+        self.layers.add(layer)
+        self.by_path[layer.path] = layer
+        self.by_name[layer.name] = layer
+
+    def add_from_path(self, layerpath, data=None):
+        self |= Layer.from_layerpath(os.path.realpath(layerpath), data)
+
+    def discard(self, layer):
+        self.layers.discard(layer)
+        del self.by_path[layer.path]
+        del self.by_name[layer.name]
+
+    def clear(self):
+        self.layers.clear()
+        self.by_path.clear()
+        self.by_name.clear()
+
+    def __contains__(self, layer):
+        return layer in self.layers
+        #return layer.path in self.by_path
+
+    def __iter__(self):
+        return iter(self.layers)
+
+    def __len__(self):
+        return len(self.layers)
+
+
 def resolve_dependencies(layers_by_name):
-    missing_dependencies = defaultdict(set)
+    missing_dependencies = collections.defaultdict(set)
 
     for layer in layers_by_name.values():
         missing_layer_deps = set()
@@ -301,28 +346,33 @@ def get_configured_layers(all_layers, base_layer_names, optional_layer_names, ex
     return configured_layers, optional
 
 
-def print_layers(cmdline_opts):
+def get_layerpaths_bitbake(globs=None, paths=None):
+    bitbake_path = None
+    layer_paths = set()
+
+    for pattern in globs:
+        for glob_path in glob.glob(pattern):
+            layerconf_path = os.path.join(glob_path, 'conf', 'layer.conf')
+            if os.path.exists(layerconf_path):
+                layer_paths.add(os.path.realpath(glob_path))
+            elif os.path.exists(os.path.join(glob_path, 'bin', 'bitbake')):
+                bitbake_path = os.path.join(glob_path, 'bin')
+
+    for path in paths:
+        for subpath in find(path, dirfilter=lambda d: d != 'lib'):
+            if subpath.endswith('/conf/layer.conf'):
+                layer_paths.add(os.path.realpath(os.path.dirname(os.path.dirname(subpath))))
+            elif subpath.endswith('/bin/bitbake'):
+                bitbake_path = os.path.dirname(subpath)
+
+    return layer_paths, bitbake_path
+
+
+def determine_layers(cmdline_opts):
     args = process_arguments(cmdline_opts)
 
-    layer_paths = set()
     with status('Locating layers and bitbake'):
-        bitbake_path = None
-
-        for pattern in args.globs:
-            for glob_path in glob.glob(pattern)
-                layerconf_path = os.path.join(glob_path, 'conf', 'layer.conf')
-                if os.path.exists(layerconf_path):
-                    layer_paths.add(os.path.realpath(glob_path))
-                elif os.path.exists(os.path.join(glob_path, 'bin', 'bitbake')):
-                    bitbake_path = os.path.join(glob_path, 'bin')
-
-        for path in args.paths:
-            for subpath in find(path, dirfilter=lambda d: d != 'lib'):
-                if subpath.endswith('/conf/layer.conf'):
-                    layer_paths.add(os.path.realpath(os.path.dirname(os.path.dirname(subpath))))
-                elif subpath.endswith('/bin/bitbake'):
-                    bitbake_path = os.path.dirname(subpath)
-
+        layer_paths, bitbake_path = get_layerpaths_bitbake(args.globs, args.paths)
         if bitbake_path is not None:
             os.environ['PATH'] += ':' + bitbake_path
 
@@ -338,22 +388,21 @@ def print_layers(cmdline_opts):
     data = bb.data.init()
     bb.parse.init_parser(data)
 
-    all_layers = set()
+    all_layers = Layers()
     with status('Parsing layer configuration files'):
         for layer_path in layer_paths:
             try:
-                layers = Layer.from_layerpath(layer_path, data)
+                all_layers.add_from_path(layer_path, data)
             except LayerError as exc:
                 sys.exit(str(exc))
-            else:
-                all_layers |= set(layers)
 
-    all_layers = set(filter(lambda layer:layer.name not in args.excluded_layers, all_layers))
-
-    for layer in all_layers:
-        priority_override = args.override_layer_priorities.get(layer.name)
-        if priority_override is not None:
-            layer.priority = priority_override
+    for layer in list(all_layers):
+        if layer.name in args.excluded_layers:
+            all_layers.discard(layer)
+        else:
+            priority_override = args.override_layer_priorities.get(layer.name)
+            if priority_override is not None:
+                layer.priority = priority_override
 
     duplicates = defaultdict(set)
     with status('Resolving layer dependencies'):
@@ -391,7 +440,7 @@ def print_layers(cmdline_opts):
 if __name__ == '__main__':
     signal.signal(signal.SIGTERM, sigterm_exception)
     try:
-        sys.exit(print_layers(sys.argv[1:]) or 0)
+        sys.exit(determine_layers(sys.argv[1:]) or 0)
     except KeyboardInterrupt:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         os.kill(os.getpid(), signal.SIGINT)

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -141,6 +141,7 @@ def process_arguments(cmdline_args):
     parser.add_argument('-m', '--machine', help='add layer(s) providing the specified MACHINE')
     parser.add_argument('-d', '--distro', help='add layer(s) providing the specified DISTRO')
     parser.add_argument('-s', '--sdkmachine', help='add layer(s) providing the specified SDKMACHINE')
+    parser.add_argument('-v', '--verbose', help='increase verbosity', action='store_true')
 
     scriptdir = os.path.dirname(__file__)
     args = parser.parse_args(cmdline_args)
@@ -314,6 +315,23 @@ class Layers(collections.MutableSet):
         return found_layers, missing
 
 
+class LayerStatus(StatusDisplay):
+    """Show status of work whose results are a set of layers."""
+
+    def __init__(self, message, verbose=False, output=None):
+        super(LayerStatus, self).__init__(message, output)
+        self.verbose = verbose
+
+    def set_layer_status(self, layers):
+        layer_names = set(l.name for l in layers)
+        if self.verbose:
+            self.set_status('')
+            for f in sorted(l.path for l in layers):
+                self.output.write('  %s\n' % f)
+        else:
+            self.set_status(','.join(sorted(layer_names)))
+
+
 def get_layerpaths_bitbake(globs=None, paths=None):
     bitbake_path = None
     layer_paths = set()
@@ -372,55 +390,65 @@ def determine_layers(cmdline_opts):
             if priority_override is not None:
                 layer.priority = priority_override
 
+    def get_layers_for(value, varname, cfgpath):
+        with LayerStatus("Determining layers to include for {0} '{1}'".format(varname, value), verbose=args.verbose) as s:
+            layers = all_layers.which('conf/{0}/{1}.conf'.format(cfgpath, value))
+            if not layers:
+                sys.exit("No layer found for {0} `{1}`".format(varname, value))
+
+            s.set_layer_status(layers)
+            layer_names = set(l.name for l in layers)
+            return layer_names
+
     configured_layer_names = set(args.layers)
 
-    if args.machine:
-        with status("Determining layers to include for MACHINE '{0}'".format(args.machine)):
-            machine_layers = all_layers.which('conf/machine/{0}.conf'.format(args.machine))
-            if not machine_layers:
-                sys.exit("No layer found for MACHINE `{0}`".format(args.machine))
-
-            configured_layer_names |= set(l.name for l in machine_layers)
-
     if args.distro and args.distro != 'nodistro':
-        with status("Determining layers to include for DISTRO '{0}'".format(args.distro)):
-            distro_layers = all_layers.which('conf/distro/{0}.conf'.format(args.distro))
-            if not distro_layers:
-                sys.exit("No layer found for DISTRO `{0}`".format(args.distro))
+        configured_layer_names |= get_layers_for(args.distro, 'DISTRO', 'distro')
 
-            configured_layer_names |= set(l.name for l in distro_layers)
+    if args.machine:
+        configured_layer_names |= get_layers_for(args.machine, 'MACHINE', 'machine')
 
     if args.sdkmachine:
-        with status("Determining layers to include for SDKMACHINE '{0}'".format(args.sdkmachine)):
-            sdkmachine_layers = all_layers.which('conf/machine-sdk/{0}.conf'.format(args.sdkmachine))
-            if not sdkmachine_layers:
-                sys.exit("No layer found for SDKMACHINE `{0}`".format(args.sdkmachine))
+        configured_layer_names |= get_layers_for(args.sdkmachine, 'SDKMACHINE', 'machine-sdk')
 
-            configured_layer_names |= set(l.name for l in sdkmachine_layers)
+    with status('Processing layer dependencies'):
+        configured_layers = Layers()
+        for name in configured_layer_names:
+            if name not in all_layers.by_name:
+                sys.exit("Layer '{0}' not found".format(name))
 
-    configured_layers = Layers()
-    for name in configured_layer_names:
-        if name not in all_layers.by_name:
-            sys.exit("Layer '{0}' not found".format(name))
-
-        layers, missing_layers = all_layers.get_by_name_recursive(name)
-        if missing_layers:
-            sys.exit("Dependent layers `{0}` not found for requested layer `{1}`".format(', '.join(missing_layers), name))
-        configured_layers |= layers
-
-    for name in args.optional_layers:
-        if name in all_layers.by_name:
             layers, missing_layers = all_layers.get_by_name_recursive(name)
             if missing_layers:
-                sys.stderr.write("Warning: optional layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
-            else:
-                configured_layers |= layers
+                sys.exit("Dependent layers `{0}` not found for requested layer `{1}`".format(', '.join(missing_layers), name))
+            configured_layers |= layers
 
-    for name in args.extra_layers:
-        if name in all_layers.by_name:
-            layers, missing_layers = all_layers.get_by_name_recursive(name)
-            if not missing_layers:
-                configured_layers |= layers
+    if args.optional_layers:
+        with LayerStatus('Checking for optional layers', verbose=args.verbose) as s:
+            found_optional = set()
+            for name in args.optional_layers:
+                if name in all_layers.by_name:
+                    layers, missing_layers = all_layers.get_by_name_recursive(name)
+                    if missing_layers:
+                        sys.stderr.write("Warning: optional layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
+                    else:
+                        found_optional.update(layers)
+
+            found_optional.difference_update(configured_layers)
+            s.set_layer_status(found_optional)
+            configured_layers |= found_optional
+
+    if args.extra_layers:
+        with LayerStatus('Checking for extra layers', verbose=args.verbose) as s:
+            found_extra = set()
+            for name in args.extra_layers:
+                if name in all_layers.by_name:
+                    layers, missing_layers = all_layers.get_by_name_recursive(name)
+                    if not missing_layers:
+                        found_extra.update(layers)
+
+            found_extra.difference_update(configured_layers)
+            s.set_layer_status(found_extra)
+            configured_layers |= found_extra
 
     for layer in configured_layers.priority_sorted():
         print(layer.path)

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -227,6 +227,7 @@ class Layers(collections.MutableSet):
     def __init__(self, iterable=None):
         """A collection of layers. Maintains lookup mappings by path and name"""
         self.layers = set()
+        self.duplicates = collections.defaultdict(set)
         self.by_path = {}
         self.by_name = {}
 
@@ -252,11 +253,12 @@ class Layers(collections.MutableSet):
         if layer in self:
             return
 
-        if layer.name in self.by_name:
-            raise Exception("Layer name '{0}' found more than once: {1}, {2}".format(
-                layer.name, self.by_name[layer.name].path, layer.path))
-
         if layer.path in self.by_path:
+            return
+
+        if layer.name in self.by_name:
+            self.duplicates[layer.name].add(self.by_name[layer.name])
+            self.duplicates[layer.name].add(layer)
             return
 
         self.layers.add(layer)
@@ -298,6 +300,9 @@ class Layers(collections.MutableSet):
         missing = set()
         found_layers = Layers()
 
+        if name in self.duplicates:
+            raise DuplicateLayers(name, self.duplicates[name])
+
         try:
             layer = self.by_name[name]
         except KeyError:
@@ -313,6 +318,15 @@ class Layers(collections.MutableSet):
                     found_layers |= dep_found
                     missing |= dep_missing
         return found_layers, missing
+
+
+class DuplicateLayers(Exception):
+    def __init__(self, name, layers):
+        self.name = name
+        self.layers = layers
+
+    def __str__(self):
+        return 'Duplicate layers found for %s:\n%s' % (self.name, ''.join('  %s\n' % l.path for l in self.layers))
 
 
 class LayerStatus(StatusDisplay):
@@ -458,6 +472,8 @@ if __name__ == '__main__':
     signal.signal(signal.SIGTERM, sigterm_exception)
     try:
         sys.exit(determine_layers(sys.argv[1:]) or 0)
+    except DuplicateLayers as exc:
+        sys.exit(str(exc))
     except KeyboardInterrupt:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         os.kill(os.getpid(), signal.SIGINT)

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -25,7 +25,7 @@ def sigterm_exception(signum, stackframe):
 
 def setup_command_import(command, relpath='../lib'):
     """Set up sys.path based on the location of a binary in the PATH """
-    PATH = os.getenv('PATH').split(':')
+    PATH = os.environ['PATH'].split(':')
     cmd_paths = [os.path.join(path, relpath)
                  for path in PATH if os.path.exists(os.path.join(path, command))]
     if not cmd_paths:
@@ -299,6 +299,28 @@ def get_configured_layers(all_layers, base_layer_names, optional_layer_names, ex
 def print_layers(cmdline_opts):
     args = process_arguments(cmdline_opts)
 
+    layer_paths = set()
+    with status('Locating layers and bitbake'):
+        bitbake_path = None
+
+        for pattern in args.globs:
+            for glob_path in glob.glob(pattern)
+                layerconf_path = os.path.join(glob_path, 'conf', 'layer.conf')
+                if os.path.exists(layerconf_path):
+                    layer_paths.add(os.path.realpath(glob_path))
+                elif os.path.exists(os.path.join(glob_path, 'bin', 'bitbake')):
+                    bitbake_path = os.path.join(glob_path, 'bin')
+
+        for path in args.paths:
+            for subpath in find(path):
+                if subpath.endswith('/conf/layer.conf'):
+                    layer_paths.add(os.path.realpath(os.path.dirname(os.path.dirname(subpath))))
+                elif subpath.endswith('/bin/bitbake'):
+                    bitbake_path = os.path.dirname(subpath)
+
+        if bitbake_path is not None:
+            os.environ['PATH'] += ':' + bitbake_path
+
     setup_command_import('bitbake')
     try:
         import bb
@@ -312,20 +334,7 @@ def print_layers(cmdline_opts):
     bb.parse.init_parser(data)
 
     all_layers = set()
-    with status('Locating layers and parsing layer.conf files'):
-        layer_paths = set()
-        for pattern in args.globs:
-            paths = glob.glob(pattern)
-            for path in paths:
-                layerconf_path = os.path.join(path, 'conf', 'layer.conf')
-                if os.path.exists(layerconf_path):
-                    layer_paths.add(os.path.realpath(path))
-
-        for path in args.paths:
-            for subpath in find(path):
-                if subpath.endswith('/conf/layer.conf'):
-                    layer_paths.add(os.path.realpath(subpath))
-
+    with status('Parsing layer configuration files'):
         for layer_path in layer_paths:
             try:
                 layers = Layer.from_layerpath(layer_path, data)

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -34,11 +34,16 @@ def setup_command_import(command, relpath='../lib'):
     sys.path[0:0] = cmd_paths
 
 
-def find(dir, **walkoptions):
+def find(dir, dirfilter=None, **walkoptions):
     """ Given a directory, recurse into that directory,
     returning all files as absolute paths. """
 
     for root, dirs, files in os.walk(dir, **walkoptions):
+        if dirfilter is not None:
+            for d in dirs:
+                if not dirfilter(d):
+                    dirs.remove(d)
+
         for file in files:
             yield os.path.join(root, file)
 
@@ -312,7 +317,7 @@ def print_layers(cmdline_opts):
                     bitbake_path = os.path.join(glob_path, 'bin')
 
         for path in args.paths:
-            for subpath in find(path):
+            for subpath in find(path, dirfilter=lambda d: d != 'lib'):
                 if subpath.endswith('/conf/layer.conf'):
                     layer_paths.add(os.path.realpath(os.path.dirname(os.path.dirname(subpath))))
                 elif subpath.endswith('/bin/bitbake'):

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -126,7 +126,7 @@ def process_arguments(cmdline_args):
     parser.add_argument('-l', '--layers', default=layers_default,
             help='base layers to include. space separated. default: `{0}`'.format(layers_default))
     parser.add_argument('-o', '--optional-layers', default='',
-            help='optional layers to include. space separated.')
+            help='optional layers to include. space separated. These layers are included if they and their dependencies are available, but are silently left out otherwise.')
     parser.add_argument('-e', '--extra-layers', default='',
             help='extra layers to include. space separated. These layers are expected to exist, but are only included if their dependencies are already included in the configuration.')
     parser.add_argument('-x', '--excluded-layers', default='',
@@ -138,15 +138,15 @@ def process_arguments(cmdline_args):
             help='wildcard patterns to locate layers. colon separated. default: `{0}`'.format(glob_default))
     parser.add_argument('-p', '--paths',
             help='paths to search recursively to find layers. colon separated. equivalent to the "find" command', default='')
-    parser.add_argument('machine', help='machine to use when selecting bsp layers')
+    parser.add_argument('-m', '--machine', help='machine to use to locate bsp layers to include')
 
     scriptdir = os.path.dirname(__file__)
     args = parser.parse_args(cmdline_args)
 
     args.layers = args.layers.split()
     args.optional_layers = args.optional_layers.split()
-    args.excluded_layers = args.excluded_layers.split()
     args.extra_layers = args.extra_layers.split()
+    args.excluded_layers = args.excluded_layers.split()
 
     new_globs = []
     for pattern in args.globs.split(':'):
@@ -170,8 +170,8 @@ class LayerError(Exception):
 
 class Layer(object):
     def __init__(self, path, confpath, name, priority, pattern, depends):
-        self.path = path
-        self.confpath = confpath
+        self.path = os.path.realpath(path)
+        self.confpath = os.path.realpath(confpath)
         self.name = name
         self.priority = priority
         self.depends = depends
@@ -179,7 +179,8 @@ class Layer(object):
         self.pattern = pattern
 
     def __repr__(self):
-        return 'Layer(%s, %s, %s, %s, %s, %s)' % (repr(self.path), repr(self.confpath), repr(self.name), repr(self.priority), repr(self.pattern), repr(self.depends))
+        return '{0.__class__.__name__}({0.path!r}, {0.confpath!r},' \
+               '{0.name!r}, {0.priority!r}, {0.pattern!r}, {0.depends!r})'.format(self)
 
     def __hash__(self):
         return hash(repr(self))
@@ -221,6 +222,7 @@ class Layer(object):
 
 class Layers(collections.MutableSet):
     def __init__(self, iterable=None):
+        """A collection of layers. Maintains lookup mappings by path and name"""
         self.layers = set()
         self.by_path = {}
         self.by_name = {}
@@ -228,9 +230,28 @@ class Layers(collections.MutableSet):
         if iterable is not None:
             self |= iterable
 
+    def __contains__(self, layer):
+        return layer in self.layers
+
+    def __iter__(self):
+        return iter(self.layers)
+
+    def __len__(self):
+        return len(self.layers)
+
+    def __repr__(self):
+        return '{0.__class__.__name__}({0.layers!r})'.format(self)
+
+    def __hash__(self):
+        return hash(repr(self))
+
     def add(self, layer):
+        if layer in self:
+            return
+
         if layer.name in self.by_name:
-            raise Exception("Layer name '{0}' found more than once", layer.name)
+            raise Exception("Layer name '{0}' found more than once: {1}, {2}".format(
+                layer.name, self.by_name[layer.name].path, layer.path))
 
         if layer.path in self.by_path:
             return
@@ -240,7 +261,11 @@ class Layers(collections.MutableSet):
         self.by_name[layer.name] = layer
 
     def add_from_path(self, layerpath, data=None):
-        self |= Layer.from_layerpath(os.path.realpath(layerpath), data)
+        layerpath = os.path.realpath(layerpath)
+        if layerpath in self.by_path:
+            return
+
+        self |= Layer.from_layerpath(layerpath, data)
 
     def discard(self, layer):
         self.layers.discard(layer)
@@ -252,98 +277,39 @@ class Layers(collections.MutableSet):
         self.by_path.clear()
         self.by_name.clear()
 
-    def __contains__(self, layer):
-        return layer in self.layers
-        #return layer.path in self.by_path
+    def priority_sorted(self):
+        return sorted(self.layers, key=lambda l: (l.priority, l.name), reverse=True)
 
-    def __iter__(self):
-        return iter(self.layers)
+    def which(self, path, all=True):
+        layers = []
+        for layer in self.priority_sorted():
+            if os.path.exists(os.path.join(layer.path, path)):
+                layers.append(layer)
+        return layers
 
-    def __len__(self):
-        return len(self.layers)
+    def get_by_name_recursive(self, name):
+        """Get a layer by name and its dependencies, recursively.
 
+        Returns a Layers() collection, and a list of missing dependencies."""
 
-def resolve_dependencies(layers_by_name):
-    missing_dependencies = collections.defaultdict(set)
+        missing = set()
+        found_layers = Layers()
 
-    for layer in layers_by_name.values():
-        missing_layer_deps = set()
-        new_deps = set()
-
-        for depname in layer.depends:
-            dep = layers_by_name.get(depname)
-            if not dep:
-                missing_layer_deps.add(depname)
-            else:
-                new_deps.add(dep)
-
-        layer.depends = new_deps
-        if missing_layer_deps:
-            layer.missingdeps |= missing_layer_deps
-            missing_dependencies[layer] = missing_layer_deps
-
-    return missing_dependencies
-
-
-class MissingDeps(Exception):
-    def __init__(self, layer, deps):
-        self.layer = layer
-        self.deps = deps
-        Exception.__init__(self)
-
-    def __str__(self):
-        return 'Layer `{}` has missing dependencies: {}'.format(self.layer, ', '.join(self.deps))
-
-
-def get_configured_layers(all_layers, base_layer_names, optional_layer_names, extra_layer_names, missing_deps, machine):
-    configured_layers, optional = set(), set()
-
-    def layer_and_deps(layer, seen):
-        if layer.missingdeps:
-            raise MissingDeps(layer.name, layer.missingdeps)
-        if layer in seen:
-            return
-        seen.add(layer)
-
-        for d in layer.depends:
-            for _d in layer_and_deps(d, seen):
-                yield _d
-        yield layer
-
-    def add_layer(layer, configured_layers, seen):
-        configured_layers |= set(layer_and_deps(layer, seen))
-
-    seen = set()
-    layers_by_name = dict((l.name, l) for l in all_layers)
-    for layer in all_layers:
-        if os.path.exists(os.path.join(layer.path, 'conf', 'machine',
-                                       '{0}.conf'.format(machine))):
-            add_layer(layer, configured_layers, seen)
-
-    for base_name in base_layer_names:
-        if base_name not in layers_by_name:
-            raise Exception("Requested base layer `{}` not found".format(base_name))
-        add_layer(layers_by_name[base_name], configured_layers, seen)
-
-    for optional_name in optional_layer_names:
-        if optional_name in layers_by_name:
-            optional_layer = layers_by_name[optional_name]
-            optional.add(optional_layer)
-            try:
-                add_layer(optional_layer, configured_layers, seen)
-            except MissingDeps:
-                pass
-
-    for extra_name in extra_layer_names:
-        layer = layers_by_name[extra_name]
-        with_deps = set(layer_and_deps(layer, seen))
-        with_deps.remove(layer)
-        if any(dep not in configured_layers for dep in with_deps):
-            continue
+        try:
+            layer = self.by_name[name]
+        except KeyError:
+            missing.add(name)
         else:
-            configured_layers.add(layer)
-
-    return configured_layers, optional
+            found_layers.add(layer)
+            for dep in layer.depends:
+                try:
+                    dep_found, dep_missing = self.get_by_name_recursive(dep)
+                except KeyError:
+                    missing.add(dep)
+                else:
+                    found_layers |= dep_found
+                    missing |= dep_missing
+        return found_layers, missing
 
 
 def get_layerpaths_bitbake(globs=None, paths=None):
@@ -404,36 +370,41 @@ def determine_layers(cmdline_opts):
             if priority_override is not None:
                 layer.priority = priority_override
 
-    duplicates = defaultdict(set)
-    with status('Resolving layer dependencies'):
-        layers_by_name = {}
-        for l in all_layers:
-            if l.name in layers_by_name:
-                duplicates[l.name].add(layers_by_name[l.name].path)
-                duplicates[l.name].add(l.path)
+    configured_layer_names = set(args.layers)
+
+    if args.machine:
+        with status("Determining layers to include for MACHINE '{0}'".format(args.machine)):
+            machine_layers = all_layers.which('conf/machine/{0}.conf'.format(args.machine))
+            if not machine_layers:
+                sys.exit("No BSP layer found for machine `{0}`".format(args.machine))
+
+            configured_layer_names |= set(l.name for l in machine_layers)
+
+    configured_layers = Layers()
+    for name in configured_layer_names:
+        if name not in all_layers.by_name:
+            sys.exit("Layer '{0}' not found".format(name))
+
+        layers, missing_layers = all_layers.get_by_name_recursive(name)
+        if missing_layers:
+            sys.exit("Dependent layers `{0}` not found for requested layer `{1}`".format(', '.join(missing_layers), name))
+        configured_layers |= layers
+
+    for name in args.optional_layers:
+        if name in all_layers.by_name:
+            layers, missing_layers = all_layers.get_by_name_recursive(name)
+            if missing_layers:
+                sys.stderr.write("Warning: optional layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
             else:
-                layers_by_name[l.name] = l
+                configured_layers |= layers
 
-        missing_deps = resolve_dependencies(layers_by_name)
+    for name in args.extra_layers:
+        if name in all_layers.by_name:
+            layers, missing_layers = all_layers.get_by_name_recursive(name)
+            if not missing_layers:
+                configured_layers |= layers
 
-    with status("Determining layers to include for MACHINE '{0}'".format(args.machine)) as s:
-        try:
-            configured_layers, optional = get_configured_layers(all_layers, args.layers, args.optional_layers, args.extra_layers, missing_deps, args.machine)
-        except Exception as exc:
-            sys.exit('ERROR: {0}'.format(exc))
-        else:
-            configured_names = set(l.name for l in configured_layers)
-            configured_dupes = list((n, l) for n, l in duplicates.iteritems() if n in configured_names)
-            if configured_dupes:
-                s.set_status('failed (duplicate layers)')
-                for name, paths in configured_dupes:
-                    sys.stderr.write("Multiple layer paths found for layer name '{0}':\n{1}\n".format(name, '\n'.join('  ' + p for p in sorted(paths))))
-                sys.exit(1)
-
-    for layer in optional:
-        sys.stderr.write("Layer '{0}' was detected, including in configuration\n".format(layer.name))
-
-    for layer in sorted(configured_layers, key=lambda l: (l.priority, l.name), reverse=True):
+    for layer in configured_layers.priority_sorted():
         print(layer.path)
 
 

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -138,7 +138,9 @@ def process_arguments(cmdline_args):
             help='wildcard patterns to locate layers. colon separated. default: `{0}`'.format(glob_default))
     parser.add_argument('-p', '--paths',
             help='paths to search recursively to find layers. colon separated. equivalent to the "find" command', default='')
-    parser.add_argument('-m', '--machine', help='machine to use to locate bsp layers to include')
+    parser.add_argument('-m', '--machine', help='add layer(s) providing the specified MACHINE')
+    parser.add_argument('-d', '--distro', help='add layer(s) providing the specified DISTRO')
+    parser.add_argument('-s', '--sdkmachine', help='add layer(s) providing the specified SDKMACHINE')
 
     scriptdir = os.path.dirname(__file__)
     args = parser.parse_args(cmdline_args)
@@ -376,9 +378,25 @@ def determine_layers(cmdline_opts):
         with status("Determining layers to include for MACHINE '{0}'".format(args.machine)):
             machine_layers = all_layers.which('conf/machine/{0}.conf'.format(args.machine))
             if not machine_layers:
-                sys.exit("No BSP layer found for machine `{0}`".format(args.machine))
+                sys.exit("No layer found for MACHINE `{0}`".format(args.machine))
 
             configured_layer_names |= set(l.name for l in machine_layers)
+
+    if args.distro and args.distro != 'nodistro':
+        with status("Determining layers to include for DISTRO '{0}'".format(args.distro)):
+            distro_layers = all_layers.which('conf/distro/{0}.conf'.format(args.distro))
+            if not distro_layers:
+                sys.exit("No layer found for DISTRO `{0}`".format(args.distro))
+
+            configured_layer_names |= set(l.name for l in distro_layers)
+
+    if args.sdkmachine:
+        with status("Determining layers to include for SDKMACHINE '{0}'".format(args.sdkmachine)):
+            sdkmachine_layers = all_layers.which('conf/machine-sdk/{0}.conf'.format(args.sdkmachine))
+            if not sdkmachine_layers:
+                sys.exit("No layer found for SDKMACHINE `{0}`".format(args.sdkmachine))
+
+            configured_layer_names |= set(l.name for l in sdkmachine_layers)
 
     configured_layers = Layers()
     for name in configured_layer_names:

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -6,7 +6,8 @@
 # version 2.  This program  is licensed "as is" without any warranty of any
 # kind, whether express or implied.
 
-CORELAYERS="${CORELAYERS:-core mel mel-support mentor-staging}"
+MEL_DISTRO="${MEL_DISTRO:-mel}"
+CORELAYERS="${CORELAYERS:-core mel-support mentor-staging}"
 OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
 EXTRAMELLAYERS="${EXTRAMELLAYERS:-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery}"
 layer_priority_overrides="openembedded-layer=1"
@@ -130,7 +131,7 @@ configure_for_machine () {
         updatelayernames="$updatelayernames $layer"
     done
 
-    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" -m "$MACHINE" "$@" >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" -m "$MACHINE" -d "$MEL_DISTRO" "$@" >$layersfile
     if [ $? -ne 0 ]; then
         rm -f $layersfile
         echo >&2 "Error in execution of bb-determine-layers, aborting"
@@ -324,7 +325,6 @@ layerdir="${scriptsdir%/*}"
 if [ -e $layerdir/../.mel-lite ]; then
     MEL_DISTRO="mel-lite"
 fi
-MEL_DISTRO="${MEL_DISTRO:-mel}"
 
 setup_builddir "$@" || exit $?
 if [ -e $BUILDDIR/conf/local.conf ]; then

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -130,7 +130,7 @@ configure_for_machine () {
         updatelayernames="$updatelayernames $layer"
     done
 
-    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" "$@" $MACHINE >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" -m "$MACHINE" "$@" >$layersfile
     if [ $? -ne 0 ]; then
         rm -f $layersfile
         echo >&2 "Error in execution of bb-determine-layers, aborting"

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -214,10 +214,6 @@ setup_builddir () {
         return 3
     fi
 
-    if [ "$force_overwrite" = "-f" ]; then
-        rm -f $BUILDDIR/conf/local.conf $BUILDDIR/conf/bblayers.conf
-    fi
-
     TEMPLATECONF=
     MACHINE=$1
     if [ -n "$MACHINE" ]; then
@@ -226,7 +222,11 @@ setup_builddir () {
             TEMPLATECONF=$MELDIR/$MACHINE/conf
         fi
     else
-        if [ ! -e $BUILDDIR/conf/local.conf -o ! -e $BUILDDIR/conf/bblayers.conf ]; then
+        if [ -e "$BUILDDIR/conf/local.conf" ]; then
+            MACHINE=$(sed -n 's/^MACHINE ?*= "\([^"]*\)"/\1/p' $BUILDDIR/conf/local.conf)
+        fi
+
+        if [ ! -e $BUILDDIR/conf/local.conf -o ! -e $BUILDDIR/conf/bblayers.conf ] || [ -z "$MACHINE" ]; then
             tmpfile="$(mktemp -t "${0##*/}.XXXXX")"
             ls -1d $MELDIR/*/binary 2>/dev/null | sed "s,^$MELDIR/,,; s,/binary$,," | \
                 while read machine; do
@@ -244,6 +244,10 @@ setup_builddir () {
                 TEMPLATECONF=$MELDIR/$MACHINE/conf
             fi
         fi
+    fi
+
+    if [ "$force_overwrite" = "-f" ]; then
+        rm -f $BUILDDIR/conf/local.conf $BUILDDIR/conf/bblayers.conf
     fi
 
     : ${TEMPLATECONF:=$layerdir/conf}
@@ -283,10 +287,6 @@ setup_builddir () {
         if [ -n "$MACHINE" ]; then
             echo "Configuring existing bblayers.conf for $MACHINE"
         fi
-    fi
-
-    if [ -z "$MACHINE" ]; then
-        MACHINE=$(sed -n 's/^MACHINE ?*= "\([^"]*\)"/\1/p' $BUILDDIR/conf/local.conf)
     fi
 
     if [ -d "$MELDIR/bitbake" ]; then

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -99,9 +99,10 @@ abspath () {
 
 configure_for_machine () {
     if [ -n "$EXCLUDEDLAYERS" ]; then
-        set -- -x "$EXCLUDEDLAYERS"
-    else
-        set --
+        set -- "$@" -x "$EXCLUDEDLAYERS"
+    fi
+    if [ "$verbose" -eq 1 ]; then
+        set -- "$@" -v
     fi
 
 
@@ -153,9 +154,10 @@ process_arguments () {
     MELDIR=
     OEROOT=
     extralayers=
-    force_overwrite=
-    toasterconfig=
-    while getopts b:o:l:fth opt; do
+    force_overwrite=0
+    toasterconfig=0
+    verbose=0
+    while getopts b:o:l:tfvh opt; do
         case "$opt" in
             b)
                 BUILDDIR="$(abspath $OPTARG)"
@@ -166,10 +168,14 @@ process_arguments () {
             l)
                 extralayers="$OPTARG"
                 ;;
-            t)  toasterconfig="yes"
+            t)
+                toasterconfig=1
                 ;;
             f)
-                force_overwrite="-f"
+                force_overwrite=1
+                ;;
+            v)
+                verbose=1
                 ;;
             \?|h)
                 usage
@@ -247,7 +253,7 @@ setup_builddir () {
         fi
     fi
 
-    if [ "$force_overwrite" = "-f" ]; then
+    if [ $force_overwrite -eq 1 ]; then
         rm -f $BUILDDIR/conf/local.conf $BUILDDIR/conf/bblayers.conf
     fi
 
@@ -300,7 +306,7 @@ setup_builddir () {
         if [ -e "$layerdir/pre-setup.$MACHINE" ]; then
             . "$layerdir/pre-setup.$MACHINE"
         fi
-        PATH="$OEROOT/scripts:$BITBAKEDIR/bin:$PATH" configure_for_machine "$BUILDDIR/conf"
+        PATH="$OEROOT/scripts:$BITBAKEDIR/bin:$PATH" configure_for_machine
     fi
 
     cat >$BUILDDIR/setup-environment <<END
@@ -334,6 +340,6 @@ if [ -e $BUILDDIR/conf/local.conf ]; then
     fi
 fi
 
-if [ "$toasterconfig" = "yes" ]; then
+if [ $toasterconfig -eq 1 ]; then
     $layerdir/scripts/toaster_configuration "$BUILDDIR" "$MELDIR"
 fi

--- a/setup-environment
+++ b/setup-environment
@@ -63,7 +63,8 @@ else
     fi
 
     OPTIONALLAYERS="$OPTIONALLAYERS" EXTRAMELLAYERS="$EXTRAMELLAYERS" EXCLUDEDLAYERS="$EXCLUDEDLAYERS" $layerdir/scripts/setup-mel-builddir "$@"
-    if [ $? -eq 0 ] && [ -n "$BUILDDIR" ] && [ -e "$BUILDDIR" ]; then
+    mel_setup_ret=$?
+    if [ $mel_setup_ret -eq 0 ] && [ -n "$BUILDDIR" ] && [ -e "$BUILDDIR" ]; then
         . $BUILDDIR/setup-environment >/dev/null 2>&1
 
         configured_layers () {
@@ -102,4 +103,5 @@ else
     unset OPTIONALLAYERS
     unset EXCLUDEDLAYERS
     unset layerdir
+    test $mel_setup_ret -eq 0
 fi


### PR DESCRIPTION
This is based on some cleanup and refactoring work I had done back in february of 2014, but which was never polished off and finished. I've now done so.

- Refactor bb-determine-layers to make it easier to submit setup script improvements to oe-core in the future
- Rather than hardcoding the dep on the 'mel' layer, instead search for and include the layers that provide `$MEL_DISTRO`, which will make it easier for mel-based products
- Display the layers which are found, and if -v is passed, display the layer paths which were found
- Add more status output so the user knows what the script is doing
- Return a correct exit code from the setup script so the user can respond to a failure from setup-mel-builddir
- Add an arg to bb-determine-layers so we can include the layers needed for a given SDKMACHINE, if needed, in the future (i.e. for mingw)