### PR TITLE
bootimg-wic: only add dep if do_image_wic exists

### DIFF
--- a/meta-mentor-staging/classes/bootimg-wic.bbclass
+++ b/meta-mentor-staging/classes/bootimg-wic.bbclass
@@ -1,4 +1,4 @@
 python () {
-    if 'do_bootimg' in d:
+    if 'do_image_wic' in d and 'do_bootimg' in d:
         bb.build.addtask('do_image_wic', '', 'do_bootimg', d)
 }


### PR DESCRIPTION
This kills errors seen when building a non-wic hddimg.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>