### PR TITLE
qt4-native: add already-stripped to INSANE_SKIP

### DIFF
--- a/meta-mentor-staging/qt4-layer/recipes-qt4/qt4/qt4-native_%.bbappend
+++ b/meta-mentor-staging/qt4-layer/recipes-qt4/qt4/qt4-native_%.bbappend
@@ -1,0 +1,2 @@
+# Silence the already-stripped sysroot warning, we don't care for this
+INSANE_SKIP_${PN} += "already-stripped"


### PR DESCRIPTION
We don't care whether qt4-native is stripped, so this quiets the sysroot strip
warnings.