### PR TITLE
toaster_configuration: update this script to generate custom fixtures

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -19,25 +19,6 @@ configured_layers () {
    awk {'print $1'}
 }
 
-configured_layers | while read layer; do
-   if [ -d "$layer" ]; then
-       while [ $(dirname $layer) != "${MELDIR}" ];do
-          layer=$(dirname $layer)
-          layername=$(basename $layer)
-       done
-       cd "$layer"
-       if [ ! -d "$PWD/.git" ]; then
-            if [ "$layername" = "poky" ]; then
-                git init . > /dev/null 2>&1
-                git add . > /dev/null 2>&1
-                git commit -m "Initial commit" > /dev/null 2>&1
-                git remote add origin http://169.254.0.1
-            fi
-       fi
-       cd - > /dev/null 2>&1
-   fi
-done
-
 create_toaster_configuration() {
 DISTRO=$(grep "DISTRO =" "$BUILDDIR/conf/local.conf"  | awk {'print $3'} | sed -e s:\'::g)
 MACHINE=$(grep -i "MACHINE ??=" "$BUILDDIR/conf/local.conf" | awk {'print $3'} | sed -e s:\"::g)
@@ -47,25 +28,60 @@ if [ -n "$EXTERNAL_TOOLCHAIN" ]; then
    EXTERNAL_TOOLCHAIN=$(eval echo "$EXTERNAL_TOOLCHAIN" &>/dev/null)
 fi
 
-cat <<EOF > "$BUILDDIR"/toasterconf.json
-{
-    "config": {
-        "MACHINE"    : "$MACHINE",
-        "DISTRO"     : "$DISTRO",
-        "IMAGE_INSTALL_append": "",
-        "PACKAGE_CLASSES": "package_ipk",
-        "EXTERNAL_TOOLCHAIN": "$EXTERNAL_TOOLCHAIN",
-        "MGLS_LICENSE_FILE": "",
-        "ACCEPT_FSL_EULA": "",
-        "SDKMACHINE"   : "x86_64"
-    },
-    "layersources": [
-       {
-          "name": "Local Yocto Project",
-          "sourcetype": "local",
-          "apiurl": "../../",
-          "branches": ["HEAD"],
-          "layers": [
+cat <<EOF > "$BUILDDIR"/custom.xml
+<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+
+  <!-- Default project settings -->
+  <object model="orm.toastersetting" pk="1">
+    <field type="CharField" name="name">DEFAULT_RELEASE</field>
+    <field type="CharField" name="value">local</field>
+  </object>
+  <object model="orm.toastersetting" pk="2">
+    <field type="CharField" name="name">DEFCONF_PACKAGE_CLASSES</field>
+    <field type="CharField" name="value">package_ipk</field>
+  </object>
+  <object model="orm.toastersetting" pk="3">
+    <field type="CharField" name="name">DEFCONF_MACHINE</field>
+    <field type="CharField" name="value">$MACHINE</field>
+  </object>
+  <object model="orm.toastersetting" pk="4">
+    <field type="CharField" name="name">DEFCONF_DISTRO</field>
+    <field type="CharField" name="value">$DISTRO</field>
+  </object>
+  <object model="orm.toastersetting" pk="5">
+    <field type="CharField" name="name">DEFCONF_EXTERNAL_TOOLCHAIN</field>
+    <field type="CharField" name="value">$EXTERNAL_TOOLCHAIN</field>
+  </object>
+  <object model="orm.toastersetting" pk="6">
+    <field type="CharField" name="name">DEFCONF_MGLS_LICENSE_FILE</field>
+    <field type="CharField" name="value"></field>
+  </object>
+  <object model="orm.toastersetting" pk="7">
+    <field type="CharField" name="name">DEFCONF_ACCEPT_FSL_EULA</field>
+    <field type="CharField" name="value"></field>
+  </object>
+  <object model="orm.toastersetting" pk="8">
+    <field type="CharField" name="name">DEFCONF_SSTATE_DIR</field>
+    <field type="CharField" name="value">${BUILDDIR}/../sstate-cache</field>
+  </object>
+  <object model="orm.toastersetting" pk="9">
+    <field type="CharField" name="name">DEFCONF_DL_DIR</field>
+    <field type="CharField" name="value">${BUILDDIR}/../downloads</field>
+  </object>
+
+EOF
+
+cat <<EOF >> "$BUILDDIR"/custom.xml
+
+  <!-- Bitbake version which correspond to our local release -->
+
+  <object model="orm.bitbakeversion" pk="2">
+    <field type="CharField" name="name">HEAD</field>
+  </object>
+
+  <!-- Default layers for each release -->
+
 EOF
 
 LAYER_PATHS=""
@@ -75,88 +91,68 @@ LAYER_PATHS=$(configured_layers | while read -r layer; do
 done)
 LAYER_PATHS=$(echo "$LAYER_PATHS" | sed -n '$p' | sed 's:,: :g'| sed 's:"::g')
 
+pk=3
 for layer in $(echo "$LAYER_PATHS"); do
+   pk=$((pk+1))
    name=
    layername=$(basename "$layer")
    cd $layer
    if [ "$layername" = "meta" ]; then
         layername="openembedded-core"
    fi
-   cat <<EOF >> "$BUILDDIR"/toasterconf.json
-              {
-                  "name": "$layername",
-                  "local_path": "$layer",
-                  "vcs_url": "remote:origin",
-                  "dirpath": "$layer"
-              },
+   cat <<EOF >> "$BUILDDIR"/custom.xml
+  <object model="orm.releasedefaultlayer" pk="$pk">
+    <field rel="ManyToOneRel" to="orm.release" name="release">2</field>
+    <field type="CharField" name="layer_name">$layername</field>
+  </object>
+
 EOF
 cd - > /dev/null 2>&1
 done
 
-sed -i '$ s/,$//' "$BUILDDIR"/toasterconf.json
+cat <<EOF >> "$BUILDDIR"/custom.xml
 
-cat <<EOF >> "$BUILDDIR"/toasterconf.json
-            ]
-        },
-        {
-            "name": "Imported layers",
-            "sourcetype": "imported",
-            "apiurl": "",
-            "branches": ["HEAD"]
+  <!-- Layers for the Local release
+       layersource TYPE_LOCAL = 0
+  -->
 
-        }
-    ],
 EOF
 
-bitbake_path=
-bitbake_path=$(configured_layers | while read layer; do
-    layer_name=$(basename "$layer")
-    if [ "$layer_name" = "meta" ]; then
-         dirpath=$(dirname "$layer")
-         bitbake_path="$dirpath"/bitbake
-         echo "$bitbake_path"
-         break
-    fi
+LAYER_PATHS=""
+LAYER_PATHS=$(configured_layers | while read -r layer; do
+    LAYER_PATHS="\"$layer\",$LAYER_PATHS"
+    echo "$LAYER_PATHS"
 done)
+LAYER_PATHS=$(echo "$LAYER_PATHS" | sed -n '$p' | sed 's:,: :g'| sed 's:"::g')
 
-cat <<EOF >> "$BUILDDIR"/toasterconf.json
-    "bitbake" : [
-        {
-            "name": "HEAD",
-            "giturl": "remote:origin",
-            "branch": "HEAD",
-            "dirpath": "bitbake"
-        }
-    ],
+pk=0
+for layer in $(echo "$LAYER_PATHS"); do
+   pk=$((pk+1))
+   name=
+   layername=$(basename "$layer")
+   dirpath=$(basename "$layer")
+   cd $layer
+   if [ "$layername" = "meta" ]; then
+        layername="openembedded-core"
+   fi
+   cat <<EOF >> "$BUILDDIR"/custom.xml
+  <object model="orm.layer" pk="$pk">
+    <field type="CharField" name="name">$layername</field>
+    <field type="CharField" name="local_source_dir">$layer</field>
+  </object>
+  <object model="orm.layer_version" pk="$pk">
+    <field rel="ManyToOneRel" to="orm.layer" name="layer">$pk</field>
+    <field type="IntegerField" name="layer_source">0</field>
+    <field rel="ManyToOneRel" to="orm.release" name="release">2</field>
+    <field type="CharField" name="dirpath">$dirpath</field>
+  </object>
 
-    "defaultrelease": "local",
-
-    "releases": [
-        {
-            "name": "local",
-            "description": "Local Yocto Project",
-            "bitbake": "HEAD",
-            "branch": "HEAD",
 EOF
+cd - > /dev/null 2>&1
+done
 
-DEFAULTLAYERS=""
-DEFAULTLAYERS=$(configured_layers | while read -r layer; do
-    layername=$(basename "$layer")
-    if [ "$layername" = "meta" ]; then
-          layername="openembedded-core"
-    fi
-    DEFAULTLAYERS="\"$layername\", $DEFAULTLAYERS"
-    echo "$DEFAULTLAYERS"
-done)
-DEFAULTLAYERS=$(echo "$DEFAULTLAYERS" | sed -n '$p' | sed 's/, $//')
-
-cat <<EOF >> "$BUILDDIR"/toasterconf.json
-            "defaultlayers": [ $DEFAULTLAYERS ],
-            "layersourcepriority": { "Imported layers": 99, "Local Yocto Project" : 10 },
-            "helptext": "Toaster will run your builds with the version of the Yocto Project you have cloned or downloaded to your computer."
-        }
-    ]
-}
+cat <<EOF >> "$BUILDDIR"/custom.xml
+</django-objects>
 EOF
 }
 
@@ -174,9 +170,7 @@ if [ -d "${MELDIR}/downloads" ]; then
 fi
 
    cat <<EOF > "$BUILDDIR"/toaster-setup-environment
-export TOASTER_CONF=$BUILDDIR/toasterconf.json
-$POKYDIR/bitbake/bin/toaster
-unset TOASTER_CONF
+. $POKYDIR/bitbake/bin/toaster start
 EOF
 }
 


### PR DESCRIPTION
As per the latest changes in the upstream django fixutres are used
to populate the default values for toaster instead of fixtures.
This script has been modified for the same. A new custom.xml
file will be generated which will be read by toaster and pre populate
the default values for our local changes.

JIRA: SB-7649

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>