### PR TITLE
toaster_configuration: Remove orm.bitbakeversion from fixtures

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -74,12 +74,6 @@ EOF
 
 cat <<EOF >> "$BUILDDIR"/custom.xml
 
-  <!-- Bitbake version which correspond to our local release -->
-
-  <object model="orm.bitbakeversion" pk="2">
-    <field type="CharField" name="name">HEAD</field>
-  </object>
-
   <!-- Default layers for each release -->
 
 EOF


### PR DESCRIPTION
Remove orm.bitbakeversion from the fixtures. No need to redefine
it. This was missed in my previous commit for this file.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>