### PR TITLE
Revert "netmap-modules: work around python 3 issue with bb.utils.vercomp

### DIFF
--- a/meta-mentor-staging/networking-layer/recipes-kernel/netmap/netmap-modules_%.bbappend
+++ b/meta-mentor-staging/networking-layer/recipes-kernel/netmap/netmap-modules_%.bbappend
@@ -1,5 +1,0 @@
-# Add fallback to avoid breakage when passing None into bb.utils.vercmp_string
-python () {
-    if not d.getVar('KERNEL_VERSION', True):
-        d.setVar('KERNEL_VERSION', '0.0')
-}


### PR DESCRIPTION

This reverts commit b1e6474ad959ba343f27194a37b7b0252f803092.

The problem has been addressed upstream in meta-oe with the following commit
https://github.com/openembedded/meta-openembedded/commit/80cf5e0ee961436fbcb2fa2c03cb709f79fa9e3c

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>