### PR TITLE
lmbench: drop the MACHINE config bits

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-benchmark/lmbench/lmbench_3.0-a9.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-benchmark/lmbench/lmbench_3.0-a9.bbappend
@@ -1,7 +1,0 @@
-# If the machine installs a config file, install it to the appropriate place
-do_install_append () {
-    if [ -f ${WORKDIR}/CONFIG.${MACHINE} ]; then
-        install -D 0644 ${WORKDIR}/CONFIG.${MACHINE} \
-                        ${D}/${datadir}/lmbench/scripts/CONFIG.${MACHINE}
-    fi
-}


### PR DESCRIPTION
1. We don't use this to ship lmbench configurations anymore.
2. It hardcodes an assumption that the hostname matches up with machine name.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>