### PR TITLE
mel.conf: switch to psplash from plymouth

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -36,7 +36,7 @@ CMD_SERIAL_CONSOLE ?= "${@','.join(reversed('${SERIAL_CONSOLE}'.split()))}"
 APPEND_KGDBOC = "kgdbwait kgdboc=${CMD_SERIAL_CONSOLE}"
 
 # Splash screen
-SPLASH ?= "plymouth"
+SPLASH ?= "psplash"
 PLYMOUTH_THEME ?= "mel"
 PLYMOUTH_SHOWDELAY ?= "0"
 DISTRO_EXTRA_RRECOMMENDS += "${@'plymouth-mel' if '${SPLASH}' == 'plymouth' else ''}"


### PR DESCRIPTION
There is a new splash image introduced in psplash along with
some cosmetic changes to reflect proper copyright information.

To revert back to plymouth, set the following:
SPLASH ?= "plymouth"

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>