### PR TITLE
For MinnowMAX, also apply our changes to linux-yocto 4.4

### DIFF
--- a/meta-mel/intel/recipes-kernel/linux/linux-yocto_4.4.bbappend
+++ b/meta-mel/intel/recipes-kernel/linux/linux-yocto_4.4.bbappend
@@ -1,0 +1,23 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
+FILESEXTRAPATHS_append = ":${@os.path.dirname(bb.utils.which("${BBPATH}", 'files/kgdb.cfg') or '')}"
+
+# Add Mentor logo & Fix CRDA Wifi messages
+SRC_URI_append_intel-corei7-64 = " \
+	file://0001-Add-Mentor-logo-to-linux-kernel.patch \
+	"
+
+# Enable necessary config options for MEL
+SRC_URI_append_intel-corei7-64 = " \
+	file://usb.cfg \
+	file://6lowpan.cfg \
+	file://bluetooth.cfg \
+	file://filesystem.cfg \
+	file://framebuffer.cfg \
+	file://wireless.cfg \
+	file://kernel.cfg \
+	file://kgdb.cfg \
+	"
+
+# Add Shallow support for mirror tarballs
+BB_GIT_SHALLOW_machine = "v4.4"
+BB_GIT_SHALLOW_meta = ""


### PR DESCRIPTION
They were being applied to 4.1 only, from the cedar release, but 4.4 is
default now, so apply our changes to both.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>