### PR TITLE
win_sdk_cull.bbclass: Workaround invalid filenames

### DIFF
--- a/meta-mentor-staging/classes/win_sdk_cull.bbclass
+++ b/meta-mentor-staging/classes/win_sdk_cull.bbclass
@@ -10,7 +10,7 @@ cull_win_files () {
             bbnote "Keeping first case duplicate '$(grep -xi "$case_dupe" cull.filelist | sed -n '1p')'"
             grep -xi "$case_dupe" cull.filelist | sed '1d' | while read actual; do
                 bbwarn "Removing case duplicate '${actual#.}' for windows SDKMACHINE"
-                rm -r "$actual"
+                rm -rf "$actual"
             done
         done
 


### PR DESCRIPTION
Some files are populated by find command that do not actually exist.
The issue is in case (upper/lower). Though manually running the command
does not reproduce this. No idea why this is happening, but this workaround
seems harmless to me. Submitting this PR for comments.

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>