### PR TITLE
wic-ppc.inc: Use correct dtb path

### DIFF
--- a/meta-mel/conf/include/wic-ppc.inc
+++ b/meta-mel/conf/include/wic-ppc.inc
@@ -3,7 +3,7 @@
 KERNEL_IMAGETYPE ?= "uImage"
 
 IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE} ${UBOOT_BINARY} \
-                ${@' '.join('${KERNEL_IMAGETYPE}-%s' % devicetree for devicetree in KERNEL_DEVICETREE.split())}"
+                ${@' '.join('${KERNEL_IMAGETYPE}-%s' % devicetree.replace('fsl/', '') for devicetree in KERNEL_DEVICETREE.split())}"
 
 # u-boot is needed for our IMAGE_BOOT_FILES
 IMAGE_DEPENDS_wic_append = " virtual/bootloader"


### PR DESCRIPTION
dtb paths are now prefixed with 'fsl/' in meta-fsl-ppc machine
files. Update ${IMAGE_BOOT_FILES} accordingly.

JIRA: SB-7588

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>