### PR TITLE
psplash-*.service: adjust TMPDIR

### DIFF
--- a/meta-mel/recipes-core/psplash/mel/psplash-quit.service
+++ b/meta-mel/recipes-core/psplash/mel/psplash-quit.service
@@ -3,9 +3,9 @@ Description=Terminate Psplash Boot Screen
 After=psplash-start.service
 
 [Service]
+Environment=TMPDIR=/run
 Type=oneshot
 ExecStart=/usr/bin/psplash-write QUIT
-TimeoutSec=20
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-mel/recipes-core/psplash/mel/psplash-start.service
+++ b/meta-mel/recipes-core/psplash/mel/psplash-start.service
@@ -5,6 +5,7 @@ After=systemd-vconsole-setup.service
 DefaultDependencies=no
 
 [Service]
+Environment=TMPDIR=/run
 ExecStart=/usr/bin/psplash
 
 [Install]


### PR DESCRIPTION
The psplash application checks for the TMPDIR environment
variable when starting and picks up /tmp as its temp dir
if this variable is not set. The /tmp gets mounted
pretty late in the boot process and on some faster booting
systems a failure can be seen where psplash-quit fails to
communicate with psplash-start because of a failure while
creating the communication pipe under this TMPDIR.
We now make use of the /run dir as the TMPDIR which is
available quite early in the boot process and avoids such
scenarios.
Also cleanup the psplash-quit service to drop the TimeoutSec
setting which is not applicable when the service is of type
oneshot.

Signed-off-by: Awais Belal <awais_belal@mentor.com>