### PR TITLE
mel: drop the libjpeg-turbo pref

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -134,9 +134,6 @@ OE_IMPORTS += "oe.terminal"
 INHERIT += "mentor-updates-check"
 ## }}}1
 ## Preferences & Package Selection {{{1
-PREFERRED_PROVIDER_jpeg               ??= "libjpeg-turbo"
-PREFERRED_PROVIDER_jpeg-native        ??= "libjpeg-turbo-native"
-
 # Prefer the chkconfig C implementation of alternatives
 VIRTUAL-RUNTIME_update-alternatives = "chkconfig-alternatives"
 PREFERRED_PROVIDER_virtual/update-alternatives = "chkconfig-alternatives"


### PR DESCRIPTION
libjpeg-turbo is default in oe-core now.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>