### PR TITLE
user_features: fix non-deterministic ordering

### DIFF
--- a/meta-mel/classes/user_features.bbclass
+++ b/meta-mel/classes/user_features.bbclass
@@ -34,12 +34,12 @@ python process_user_features () {
             defvalue = set((d.getVar(defvar, True) or '').split())
             to_add_here = set(a for a in to_add if a in defvalue)
             to_add -= to_add_here
-            d.appendVar(var, ' ' + ' '.join(to_add_here))
+            d.appendVar(var, ' ' + ' '.join(sorted(to_add_here)))
 
-        d.setVar(var + '_remove', ' '.join(to_remove))
+        d.setVar(var + '_remove', ' '.join(sorted(to_remove)))
 
     if to_add:
-        d.appendVar('DISTRO_FEATURES', ' ' + ' '.join(to_add))
+        d.appendVar('DISTRO_FEATURES', ' ' + ' '.join(sorted(to_add)))
 }
 process_user_features[eventmask] = "bb.event.ConfigParsed"
 addhandler process_user_features


### PR DESCRIPTION
Currently, the items used in _append/_prepend/_remove are not
deterministically ordered, as they're using sets and don't sort them before
setting the variables. Correct this by sorting the sets, which avoids
unnecessary config file reparsing due to ordering changes.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>