### PR TITLE
gdbserver-gplv3: avoid reimplementing license whitelisting

### DIFF
--- a/meta-mel/conf/distro/include/gdbserver-gplv3.inc
+++ b/meta-mel/conf/distro/include/gdbserver-gplv3.inc
@@ -1,21 +1,25 @@
-# If ALLOW_GPLV3_GDBSERVER is enabled, gdbserver-external will become
-# buildable even when GPLv3 is in INCOMPATIBLE_LICENSE, to make it available
-# for debugging.
-#
-# FIXME: obey the gdb version from the external toolchain, if possible
-
+# If ALLOW_GPLV3_GDBSERVER is set, whitelist {L,}GPLv3 for the gdb recipes
 ALLOW_GPLV3_GDBSERVER ?= ""
+WHITELIST_GPL-3.0 += "${@'gdbserver-external gdb' if '${ALLOW_GPLV3_GDBSERVER}' else ''}"
+WHITELIST_LGPL-3.0 += "${@'gdb' if '${ALLOW_GPLV3_GDBSERVER}' else ''}"
 
-python adjust_packagegroup_gdbserver () {
-    if 'GPLv3' in (d.getVar('INCOMPATIBLE_LICENSE', True) or ''):
-        if not d.getVar('ALLOW_GPLV3_GDBSERVER', True):
-            # Remove installation of gdbserver from codebench-debug
-            pkggroup = d.getVar('FEATURE_PACKAGES_codebench-debug', True).split()
-            pkggroup.remove('gdbserver')
-            d.setVar('FEATURE_PACKAGES_codebench-debug', ' '.join(pkggroup))
-        else:
-            # Allow gdbserver-external to build despite its license
-            d.setVar('INCOMPATIBLE_LICENSE_pn-gdbserver-external', '')
-}
-adjust_packagegroup_gdbserver[eventmask] = "bb.event.ConfigParsed"
-addhandler adjust_packagegroup_gdbserver
+# If GPL-3.0 is in INCOMPATIBLE_LICENSE, and gdbserver/gdb isn't whitelisted,
+# then remove gdbserver from the codebench-debug image feature, otherwise the
+# build will fail.
+FEATURE_PACKAGES_codebench-debug_remove = "${@'gdbserver' if gdbserver_is_incompatible(d) else ''}"
+
+def gdbserver_is_incompatible(d):
+    return incompatible_license_contains('GPL-3.0', not gdbserver_is_whitelisted(d), False, d)
+
+def gdbserver_is_whitelisted(d):
+    gdbserver_recipes = ['gdbserver-external', 'gdb']
+    gplv3_lics = ['GPL-3.0']
+    for flag, value in d.getVarFlags('SPDXLICENSEMAP').items():
+        if value == 'GPL-3.0':
+            gplv3_lics.append(flag)
+
+    for lic in gplv3_lics:
+        wval = (d.getVar('WHITELIST_' + lic, True) or '').split()
+        if any(i in wval for i in gdbserver_recipes):
+            return True
+    return False


### PR DESCRIPTION
oe-core has built in support for license whitelisting, so make use of it. We still
need our bits which remove gdbserver from the codebench-debug feature when
it's not buildable, however.

As a consequence of this, we now get messages from bitbake reminding us that it's being included despite the incompatible license:

    NOTE: INCLUDING gdb as buildable despite INCOMPATIBLE_LICENSE because it has been whitelisted
    NOTE: INCLUDING gdbserver-external as buildable despite INCOMPATIBLE_LICENSE because it has been whitelisted

I think this behavioral change is an improvement, since it keeps the user
aware of the exception to the rule.