### PR TITLE
mk-cyclone5-boot-part.sh: modify the way we check root access

### DIFF
--- a/meta-mel/scripts/mk-cyclone5-boot-part.sh
+++ b/meta-mel/scripts/mk-cyclone5-boot-part.sh
@@ -21,7 +21,7 @@ BOOT_PT_END="32775"
 P="p"
 
 # only Superuser can run this script
-if [ ${UID} -ne 0 ] ; then
+if [ `whoami` != "root" ] ; then
     echo "Please run this script as a Superuser."
     exit -1
 fi


### PR DESCRIPTION
Checking the UID environment variable doesn't work with dash, so use the
'whoami' command.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>