### PR TITLE
ruby: ensure that .ext/rdoc is gone in compile

### DIFF
--- a/meta-mentor-staging/recipes-devtools/ruby/ruby_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/ruby/ruby_%.bbappend
@@ -1,0 +1,3 @@
+do_compile_prepend () {
+    rm -rf .ext/rdoc
+}


### PR DESCRIPTION
rdoc gets unhappy if this already exists, so remove it before building.

Without this, it's possible to hit this error:

    Directory .ext/rdoc already exists, but it looks like it isn't an RDoc
    directory.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>