### PR TITLE
iperf: Upgrade to iperf3

### DIFF
--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} += "\
     bonnie++ \
     lmbench \
     iozone3 \
-    iperf \
+    iperf3 \
     dbench \
     tbench \
     tiobench \


### PR DESCRIPTION
The older, obsolete iperf v2 fails to build with GCCv6.  Upgrade
to v3 to resolve this build failure.

Signed-off-by: Drew Moseley <drew_moseley@mentor.com>