### PR TITLE
sdk_auto_relocate.bbclass: fix 'sed' command

### DIFF
--- a/meta-mentor-staging/classes/sdk_auto_relocate.bbclass
+++ b/meta-mentor-staging/classes/sdk_auto_relocate.bbclass
@@ -18,7 +18,7 @@ sdkpath_to_bindir = "${@os.path.relpath('${SDKPATHNATIVE}${bindir_nativesdk}', '
 
 toolchain_env_script_reloc_fragment () {
     mv "$script" "$script.fragment"
-    sed -ie "s#${SDKPATH}#\$scriptdir#g" "$script.fragment" 
+    sed -i -e "s#${SDKPATH}#\$scriptdir#g" "$script.fragment" 
     cat >"$script" <<END
 if [ -z "\$SDK_RELOCATING" ]; then
     if [ -n "\$BASH_SOURCE" ] || [ -n "\$ZSH_NAME" ]; then


### PR DESCRIPTION
The -i (inline) and -e (expression) options of sed command cannot be
combined. Passing them as -ie creates a backup of the original file with
'e' appended to the file name.

JIRA: http://jira.alm.mentorg.com:8080/browse/SB-7175

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>