### PR TITLE
lttng-tools: remove the override

### DIFF
--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-tools_2.6.0.bbappend
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-tools_2.6.0.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append_x86-64 += "file://0001-Fix-regression-tests.patch \
-                         "
+SRC_URI_append += "file://0001-Fix-regression-tests.patch \
+                  "


### PR DESCRIPTION
0001-Fix-regression-tests.patch is not architecture specific so remove
the x86-64 override.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-7174

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>