### PR TITLE
archive-release: include probe configuration files

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -12,6 +12,8 @@ EXCLUDE_FROM_WORLD = "1"
 MELDIR ?= "${COREBASE}/.."
 TEMPLATECONF ?= "${FILE_DIRNAME}/../../../conf"
 
+PROBECONFIGS ?= "${@bb.utils.which('${BBPATH}', 'conf/probe-configs/${MACHINE}')}" 
+
 # Add a default in case the user doesn't inherit copyleft_compliance
 ARCHIVE_RELEASE_DL_DIR ?= "${DL_DIR}"
 ARCHIVE_RELEASE_DL_TOPDIR ?= "${DL_DIR}"
@@ -42,8 +44,8 @@ SUBLAYERS_INDIVIDUAL_ONLY_TOPLEVEL ?= "${@configured_update_layers(d)}"
 
 DUMP_HEADREVS_DB ?= ""
 DEPLOY_DIR_RELEASE ?= "${DEPLOY_DIR}/release-artifacts"
-RELEASE_ARTIFACTS ?= "layers bitbake templates images downloads sstate"
-RELEASE_ARTIFACTS[doc] = "List of artifacts to include (available: layers, bitbake, templates, images, downloads, sstate"
+RELEASE_ARTIFACTS ?= "layers bitbake templates images downloads sstate probeconfigs"
+RELEASE_ARTIFACTS[doc] = "List of artifacts to include (available: layers, bitbake, templates, images, downloads, sstate, probeconfigs"
 RELEASE_IMAGE ?= "core-image-base"
 RELEASE_IMAGE[doc] = "The image to build and archive in this release"
 RELEASE_USE_TAGS ?= "false"
@@ -394,6 +396,13 @@ do_prepare_release () {
         elif [ ${BINARY_ARTIFACTS_COMPRESSION} = ".gz" ]
         then
             gzip deploy/${MACHINE}.tar
+        fi
+    fi
+
+    if echo "${RELEASE_ARTIFACTS}" | grep -qw probeconfigs; then
+        if [ -d ${PROBECONFIGS} ]
+        then
+            release_tar "--transform=s,${PROBECONFIGS},probe-configs-${MACHINE}," -rf deploy/${MACHINE}.tar ${PROBECONFIGS}
         fi
     fi
 

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -181,7 +181,7 @@ IMAGE_CLASSES += "${ADE_IMAGE_CLASS}"
 RELEASE_IMAGE ?= "console-image"
 
 # Don't distribute shared state for now
-RELEASE_ARTIFACTS ?= "layers bitbake templates images downloads"
+RELEASE_ARTIFACTS ?= "layers bitbake templates images downloads probeconfigs"
 
 # Restore any available saved headrevs (used for our installers)
 DUMP_HEADREVS_DB ?= "${MELDIR}/${MACHINE}/saved_persist_data.db"


### PR DESCRIPTION
Include probe configuration files for a particular machine if they are
present in meta-mentor-private. If the files are not there or
meta-mentor-private layer isn't included, they will be silently skipped.

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>