### PR TITLE
96boards-tools: add recipe for resize-helper

### DIFF
--- a/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.7.bb
+++ b/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.7.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Useful bits an pieces to make 96Boards more standard across the board"
+HOMEPAGE = "https://github.com/96boards/96boards-tools"
+SECTION = "devel"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SRCREV = "193f355823d9dc38f370759153ac950a2833b0e2"
+SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https"
+
+S = "${WORKDIR}/git"
+
+inherit systemd allarch
+
+do_compile () {
+    # The parted version we're using doesn't want this argument
+    sed -i -e "/PARTED/s/ Yes / /" ${S}/resize-helper
+}
+
+do_install () {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0755 ${S}/*.rules ${D}${sysconfdir}/udev/rules.d/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/resize-helper.service ${D}${systemd_unitdir}/system
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/resize-helper ${D}${sbindir}
+}
+
+SYSTEMD_SERVICE_${PN} = "resize-helper.service"
+RDEPENDS_${PN} += "e2fsprogs-resize2fs gptfdisk parted util-linux udev"


### PR DESCRIPTION
resize-helper will resize the rootfs partition and filesystem to the available
capacity, which is invaluable for sd card images, where the size may not
necessarily be known at image creation time.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>