### PR TITLE
qtmultimedia: drop the gstreamer1.0-plugins-bad dep

### DIFF
--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtmultimedia_%.bbappend
@@ -1,0 +1,3 @@
+# qtmultimedia needs gstreamer, not a random collection of plugins with
+# questionable quality
+DEPENDS_remove_pn-qtmultimedia = "gstreamer1.0-plugins-bad"


### PR DESCRIPTION
qtmultimedia needs gstreamer, not a random collection of plugins with
questionable quality

Signed-off-by: Christopher Larson <chris_larson@mentor.com>