### PR TITLE
update_gio_module_cache: fix postinst owner adjustment

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -214,6 +214,11 @@ MACHINE_HWCODECS = ""
 
 # Work around missing vardep bug in bitbake
 sstate_stage_all[vardeps] += "sstate_stage_dirs"
+
+# Assemble a recipe-local postinst-intecepts directory by gathering intercepts
+# from BBPATH. This lets layers override intercepts. This functionality
+# belongs upstream.
+IMAGE_CLASSES += "bbpath-intercepts"
 ## }}}1
 ## SDK & Application Development Environment {{{1
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not

--- a/meta-mentor-staging/classes/bbpath-intercepts.bbclass
+++ b/meta-mentor-staging/classes/bbpath-intercepts.bbclass
@@ -1,0 +1,25 @@
+# Assemble a recipe-local postinst-intecepts directory by gathering intercepts
+# from BBPATH. This lets layers override intercepts.
+POSTINST_INTERCEPTS_DIR = "${WORKDIR}/bbpath-intercepts"
+POSTINST_INTERCEPTS_PATHS = "${@':'.join('%s/postinst-intercepts' % p for p in '${BBPATH}'.split(':'))}:${COREBASE}/scripts/postinst-intercepts"
+POSTINST_INTERCEPTS = "${@find_intercepts(d)}"
+
+def find_intercepts(d):
+    intercepts = {}
+    for p in d.getVar('POSTINST_INTERCEPTS_PATHS', True).split(':'):
+        if os.path.isdir(p):
+            for s in os.listdir(p):
+                if s not in intercepts:
+                    intercepts[s] = os.path.join(p, s)
+    return ' '.join(intercepts.values())
+
+python assemble_intercepts () {
+    intercepts = d.getVar('POSTINST_INTERCEPTS', True).split()
+    bb.debug(1, 'Collected intercepts:\n%s' % ('  %s\n' % i for i in intercepts))
+    intercepts_dir = d.getVar('POSTINST_INTERCEPTS_DIR', True)
+    bb.utils.mkdirhier(intercepts_dir)
+    bb.process.run(['cp'] + intercepts + [intercepts_dir])
+}
+do_rootfs[prefuncs] += "assemble_intercepts"
+do_rootfs[cleandirs] += "${POSTINST_INTERCEPTS_DIR}"
+do_rootfs[file-checksums] += "${@' '.join('%s:True' % f for f in '${POSTINST_INTERCEPTS}'.split())}"

--- a/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D${libdir}:$D${base_libdir} \
+        $D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
+
+# If no modules are installed, no cache file will be written
+if [ -e $D${libdir}/gio/modules/giomodule.cache ]; then
+    chown root:root $D${libdir}/gio/modules/giomodule.cache
+fi
+


### PR DESCRIPTION
We need to correct the ownership of the generated cache file, but only if a
cache file was generated (which is not the case when the modules dir is
empty).

JIRA: SB-8312, SB-8314