### PR TITLE
x264: This change can be removed safely

### DIFF
--- a/meta-mentor-staging/recipes-multimedia/x264/x264_git.bbappend
+++ b/meta-mentor-staging/recipes-multimedia/x264/x264_git.bbappend
@@ -1,2 +1,0 @@
-INSANE_SKIP_${PN}_append = " textrel"
-


### PR DESCRIPTION
This change got merged upstream. Hence we can
safely remove this change from the layer.

Upstream commit: http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=aa7f7b63485b8c4d33491b9cd467fc4487a281c7

JIRA: SB-8059

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>