### PR TITLE
platform-init,obexd: fix odd files:// bugs

### DIFF
--- a/meta-mentor-staging/meta-arago-extras/recipes-connectivity/obex/obexd_0.34.bbappend
+++ b/meta-mentor-staging/meta-arago-extras/recipes-connectivity/obex/obexd_0.34.bbappend
@@ -1,0 +1,3 @@
+python () {
+    d.setVar('LIC_FILES_CHKSUM', d.getVar('LIC_FILES_CHKSUM', False).replace('files://', 'file://'))
+}

--- a/meta-mentor-staging/xilinx/recipes-bsp/platform-init/platform-init.bbappend
+++ b/meta-mentor-staging/xilinx/recipes-bsp/platform-init/platform-init.bbappend
@@ -1,0 +1,3 @@
+python () {
+    d.setVar('LIC_FILES_CHKSUM', d.getVar('LIC_FILES_CHKSUM', False).replace('files://', 'file://'))
+}


### PR DESCRIPTION
These recipes in meta-arago-extras and meta-xilinx use invalid files:// urls
in their LIC_FILES_CHKSUM.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>