### PR TITLE
gstreamer1.0-libav: This change can be removed safely

### DIFF
--- a/meta-mentor-staging/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,2 +1,0 @@
-# ffmpeg/libav disables PIC on some platforms (e.g. x86-32)
-INSANE_SKIP_${PN} = "textrel"


### PR DESCRIPTION
This recipe can be removed safely as the changes are
already available upstream:

http://git.openembedded.org/openembedded-core/commit/?id=4438a1125bb15ed19c78833f4d8a5b108cd91d30

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>