### PR TITLE
toaster_configuration: Enable auto launch of browser

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -227,6 +227,7 @@ else
   if [ "\$1" == "start" ]; then
     . $BUILDDIR/venv/bin/activate
     . $BITBAKEDIR/bin/toaster start
+    xdg-open "http://localhost:8000"
   elif [ "\$1" == "stop" ]; then
     . $BITBAKEDIR/bin/toaster stop
     deactivate


### PR DESCRIPTION
Once the toaster-setup-environment script is successfully
started, user should be able to see the browser opened
at the machine where toaster's setup script is sourced.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>