### PR TITLE
meta-mel-support: remove bbappend from layer.conf

### DIFF
--- a/meta-mel-support/conf/layer.conf
+++ b/meta-mel-support/conf/layer.conf
@@ -1,10 +1,9 @@
 BBPATH .= ":${LAYERDIR}"
-BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*.bbappend"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb"
 
-# Let us add layer-specific bbappends which are only applied when that
+# Let us add layer-specific files which are only applied when that
 # layer is included in our configuration
-BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
+BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split())}"
 
 LAYERDIR_RE ?= "${LAYERDIR}"


### PR DESCRIPTION
This layer exists to provide additional recipes for use by Mentor Graphics,
where it's not appropriate to keep them in meta-mel (for yocto compliance
reasons) or meta-mentor-staging (not for upstream), so we don't want appends
collecting here.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>