### PR TITLE
toaster_configuration: Use MGLS_LICENSE_FILE from env

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -24,7 +24,6 @@ create_toaster_configuration() {
 DISTRO=$(grep "DISTRO =" "$BUILDDIR/conf/local.conf"  | awk {'print $3'} | sed -e s:\'::g | head -n 1)
 MACHINE=$(grep -i "MACHINE ??=" "$BUILDDIR/conf/local.conf" | awk {'print $3'} | sed -e s:\"::g)
 EXTERNAL_TOOLCHAIN=$(grep -i "^EXTERNAL_TOOLCHAIN" "$BUILDDIR/conf/local.conf" | awk {'print $3'})
-MGLS_LICENSE_FILE=$(env | grep "MGLS_LICENSE_FILE=" | sed -e 's:^.*=::' | sed -e 's:\:$::')
 
 if [ -n "$EXTERNAL_TOOLCHAIN" ]; then
    EXTERNAL_TOOLCHAIN=$(eval echo "$EXTERNAL_TOOLCHAIN" &>/dev/null)


### PR DESCRIPTION
Remove all complexities done using sed and grep.
Just use MGLS_LICENSE_FILE from the env directly.

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>