### PR TITLE
toaster_configuration: Update toaster-setup-environment to facilitate…

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -220,8 +220,20 @@ if [ -d "${MELDIR}/downloads" ]; then
 fi
 
    cat <<EOF > "$BUILDDIR"/toaster-setup-environment
-. $BUILDDIR/venv/bin/activate
-. $BITBAKEDIR/bin/toaster start
+if [ "\$#" -ne 1 ]; then
+    echo >&2 "Usage: . ./toaster-setup-environment {start|stop}"
+else
+  if [ "\$1" == "start" ]; then
+    . $BUILDDIR/venv/bin/activate
+    . $BITBAKEDIR/bin/toaster start
+  elif [ "\$1" == "stop" ]; then
+    . $BITBAKEDIR/bin/toaster stop
+    deactivate
+  else
+     echo >&2 "Usage: . ./toaster-setup-environment {start|stop}"
+  fi
+fi
+
 EOF
 }
 


### PR DESCRIPTION
… start and stop

Update the toaster-setup-environment script generated, to provide
start and stop functionality. User can now run the toaster-setup-environment
script like:
. ./toaster-setup-environment start
and "stop" argument can be passed in the same way.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>