### PR TITLE
initial support for Imx7 based sabresd board

### DIFF
--- a/meta-mel/conf/local.conf.append.imx7dsabresd
+++ b/meta-mel/conf/local.conf.append.imx7dsabresd
@@ -1,0 +1,5 @@
+# By default meta-fsl-arm selects u-boot-fslc.
+# Override it and select u-boot-imx as our PREFERED_PROVIDER.
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-imx"
+PREFERRED_PROVIDER_u-boot = "u-boot-imx"

--- a/meta-mentor-staging/fsl-arm/recipes-graphics/directfb/directfb_1.7.4.bbappend
+++ b/meta-mentor-staging/fsl-arm/recipes-graphics/directfb/directfb_1.7.4.bbappend
@@ -1,1 +1,0 @@
-FILESPATH .= ":${COREBASE}/meta/recipes-graphics/directfb/directfb"

--- a/meta-mentor-staging/recipes-core/systemd/systemd-serialgetty.bbappend
+++ b/meta-mentor-staging/recipes-core/systemd/systemd-serialgetty.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/systemd-serialgetty:"
+

--- a/meta-mentor-staging/recipes-core/systemd/systemd-serialgetty/serial-getty@.service
+++ b/meta-mentor-staging/recipes-core/systemd/systemd-serialgetty/serial-getty@.service
@@ -1,0 +1,36 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Serial Getty on %I
+Documentation=man:agetty(8) man:systemd-getty-generator(8)
+Documentation=http://0pointer.de/blog/projects/serial-console.html
+After=systemd-user-sessions.service plymouth-quit-wait.service
+After=rc-local.service
+
+# If additional gettys are spawned during boot then we should make
+# sure that this is synchronized before getty.target, even though
+# getty.target didn't actually pull it in.
+Before=getty.target
+IgnoreOnIsolate=yes
+
+[Service]
+Environment="TERM=xterm"
+ExecStart=-/sbin/agetty -8 -L --keep-baud %I @BAUDRATE@ $TERM
+Type=idle
+Restart=always
+RestartSec=0
+UtmpIdentifier=%I
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=getty.target


### PR DESCRIPTION
meta-fsl-arm "jethro" provides imx7dsabresd machine file.
. directfb is removed in meta-fsl-arm stating that the project is dead upstream
. set preferred provider to uboot-imx instead of uboot-fslc
. systemd workaround for the random bug when boot hangs at serial-getty service.

Signed-off-by:  Adnan Ali <Adnan_Ali@mentor.com>