### PR TITLE
psplash: add service to launch splash on reboot, halt and shutdown

### DIFF
--- a/meta-mel/recipes-core/psplash/mel/psplash-final.service
+++ b/meta-mel/recipes-core/psplash/mel/psplash-final.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Show Psplash Final Screen
+After=getty@tty1.service display-manager.service psplash-start.service
+Before=systemd-reboot.service systemd-halt.service systemd-poweroff.service
+DefaultDependencies=no
+
+[Service]
+Environment=TMPDIR=/run
+ExecStart=/usr/bin/psplash
+
+[Install]
+WantedBy=reboot.target halt.target poweroff.target

--- a/meta-mel/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-mel/recipes-core/psplash/psplash_git.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}:"
 SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '\
                    file://psplash-quit.service \
                    file://psplash-start.service \
+                   file://psplash-final.service \
                    file://0001-psplash-disable-progress-bar-for-systemd.patch \
                    ', '', d)}"
 
@@ -10,7 +11,7 @@ SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '\
 SRCREV = "5b3c1cc28f5abdc2c33830150b48b278cc4f7bca"
 
 inherit systemd
-SYSTEMD_SERVICE_${PN} = "psplash-start.service psplash-quit.service"
+SYSTEMD_SERVICE_${PN} = "psplash-start.service psplash-quit.service psplash-final.service"
 SYSTEMD_AUTO_ENABLE ?= "enable"
 
 do_install_append() {
@@ -18,5 +19,6 @@ do_install_append() {
                 install -d ${D}${systemd_unitdir}/system/
                 install -m 0644 ${WORKDIR}/psplash-quit.service ${D}${systemd_unitdir}/system
                 install -m 0644 ${WORKDIR}/psplash-start.service ${D}${systemd_unitdir}/system
+                install -m 0644 ${WORKDIR}/psplash-final.service ${D}${systemd_unitdir}/system
         fi
 }


### PR DESCRIPTION
This adds the ability to launch the splash screen again
when the system is going to reboot, halt or shutdown
state.

Signed-off-by: Awais Belal <awais_belal@mentor.com>