### PR TITLE
archive-release: limit version to the sub-repo

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -145,7 +145,7 @@ git_tar () {
             if [ "${@oe.data.typed_value('RELEASE_USE_TAGS', d)}" = "True" ]; then
                 version=$(cd "$path" && git describe --tags)
             else
-                version=$(cd "$path" && git rev-list HEAD | wc -l)
+                version=$(cd "$path" && git rev-list HEAD . | wc -l)
             fi
             release_tar $path "$@" -cjf deploy/${name}_${version}.tar.bz2
         else


### PR DESCRIPTION
For git repositories, which use commit counts for versions, we want to limit
the commit count to the current path, so it doesn't increase due to changes in
unrelated layers.

JIRA: SB-7773

Signed-off-by: Christopher Larson <chris_larson@mentor.com>