### PR TITLE
firmware-wireless: Update source and destination paths for licenses

### DIFF
--- a/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
+++ b/meta-mel-support/recipes-kernel/firmware-wireless/firmware-wireless_git.bb
@@ -56,7 +56,7 @@ inherit allarch update-alternatives
 hack_around_do_populate_lic_limitations () {
     for license in ${@' '.join(d.getVarFlags('NO_GENERIC_LICENSE').values())}; do
         n="$(echo "$license" | sed 's,\([^.]*\)\.\(.*\),\2/\1,')"
-        cp -f "$n" "$license"
+        cp -f "${S}/$n" "${S}/$license"
     done
 }
 hack_around_do_populate_lic_limitations[vardeps] += "NO_GENERIC_LICENSE"


### PR DESCRIPTION
Update source and destination paths for licenses in
hack_around_do_populate_lic_limitations function. With this
change the do_unpack doesn't fail to unpack.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>