### PR TITLE
mel: enable wic fstypes if a wks exists

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -30,6 +30,10 @@ SANITY_TESTED_DISTROS = "\
 IMAGE_FSTYPES ?= "tar.bz2 ext3"
 UBI_VOLNAME = "rootfs"
 
+# If a wks file exists for this BSP, use it to emit a wic image
+WKS_FULL_PATH ??= ""
+IMAGE_FSTYPES += "${@'wic.bz2 wic.bmap' if os.path.exists('${WKS_FULL_PATH}') else ''}"
+
 # Quadruple the normal. 'du' is not a good way to really see how much
 # space will be needed and fails badly as the fs size grows.
 IMAGE_ROOTFS_EXTRA_SPACE = "40960"


### PR DESCRIPTION
As we prefer wic images for our BSPs, we can automatically enable such images
when a wks file exists for this BSP. If it exists, then either the WKS_FILE
has been changed (presumably by the BSP), or the default path which includes
the MACHINE exists. In either case, we can assume the existence of such a file
indicates wic support is available for this BSP, so use it.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>