### PR TITLE
mel: add -Wl,--build-id=sha1 to LDFLAGS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -174,6 +174,10 @@ DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 
 KERNEL_IMAGETYPES_append = " vmlinux"
 ## }}}1
 ## Workarounds & Overrides {{{1
+# Align the external toolchain with the internal one. This is also needed for
+# Sourcery Analyzer with lttng-ust
+TARGET_LDFLAGS += "-Wl,--build-id=sha1"
+
 # Add missing dep from do_image_wic on do_bootimg when both are used
 IMAGE_CLASSES += "bootimg-wic"
 


### PR DESCRIPTION
Align the external toolchain with the internal one. This is also needed for
Sourcery Analyzer with lttng-ust.

JIRA: SB-7585

Signed-off-by: Christopher Larson <chris_larson@mentor.com>