### PR TITLE
local.conf.sample: use include, not require for drop-toolchain-from-sdk

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -129,7 +129,7 @@ SSTATE_MIRROR_SITES += "\
 
 # When we're using an external toolchain, we don't want to ship a newly built
 # toolchain inside the Yocto SDK.
-require conf/include/drop-toolchain-from-sdk.inc
+include conf/include/drop-toolchain-from-sdk.inc
 
 #
 # Package Management configuration


### PR DESCRIPTION
This file currently lives in meta-mel, and our setup scripts can be used with
other distros by setting MEL_DISTRO , so meta-mel might or might not be
currently in BBLAYERS. Switch to include so it's non-fatal if it's missing.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>