### PR TITLE
mplayer2: drop changes from our layer

### DIFF
--- a/meta-mel/openembedded-layer/recipes-multimedia/mplayer/mplayer2_git.bbappend
+++ b/meta-mel/openembedded-layer/recipes-multimedia/mplayer/mplayer2_git.bbappend
@@ -1,3 +1,0 @@
-# Clear blacklist if we want to include mplayer
-UPSTREAM_BLACKLIST_VALUE := "${@d.getVarFlag('PNBLACKLIST', 'mplayer2', False)}"
-PNBLACKLIST[mplayer2] = "${@bb.utils.contains('INCLUDE_MPLAYER', 'yes', '', '${UPSTREAM_BLACKLIST_VALUE}', d)}"


### PR DESCRIPTION
For MEL on the required BSPs we now use mpv which is
the better suited option so the changes for mplayer2
are not needed anymore and are irrelevant.

Signed-off-by: Awais Belal <awais_belal@mentor.com>