### PR TITLE
Toaster script update to populate layers and recipes

### DIFF
--- a/scripts/list-recipes
+++ b/scripts/list-recipes
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+list_layers() {
+    find . -mindepth 3 -maxdepth 4 -wholename \*/conf/layer.conf |
+        sed 's,^\./,,; s,/conf/layer\.conf$,,'
+}
+
+list_recipes() {
+    find "$1" -iname \*.bb
+}
+
+list_layers | while read -r layer; do
+    if ! grep -qFx "$layer/" "$1"; then
+        echo "$layer/"
+        list_recipes "$layer"
+    fi
+done >>"$1"

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -371,5 +371,10 @@ if [ $toasterconfig -eq 1 ]; then
        cmdline_string="$cmdline_string $i"
     done
     CMD_LINE="$cmdline_string"
+    cd "${MELDIR}"
+    if [ ! -e "${BUILDDIR}/conf/recipes-list.txt" ] && [ -e "${MACHINE}/recipes-list.txt" ]; then
+        cp -f "${MACHINE}/recipes-list.txt" "${BUILDDIR}/conf/recipes-list.txt"
+    fi
+    ${MELDIR}/meta-mentor/scripts/list-recipes "$BUILDDIR/conf/recipes-list.txt"
     $layerdir/scripts/toaster_configuration "$BUILDDIR" "$MELDIR" "$BITBAKEDIR" "$CMD_LINE"
 fi

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -346,5 +346,30 @@ if [ -e $BUILDDIR/conf/local.conf ]; then
 fi
 
 if [ $toasterconfig -eq 1 ]; then
-    $layerdir/scripts/toaster_configuration "$BUILDDIR" "$MELDIR" "$BITBAKEDIR"
+    machine=$(echo "$@" | awk -F" " {'print $NF'})
+    cmdline_string="$MELDIR/meta-mentor/setup-environment "
+    check_layer_option=0
+    for i in "$@"; do
+       if [ "$i" = "-t" ]; then
+          continue
+       fi
+       if [ "$i" = "-l" ]; then
+          check_layer_option=1
+          cmdline_string="$cmdline_string $i"
+          continue
+       fi
+       if [ $check_layer_option -eq 1 ]; then
+            check_layer_option=0
+            i="\"$i\""
+            cmdline_string="$cmdline_string $i"
+            continue
+       fi
+       if [ "$i" = "$machine" ]; then
+           cmdline_string="$cmdline_string -b \"%BUILDDIR%\" $machine"
+           continue
+       fi
+       cmdline_string="$cmdline_string $i"
+    done
+    CMD_LINE="$cmdline_string"
+    $layerdir/scripts/toaster_configuration "$BUILDDIR" "$MELDIR" "$BITBAKEDIR" "$CMD_LINE"
 fi

--- a/scripts/toaster-layers-recipes-config.py
+++ b/scripts/toaster-layers-recipes-config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+from collections import OrderedDict
+
+bblayers, builddir, meldir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+bblayers = bblayers.split(",")
+
+totalLayers = bblayers
+
+layer_and_recipes = OrderedDict()
+
+recipeListFile = builddir + "/conf/recipes-list.txt"
+customXML = builddir + "/custom.xml"
+
+layerabsPath = []
+
+toStrip = None
+layer = None
+
+#Populate layer_and_recipes 
+
+with open(recipeListFile, 'r') as f:
+    for line in f:
+        line = line.rstrip("\n")
+        if line.endswith("/"):
+            line = line.rstrip("/")
+            toStrip = line
+            if len(line.split("/")) > 1:
+                layer = line.split("/")[-1]
+            else:
+                layer = line
+            layer_and_recipes[layer] = [line]
+        else:
+            if line.endswith('.bb'):
+                layer_and_recipes[layer].append(line.replace(toStrip + "/", ""))
+
+
+# Now time to populate custom.xml
+
+for layername in layer_and_recipes:
+    if len(layer_and_recipes[layername]) == 1:
+        del layer_and_recipes[layername]
+
+pk = len(bblayers) + 1
+
+fd = open(customXML, 'a')
+
+for layername in layer_and_recipes:
+    if len(layer_and_recipes[layername]) == 0 or layername in bblayers:
+        continue
+    totalLayers.append(layername)
+    fd.write('  <object model="orm.layer" pk="%s">\n' %(str(pk)))
+    fd.write('    <field type="CharField" name="name">%s</field>\n' %(layername))
+    fd.write('    <field type="CharField" name="local_source_dir">%s</field>\n' %( meldir + "/" + layer_and_recipes[layername][0]))
+    fd.write('  </object>\n')
+    fd.write('  <object model="orm.layer_version" pk="%s">\n' %(str(pk)))
+    fd.write('    <field rel="ManyToOneRel" to="orm.layer" name="layer">%s</field>\n' %(str(pk)))
+    fd.write('    <field type="IntegerField" name="layer_source">0</field>\n')
+    fd.write('    <field rel="ManyToOneRel" to="orm.release" name="release">2</field>\n')
+    fd.write('    <field type="CharField" name="dirpath"></field>\n')
+    fd.write('  </object>\n\n')
+    pk += 1
+
+pk = 1
+
+# Populate recipes
+
+for layername in layer_and_recipes:
+    if len(layer_and_recipes[layername]) == 1:
+        continue
+    for recipePath in layer_and_recipes[layername]:
+        if '.bb' not in recipePath:
+            continue
+        fd.write('  <object model="orm.recipe" pk="%s">\n' %(str(pk)))
+        pk += 1
+        recipe = recipePath.split("/")[-1]
+        recipeName = recipe.split("_")[0]
+        recipeVersion = None
+        image = None
+        layerindex = None
+        if '.bb' in recipeName:
+            recipeName = recipeName.rstrip('.bb')
+        if len(recipe.split("_")) > 1:
+            recipeVersion = recipe.split("_")[-1].rstrip('.bb')
+        fd.write('    <field name="name" type="CharField">%s</field>\n' %(recipeName))
+        if recipeVersion is None:
+            fd.write('    <field name="version" type="CharField"></field>\n')
+        else:
+            fd.write('    <field name="version" type="CharField">%s</field>\n' %(recipeVersion))
+        fd.write('    <field rel="ManyToOneRel" name="layer_version" to="orm.layer_version">%s</field>\n' %(str(totalLayers.index(layername)+1)))
+        fd.write('    <field name="file_path" type="FilePathField">%s</field>\n' %(recipePath))
+        if '-image' in recipePath:
+           image = "yes"
+        if image == "yes":
+           fd.write('    <field name="is_image" type="BooleanField">True</field>\n')
+        else:
+           fd.write('    <field name="is_image" type="BooleanField">False</field>\n')
+        fd.write('  </object>\n')
+
+fd.close()

--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -11,7 +11,7 @@ echo "Creating toaster configuration"
 BUILDDIR="$1"
 MELDIR="$2"
 BITBAKEDIR="$3"
-
+CMD_LINE="$4"
 
 BBLAYERS=
 configured_layers () {
@@ -21,7 +21,7 @@ configured_layers () {
 }
 
 create_toaster_configuration() {
-DISTRO=$(grep "DISTRO =" "$BUILDDIR/conf/local.conf"  | awk {'print $3'} | sed -e s:\'::g)
+DISTRO=$(grep "DISTRO =" "$BUILDDIR/conf/local.conf"  | awk {'print $3'} | sed -e s:\'::g | head -n 1)
 MACHINE=$(grep -i "MACHINE ??=" "$BUILDDIR/conf/local.conf" | awk {'print $3'} | sed -e s:\"::g)
 EXTERNAL_TOOLCHAIN=$(grep -i "^EXTERNAL_TOOLCHAIN" "$BUILDDIR/conf/local.conf" | awk {'print $3'})
 
@@ -32,6 +32,16 @@ fi
 cat <<EOF > "$BUILDDIR"/custom.xml
 <?xml version="1.0" encoding="utf-8"?>
 <django-objects version="1.0">
+
+  <!-- Reset to MEL -->
+
+  <object model="orm.release" pk="2">
+    <field type="CharField" name="name">local</field>
+    <field type="CharField" name="description">Mentor Embedded Linux</field>
+    <field rel="ManyToOneRel" to="orm.bitbakeversion" name="bitbake_version">2</field>
+    <field type="CharField" name="branch_name">HEAD</field>
+    <field type="TextField" name="helptext">Toaster will run your builds with the version of the Yocto Project you have cloned or downloaded to your computer.</field>
+  </object>
 
   <!-- Default project settings -->
   <object model="orm.toastersetting" pk="1">
@@ -69,6 +79,10 @@ cat <<EOF > "$BUILDDIR"/custom.xml
   <object model="orm.toastersetting" pk="9">
     <field type="CharField" name="name">DEFCONF_DL_DIR</field>
     <field type="CharField" name="value">${BUILDDIR}/../downloads</field>
+  </object>
+  <object model="orm.toastersetting" pk="10">
+    <field type="CharField" name="name">CUSTOM_BUILD_INIT_SCRIPT</field>
+    <field type="CharField" name="value">${CMD_LINE}</field>
   </object>
 
 EOF
@@ -128,6 +142,7 @@ LAYER_PATHS=$(configured_layers | while read -r layer; do
 done)
 LAYER_PATHS=$(echo "$LAYER_PATHS" | sed -n '$p' | sed 's:,: :g'| sed 's:"::g')
 
+collectLayers="meta"
 pk=1
 # Openembedded-core is poky's meta layer.
 layer=$(dirname "$BITBAKEDIR")
@@ -153,6 +168,7 @@ for layer in $(echo "$LAYER_PATHS"); do
    if [ "$layername" = "meta" ]; then
         continue
    fi
+   collectLayers="$collectLayers,$layername"
    dirpath=$(basename "$layer")
    cd $layer
    pk=$((pk+1))
@@ -171,6 +187,10 @@ for layer in $(echo "$LAYER_PATHS"); do
 EOF
 cd - > /dev/null 2>&1
 done
+
+# Time to grab rest of the layers in MELDIR
+"$MELDIR"/meta-mentor/scripts/toaster-layers-recipes-config.py "$collectLayers" "$BUILDDIR" "$MELDIR"
+
 
 cat <<EOF >> "$BUILDDIR"/custom.xml
 </django-objects>


### PR DESCRIPTION
This patchset has 2 commits.
First commit modifies 2 files:
a) setup-mel-builddir
b) toaster_configuration
and creates a new file toaster-layer-recipes-config.py

The change made here is to address the following:
1) Populate toaster db with the recipes and layers
2) Cosmetic change to rename the release name from
   "Local Yocto Project" to "Mentor Embedded Linux"

To populate the toaster db the data is read from:
  BUILDDIR/conf/recipes-list.txt

Second commit has changes for generating recipes-list.txt.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>