### PR TITLE
local.conf.sample: drop the SDKMACHINE default of i686

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -147,14 +147,12 @@ include conf/include/drop-toolchain-from-sdk.inc
 
 # SDK/ADT target architecture
 #
-# CodeBench is 32-bit at this time, so we need to set this to ensure the ADE
-# is configured correctly for that target by default. Set to one of the
-# mingw32 SDKMACHINEs to target Windows rather than Linux. Warning: if you
-# choose to add packages to TOOLCHAIN_HOST_TASK and target Windows, then you
-# must add the meta-mingw layer to your configuration.
+# Set to one of the mingw32 SDKMACHINEs to target Windows rather than Linux.
+# Warning: if you choose to add packages to TOOLCHAIN_HOST_TASK and target
+# Windows, then you must add the meta-mingw layer to your configuration.
 #
 # Valid values: i686, x86_64, i686-mingw32, x86_64-mingw32
-SDKMACHINE ?= "i686"
+#SDKMACHINE ?= "x86_64"
 
 # Uncomment to make populate_sdk write a tar file rather than a .sh installer
 #SDK_PACKAGING_FUNC = ""


### PR DESCRIPTION
We're using 64-bit toolchains in MEL now.

JIRA: SB-8249