### PR TITLE
plymouth-mel: correctly handle license-checksum error

### DIFF
--- a/meta-mel-support/recipes-core/plymouth/plymouth-mel.bb
+++ b/meta-mel-support/recipes-core/plymouth/plymouth-mel.bb
@@ -13,7 +13,8 @@ SRC_URI = "\
     file://*.png \
 "
 
-INSANE_SKIP_${PN} += "already-stripped license-checksum"
+INSANE_SKIP_${PN} += "already-stripped"
+ERROR_QA_remove = "license-checksum"
 
 do_install () {
     install -d -m 0755 "${D}${datadir}/plymouth/themes/mel"


### PR DESCRIPTION
The license-checksum checks are run through populate_lic_qa_checksum()
which does not handle INSANE_SKIP. We drop the checking altogether
by removing it from the ERROR_QA list.

JIRA Ticket: SB-7753

Signed-off-by: Awais Belal <awais_belal@mentor.com>