### PR TITLE
meta-mel: add local.conf.append with ADE vars

### DIFF
--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -1,0 +1,9 @@
+# Uncomment to alter the identifier for this build for the ADE. This mechanism
+# is used to support installation of multiple ADEs side-by-side. By default,
+# every ADE build gets its own identifier, so is self-contained already.
+# Default: ${MACHINE}-${ADE_VERSION}
+#ADE_IDENTIFIER ?= "${MACHINE}-${ADE_VERSION}.some-configuration"
+#
+# Uncomment to set a site name (shown in CodeBench) for this ADE build.
+# Default: ADE for ${ADE_IDENTIFIER}
+#ADE_SITENAME ?= "My Company's ADE for ${ADE_IDENTIFIER}"


### PR DESCRIPTION
These are used by mel.conf, so this is really where they belong.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>