### PR TITLE
mel: exclude DATETIME_SECS from checksums

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -199,6 +199,7 @@ ADE_PROVIDER ?= "Mentor Graphics Corporation"
 # The ADE_VERSION has to stay numeric with . separators
 OE_IMPORTS += "string"
 ADE_VERSION ?= "${@'0.0' if not all(c in string.digits for c in '${SDK_VERSION}'.split('.')[0]) else '${SDK_VERSION}'}.${DATETIME_SECS}"
+ADE_VERSION[vardepsexclude] += "DATETIME_SECS"
 ADE_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}"
 ADE_IDENTIFIER_SUBDIR = "/ade-${ADE_IDENTIFIER}"
 ADE_SITENAME ?= "ADE for ${ADE_IDENTIFIER}"
@@ -214,6 +215,7 @@ SDK_P2_CATEGORY = "${ADE_TOP_CATEGORY}"
 SDK_P2_CATEGORY_NAME = "${ADE_TOP_CATEGORY}"
 SDK_P2_VERSION = "${ADE_VERSION}"
 SDK_P2_TIMESTAMP = "${DATETIME_SECS}"
+SDK_P2_TIMESTAMP[vardepsexclude] += "DATETIME_SECS"
 
 # Fixup these vars to use correct values for the image
 SDK_RESET_ENV_SCRIPT_VARS += "\


### PR DESCRIPTION
Currently, bitbake is erroring with a taskbase hash mismatch due to the ade
version string changing between the main bitbake process which checks
sstate and the worker process that runs the task.

So, exclude the datetime from the checksums to avoid this mismatch. This
means a bitbake of populate_ade won't re-run every time, but when it does
re-run, the version will still increment. This retains the properties we
need of the versioning while fixing the bitbake error.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>