### PR TITLE
bootimg-wic: fix the class

### DIFF
--- a/meta-mentor-staging/classes/bootimg-wic.bbclass
+++ b/meta-mentor-staging/classes/bootimg-wic.bbclass
@@ -1,4 +1,4 @@
 python () {
-    if oe.utils.inherits(d, 'bootimg'):
+    if 'do_bootimg' in d:
         bb.build.addtask('do_image_wic', '', 'do_bootimg', d)
 }


### PR DESCRIPTION
The bootimg class no longer exists, so we can't use that to determine
whether to run the addtask.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>