### PR TITLE
mpeg2dec: Recipe can be removed safely

### DIFF
--- a/meta-mentor-staging/recipes-multimedia/mpeg2dec/mpeg2dec_0.4.1.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/mpeg2dec/mpeg2dec_0.4.1.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG[x11] = "--with-x,--without-x,virtual/libx11 libxext libxv libice libsm"


### PR DESCRIPTION
This recipe can be removed safely. With upstream
meta-altera, tried to build it. But that didn't
showed up any warning.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>