### PR TITLE
Switch back to linux-firmware for minnowmax

### DIFF
--- a/meta-mel/conf/local.conf.append.intel-corei7-64
+++ b/meta-mel/conf/local.conf.append.intel-corei7-64
@@ -1,8 +1,3 @@
-# Override intel-corei7-64's inclusion of linux-firmware in favor of a minimal subset
-# which holds just the wireless firmware
-MACHINE_EXTRA_RRECOMMENDS_remove_intel-corei7-64 = "linux-firmware"
-MACHINE_EXTRA_RRECOMMENDS_append_intel-corei7-64 = " firmware-wireless"
-
 # vfat support required for minnowmax
 MACHINE_FEATURES_append_intel-corei7-64 = " vfat"
 


### PR DESCRIPTION
linux-firmware-i915 is needed for the graphics, according to meta-intel, so
firmware-wireless is no longer sufficient. Either we switch back to
linux-firmware, or also split off i915 into its own recipe the way we did
the wireless firmware.

Without this, both recipes end up building, conflicting, and resulting in
warnings/errors in the build.