### PR TITLE
plymouth: disable dracut

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -104,6 +104,9 @@ PACKAGECONFIG_remove = "${PACKAGECONFIG_REMOVE}"
 # We prefer EGL to GLX
 PACKAGECONFIG_REMOVE_pn-mesa-demos = "glx"
 
+# We don't use dracut to build initramfs
+PACKAGECONFIG_REMOVE_pn-plymouth = "initrd"
+
 # Ensure we have the writable paths we need in a read-only rootfs
 VOLATILE_BINDS_append = "\
     /var/volatile/root-home ${ROOT_HOME}\n\

--- a/meta-mentor-staging/openembedded-layer/recipes-core/plymouth/plymouth_%.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-core/plymouth/plymouth_%.bbappend
@@ -1,0 +1,10 @@
+PACKAGECONFIG += "initrd"
+PACKAGECONFIG[initrd] = ",,,"
+
+PACKAGES_remove = "${@bb.utils.contains('PACKAGECONFIG', 'initrd', '', '${PN}-initrd', d)}"
+
+do_install_append () {
+    if ! ${@bb.utils.contains('PACKAGECONFIG', 'initrd', 'true', 'false', d)}; then
+        rm -rf "${D}${libexecdir}"
+    fi
+}


### PR DESCRIPTION
We aren't using dracut for initramfs construction, so there's no need to pull in the dependency and therefore the meta-initramfs layer.