### PR TITLE
lttng-modules: Fix crash in LTTng kernel tracing

### DIFF
--- a/meta-mentor-staging/recipes-kernel/lttng/files/0001-Fix-ctf_string-should-handle-NULL-pointers.patch
+++ b/meta-mentor-staging/recipes-kernel/lttng/files/0001-Fix-ctf_string-should-handle-NULL-pointers.patch
@@ -1,0 +1,66 @@
+From 8e4b115ba22066b923d36ff230a7c155f59f03de Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Mon, 16 May 2016 16:51:00 -0400
+Subject: [PATCH] Fix: ctf_string() should handle NULL pointers
+
+The regmap instrumentation can send a NULL string (e.g. on ARM32).
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+ probes/lttng-events.h | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/probes/lttng-events.h b/probes/lttng-events.h
+index 86c13bb..1fab263 100644
+--- a/probes/lttng-events.h
++++ b/probes/lttng-events.h
+@@ -34,6 +34,8 @@
+ #include <asm/byteorder.h>
+ #include <linux/swab.h>
+ 
++#define __LTTNG_NULL_STRING	"(null)"
++
+ /*
+  * Macro declarations used for all stages.
+  */
+@@ -333,7 +335,7 @@ static void __event_probe__##_name(void *__data);
+ 			max_t(size_t, lttng_strlen_user_inatomic(_src), 1);    \
+ 	else								       \
+ 		__event_len += __dynamic_len[__dynamic_len_idx++] =	       \
+-			strlen(_src) + 1;
++			strlen((_src) ? (_src) : __LTTNG_NULL_STRING) + 1;
+ 
+ #undef TP_PROTO
+ #define TP_PROTO(...)	__VA_ARGS__
+@@ -511,7 +513,8 @@ static inline size_t __event_get_size__##_name(size_t *__dynamic_len,	      \
+ #undef _ctf_string
+ #define _ctf_string(_item, _src, _user, _nowrite)			       \
+ 	{								       \
+-		const void *__ctf_tmp_ptr = (_src);			       \
++		const void *__ctf_tmp_ptr =				       \
++			((_src) ? (_src) : __LTTNG_NULL_STRING);	       \
+ 		memcpy(__stack_data, &__ctf_tmp_ptr, sizeof(void *));	       \
+ 		__stack_data += sizeof(void *);				       \
+ 	}
+@@ -677,12 +680,16 @@ static inline size_t __event_get_align__##_name(void *__tp_locvar)	      \
+ 
+ #undef _ctf_string
+ #define _ctf_string(_item, _src, _user, _nowrite)		        \
+-	lib_ring_buffer_align_ctx(&__ctx, lttng_alignof(*(_src)));	\
+ 	if (_user) {							\
++		lib_ring_buffer_align_ctx(&__ctx, lttng_alignof(*(_src))); \
+ 		__chan->ops->event_strcpy_from_user(&__ctx, _src,	\
+ 			__get_dynamic_len(dest));			\
+ 	} else {							\
+-		__chan->ops->event_strcpy(&__ctx, _src,			\
++		const char *__ctf_tmp_string =				\
++			((_src) ? (_src) : __LTTNG_NULL_STRING);	\
++		lib_ring_buffer_align_ctx(&__ctx,			\
++			lttng_alignof(*__ctf_tmp_string));		\
++		__chan->ops->event_strcpy(&__ctx, __ctf_tmp_string,	\
+ 			__get_dynamic_len(dest));			\
+ 	}
+ 
+-- 
+2.8.1
+

--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-Fix-ctf_string-should-handle-NULL-pointers.patch"
+


### PR DESCRIPTION
The issue has been recently fixed upstream and the fix is available in
LTTng modules version 2.7.4, but not in version 2.7.3 that we are currently
using in Dogwood. Back-porting the patch for now.

Upstream commit: http://git.lttng.org/?p=lttng-modules.git;a=commit;h=8e4b115ba22066b923d36ff230a7c155f59f03de

Jira: http://jira.alm.mentorg.com:8080/browse/SB-7450

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>