### PR TITLE
layerdirs: handle empty BBFILE_COLLECTIONS

### DIFF
--- a/meta-mel/classes/layerdirs.bbclass
+++ b/meta-mel/classes/layerdirs.bbclass
@@ -7,7 +7,7 @@ python save_layerdirs() {
         l = bb.parse.handle(layerconf, l)
         l.expandVarref('LAYERDIR')
 
-        for layername in l.getVar('BBFILE_COLLECTIONS', True).split():
+        for layername in (l.getVar('BBFILE_COLLECTIONS', True) or '').split():
             d.setVar('LAYERDIR_%s' % layername, layerpath)
 }
 save_layerdirs[eventmask] = "bb.event.ConfigParsed"


### PR DESCRIPTION
meta-yocto's layer.conf exists only to allow parsing of old build dirs, but as
it doesn't set BBFILE_COLLECTIONS, including it will cause our
layerdirs.bbclass to error. Fix that by handling the var being unset.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>