### PR TITLE
webkitgtk: drop the manual dbg packaging bits

### DIFF
--- a/meta-mentor-staging/recipes-sato/webkit/webkitgtk_%.bbappend
+++ b/meta-mentor-staging/recipes-sato/webkit/webkitgtk_%.bbappend
@@ -1,7 +1,3 @@
 # Link fails due to memory exhaustion, so disable debug info to reduce the
 # memory footprint
 DEBUG_FLAGS_remove = "-g"
-
-FILES_${PN}-dbg += "${libdir}/webkit2gtk-4.0/injected-bundle/.debug \
-		    ${libdir}/webkitgtk/webkit2gtk-4.0/.debug/* \
-                   "


### PR DESCRIPTION
Upstream handles this automatically, and removing it doesn't result in any
build warnings now.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>