### PR TITLE
Revert "perf: Remove this change safely"

### DIFF
--- a/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
+++ b/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
@@ -1,0 +1,10 @@
+EXTRA_OEMAKE += "'LD=${LD}'"
+
+do_configure_prepend () {
+    for makefile in "${S}/tools/perf/Makefile.perf" \
+                    "${S}/tools/lib/api/Makefile"; do
+        if [ -e "$makefile" ]; then
+            sed -i 's,LD = $(CROSS_COMPILE)ld,#LD,' "$makefile"
+        fi
+    done
+}


### PR DESCRIPTION
We need to revert this patch. The local builds
for minnow max is still failing. There is an
upstream patch posted:
http://lists.openembedded.org/pipermail/openembedded-core/2016-October/127281.html
Once this get merged, we can safely remove our
changes for perf.

This reverts commit 31049561fdca150ece2e18856a94f05e8725b3fc.