### PR TITLE
setup-mel-builddir: recurse an extra level in meta* dirs

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -110,7 +110,7 @@ configure_for_machine () {
     echo 'BBLAYERS = "\' >> $BUILDDIR/conf/bblayers.conf
     layersfile=$(mktemp setup-mel-builddir.XXXXXX)
 
-    layerpaths="*:*/*:$MELDIR/*:$MELDIR/*/*"
+    layerpaths="*:*/*:meta*/*/*:$MELDIR/*:$MELDIR/*/*:$MELDIR/meta*/*/*"
     # Convert layer paths to layer names for bb-determine-layers
     extralayernames=
     for layer in $extralayers; do


### PR DESCRIPTION
meta-haswell-wc is an extra level deep in meta-intel, so we need to check one
level deeper for layers. If we recurse into `*/*/*` rather than `meta*/*/*`, the
layer search can take quite a long time due to searching into downloads/ and
cached-binaries/, unless we add exclusions.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>