### PR TITLE
bbpath-intercepts.bbclass: set cleandirs on assemble_intercepts

### DIFF
--- a/meta-mentor-staging/classes/bbpath-intercepts.bbclass
+++ b/meta-mentor-staging/classes/bbpath-intercepts.bbclass
@@ -20,6 +20,7 @@ python assemble_intercepts () {
     bb.utils.mkdirhier(intercepts_dir)
     bb.process.run(['cp'] + intercepts + [intercepts_dir])
 }
+assemble_intercepts[cleandirs] += "${POSTINST_INTERCEPTS_DIR}"
+
 do_rootfs[prefuncs] += "assemble_intercepts"
-do_rootfs[cleandirs] += "${POSTINST_INTERCEPTS_DIR}"
 do_rootfs[file-checksums] += "${@' '.join('%s:True' % f for f in '${POSTINST_INTERCEPTS}'.split())}"


### PR DESCRIPTION
Having the cleandirs on do_rootfs resulted in the path being cleaned after
assemble_intercepts was run, and an empty intercepts dir being passed to the
rootfs construction, so no intercepts were run at all. Bitbake handles
cleandirs/dirs on a per-function, not per-task, basis, so it belongs on the
prefunc.

Thanks to Abdur Rehman for investigating this and identifying the root cause.

JIRA: SB-8314