### PR TITLE
ls1021atwr: move pre-setup changes to bsp layer

### DIFF
--- a/pre-setup.ls1021atwr
+++ b/pre-setup.ls1021atwr
@@ -1,1 +1,0 @@
-OPTIONALLAYERS="$OPTIONALLAYERS fsl-networking"


### PR DESCRIPTION
JIRA: SB-8266

This belongs to BSP layer and should not reside here, add it to
internal bsp layer dependency of ls1021atwr.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>