### PR TITLE
Revert "syslinux: obey our binutils vars"

### DIFF
--- a/meta-mentor-staging/recipes-devtools/syslinux/syslinux_6.03.bbappend
+++ b/meta-mentor-staging/recipes-devtools/syslinux/syslinux_6.03.bbappend
@@ -1,5 +1,0 @@
-# Obey our vars for binutils
-EXTRA_OEMAKE += "\
-    'LD=${LD}' 'RANLIB=${RANLIB}' 'STRIP=${STRIP}' \
-    'NM=${NM}' 'AR=${AR}' 'OBJCOPY=${OBJCOPY}' 'OBJDUMP=${OBJDUMP}' \
-"


### PR DESCRIPTION
This reverts commit 5b7608cbac007fe5e0e5622c0514bd47a8d416d7.
The changes to LD were made upstream with commit
http://cgit.openembedded.org/openembedded-core/commit/meta/recipes-devtools/syslinux?id=c4897af85eace49e3c27aebc1448227105286e30
and all other variables fixed with the meta-mentor commit
in question also show up correctly.

Signed-off-by: Awais Belal <awais_belal@mentor.com>