### PR TITLE
ruby: Remove ruby bbappend

### DIFF
--- a/meta-mentor-staging/recipes-devtools/ruby/ruby_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/ruby/ruby_%.bbappend
@@ -1,3 +1,0 @@
-do_compile_prepend () {
-    rm -rf .ext/rdoc
-}


### PR DESCRIPTION
We can remove ruby bbappend from meta-mentor-staging

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>