### PR TITLE
firmware-wireless: quiet warnings from do_populate_lic

### DIFF
--- a/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
+++ b/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
@@ -5,6 +5,7 @@ LICENSE = "\
     Firmware-atheros & \
     Firmware-broadcom & \
     Firmware-cw1200 & \
+    Firmware-carl9170 & \
     Firmware-intelwimax & \
     Firmware-libertas & \
     Firmware-orinoco & \
@@ -17,32 +18,32 @@ LICENSE = "\
 "
 
 LIC_FILES_CHKSUM = "\
-    file://atheros/LICENSE;md5=670a25baf80964a6a286bfa4d981aef4 \
-    file://broadcom/LICENSE;md5=8cba1397cda6386db37210439a0da3eb \
-    file://cw1200/LICENSE;md5=f0f770864e7a8444a5c5aa9d12a3a7ed \
-    file://intelwimax/LICENSE;md5=14b901969e23c41881327c0d9e4b7d36 \
-    file://libertas/LICENSE;md5=d934c5881815c89f0ed946179315fa35 \
-    file://orinoco/LICENSE;md5=af0133de6b4a9b2522defd5f188afd31 \
-    file://ralink/LICENSE;md5=d0ac64cc96774fed46eb5a772a658652 \
-    file://realtek/LICENSE;md5=4f9d5ca75b4e819b2afa39ee8a8496e9 \
-    file://rsi/LICENSE;md5=84bfadbcb40f0f3fd3967aafd77c85f7 \
-    file://ti-connectivity/LICENSE;md5=8b81af85c4472aea6355d742b472572c \
-    file://via_vt6656/LICENSE;md5=e4159694cba42d4377a912e78a6e850f \
-    file://carl9170/COPYRIGHT;md5=b0e5b5cb9edb5794f96103f3598518ac \
-    file://carl9170/LICENSE;md5=751419260aa954499f7abaabaa882bbe \
+    file://LICENSE.atheros;md5=670a25baf80964a6a286bfa4d981aef4 \
+    file://LICENSE.broadcom;md5=8cba1397cda6386db37210439a0da3eb \
+    file://LICENSE.cw1200;md5=f0f770864e7a8444a5c5aa9d12a3a7ed \
+    file://LICENSE.intelwimax;md5=14b901969e23c41881327c0d9e4b7d36 \
+    file://LICENSE.libertas;md5=d934c5881815c89f0ed946179315fa35 \
+    file://LICENSE.orinoco;md5=af0133de6b4a9b2522defd5f188afd31 \
+    file://LICENSE.ralink;md5=d0ac64cc96774fed46eb5a772a658652 \
+    file://LICENSE.realtek;md5=4f9d5ca75b4e819b2afa39ee8a8496e9 \
+    file://LICENSE.rsi;md5=84bfadbcb40f0f3fd3967aafd77c85f7 \
+    file://LICENSE.ti-connectivity;md5=8b81af85c4472aea6355d742b472572c \
+    file://LICENSE.via_vt6656;md5=e4159694cba42d4377a912e78a6e850f \
+    file://LICENSE.carl9170;md5=751419260aa954499f7abaabaa882bbe \
 "
 
-NO_GENERIC_LICENSE[Firmware-atheros] = "atheros/LICENSE"
-NO_GENERIC_LICENSE[Firmware-broadcom] = "broadcom/LICENSE"
-NO_GENERIC_LICENSE[Firmware-cw1200] = "cw1200/LICENSE"
-NO_GENERIC_LICENSE[Firmware-intelwimax] = "intelwimax/LICENSE"
-NO_GENERIC_LICENSE[Firmware-libertas] = "libertas/LICENSE"
-NO_GENERIC_LICENSE[Firmware-orinoco] = "orinoco/LICENSE"
-NO_GENERIC_LICENSE[Firmware-ralink] = "ralink/LICENSE"
-NO_GENERIC_LICENSE[Firmware-realtek] = "realtek/LICENSE"
-NO_GENERIC_LICENSE[Firmware-rsi] = "rsi/LICENSE"
-NO_GENERIC_LICENSE[Firmware-ti-connectivity] = "ti-connectivity/LICENSE"
-NO_GENERIC_LICENSE[Firmware-via_vt6656] = "via_vt6656/LICENSE"
+NO_GENERIC_LICENSE[Firmware-atheros] = "LICENSE.atheros"
+NO_GENERIC_LICENSE[Firmware-broadcom] = "LICENSE.broadcom"
+NO_GENERIC_LICENSE[Firmware-cw1200] = "LICENSE.cw1200"
+NO_GENERIC_LICENSE[Firmware-intelwimax] = "LICENSE.intelwimax"
+NO_GENERIC_LICENSE[Firmware-libertas] = "LICENSE.libertas"
+NO_GENERIC_LICENSE[Firmware-orinoco] = "LICENSE.orinoco"
+NO_GENERIC_LICENSE[Firmware-ralink] = "LICENSE.ralink"
+NO_GENERIC_LICENSE[Firmware-realtek] = "LICENSE.realtek"
+NO_GENERIC_LICENSE[Firmware-rsi] = "LICENSE.rsi"
+NO_GENERIC_LICENSE[Firmware-ti-connectivity] = "LICENSE.ti-connectivity"
+NO_GENERIC_LICENSE[Firmware-via_vt6656] = "LICENSE.via_vt6656"
+NO_GENERIC_LICENSE[Firmware-carl9170] = "LICENSE.carl9170"
 
 SRCREV = "c2c3df64df50d826d7649e03fbbe84ea99e5dbc8"
 PV = "0.0+git${SRCPV}"
@@ -51,6 +52,15 @@ SRC_URI = "git://github.com/MentorEmbedded/firmware-wireless;protocol=https"
 S = "${WORKDIR}/git"
 
 inherit allarch update-alternatives
+
+hack_around_do_populate_lic_limitations () {
+    for license in ${@' '.join(d.getVarFlags('NO_GENERIC_LICENSE').itervalues())}; do
+        n="$(echo "$license" | sed 's,\([^.]*\)\.\(.*\),\2/\1,')"
+        cp -f "$n" "$license"
+    done
+}
+hack_around_do_populate_lic_limitations[vardeps] += "NO_GENERIC_LICENSE"
+do_unpack[postfuncs] += "hack_around_do_populate_lic_limitations"
 
 do_compile() {
 	:


### PR DESCRIPTION
This works around a do_populate_lic limitation. do_populate_lic apparently
expects the license files to always have unique basenames, particularly for
NO_GENERIC_LICENSE, but this wasn't the case here.

A yocto bug has been opened to track this limitation.

[YOCTO #9663]
JIRA: SB-7212

Signed-off-by: Christopher Larson <chris_larson@mentor.com>