### PR TITLE
Revert "pasplash: Remove psplash from the layer"

### DIFF
--- a/meta-mentor-staging/recipes-core/psplash/files/psplash-quit.service
+++ b/meta-mentor-staging/recipes-core/psplash/files/psplash-quit.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Terminate Psplash Boot Screen
+After=psplash-start.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/psplash-write QUIT
+TimeoutSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mentor-staging/recipes-core/psplash/files/psplash-start.service
+++ b/meta-mentor-staging/recipes-core/psplash/files/psplash-start.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Starts Psplash Boot screen
+Wants=systemd-vconsole-setup.service
+After=systemd-vconsole-setup.service systemd-udev-trigger.service systemd-udevd.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/bin/psplash
+
+[Install]
+WantedBy=sysinit.target

--- a/meta-mentor-staging/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-mentor-staging/recipes-core/psplash/psplash_git.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://psplash-quit.service \
+	file://psplash-start.service \
+	"
+inherit systemd
+SYSTEMD_SERVICE_${PN} = "psplash-start.service psplash-quit.service"
+
+do_install_append() {
+	install -d ${D}${systemd_unitdir}/system/
+	install -m 0644 ${WORKDIR}/psplash-quit.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/psplash-start.service ${D}${systemd_unitdir}/system
+}


### PR DESCRIPTION
The MEL distro configuration (mel.conf) allows specifying
the SPLASH variable to select between different packages
that provide the mechanism for displaying a splash. psplash
is one of these packages so we shouldn't remove this.

This reverts commit 413cbf8.

Signed-off-by: Awais Belal <awais_belal@mentor.com>