### PR TITLE
Drop unneeded LICENSE / LIC_FILE_CHKSUM

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Archive the artifacts for a ${DISTRO_NAME} release"
 SRC_URI_append_qemuall = "file://runqemu.in"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 INHIBIT_DEFAULT_DEPS = "1"
 PROVIDES += "mel-release"

--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-role-nas.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-role-nas.bb
@@ -1,9 +1,6 @@
 inherit packagegroup
 
 DESCRIPTION = "Package group for a nas-type device"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PR = "r0"
 
 VIRTUAL-RUNTIME_swan ?= "strongswan"

--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-role-print-server.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-role-print-server.bb
@@ -1,9 +1,6 @@
 inherit packagegroup
 
 DESCRIPTION = "Package group for a print-server-type device"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PR = "r0"
 
 RDEPENDS_${PN} += "\

--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-role-router.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-role-router.bb
@@ -1,9 +1,6 @@
 inherit packagegroup
 
 DESCRIPTION = "Package group for a router-type device"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PR = "r0"
 
 RDEPENDS_${PN} += "\

--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-audio.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-audio.bb
@@ -1,7 +1,4 @@
 DESCRIPTION = "Package group for audio support."
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 inherit packagegroup
 

--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
@@ -1,9 +1,6 @@
 inherit packagegroup
 
 DESCRIPTION = "Package group for benchmarking the target"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=3f40d7994397109285ec7b81fdeb3b58 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PR = "r0"
 
 RDEPENDS_${PN} += "\


### PR DESCRIPTION
Upstream no longer requires this for recipes which have no sources, and
poky/LICENSE has changed, so all these would need updating to fix the build
anyway.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>