### PR TITLE
pre-setup.t4240rdb-64b: move to meta-mentor-bsp

### DIFF
--- a/pre-setup.t4240rdb-64b
+++ b/pre-setup.t4240rdb-64b
@@ -1,1 +1,0 @@
-OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"


### PR DESCRIPTION
Remove pre-setup.t4240rdb-64b from meta-mentor.

Move to meta-mentor-bsp/t4240rdb-64b once meta-fsl-networking has been
updated for this BSP.

JIRA: SB-8266

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>