### PR TITLE
Revert "local.conf.append.mel-dra7xx-evm: ensure distro features have…

### DIFF
--- a/meta-mel/conf/local.conf.append.mel-dra7xx-evm
+++ b/meta-mel/conf/local.conf.append.mel-dra7xx-evm
@@ -1,4 +1,0 @@
-# For DRA7xx MEL only has Wayland, no X11. 
-
-USER_FEATURES += "~x11"
-USER_FEATURES += "wayland"


### PR DESCRIPTION
… wayland instead of x11"

JIRA-ID: SB-8291

This reverts commit a8e19772e232e3153b492bd5661542dd969f38c5.

Cleanup mel-dra7xx-evm related bits.

Signed-off-by: Shrikant Bobade <shrikant_bobade@mentor.com>