### PR TITLE
mel: add vmlinux to KERNEL_IMAGETYPES by default

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -175,6 +175,9 @@ FEATURE_PACKAGES_samba-server    ?= "samba swat"
 # Include nss-myhostname for sysvinit, so the hostname resolves. systemd
 # includes myhostname itself.
 DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
+
+# Include vmlinux in DEPLOY_DIR_IMAGE for debugging purposes
+KERNEL_IMAGETYPES_append = " vmlinux"
 ## }}}1
 ## Workarounds & Overrides {{{1
 # Add missing dep from do_image_wic on do_bootimg when both are used


### PR DESCRIPTION
This ensures vmlinux ends up in tmp/deploy/images/${MACHINE}, next to the
kernel and disk images, which is useful for debugging.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>