### PR TITLE
96boards-tools: allow udevd to process device creation events on imx6…

### DIFF
--- a/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.7.bb
+++ b/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.7.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=80
 
 SRCREV = "193f355823d9dc38f370759153ac950a2833b0e2"
 SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https"
+SRC_URI_append_imx6ulevk-mel = " file://0001-resize-helper.service-allow-udevd-to-process-device-.patch"
 
 S = "${WORKDIR}/git"
 

--- a/meta-mel-support/recipes-bsp/96boards-tools/files/0001-resize-helper.service-allow-udevd-to-process-device-.patch
+++ b/meta-mel-support/recipes-bsp/96boards-tools/files/0001-resize-helper.service-allow-udevd-to-process-device-.patch
@@ -1,0 +1,26 @@
+From 0a3f648ddb8d5301bb5566889225926ec4bb58ac Mon Sep 17 00:00:00 2001
+From: Fahad Arslan <Fahad_Arslan@mentor.com>
+Date: Fri, 2 Dec 2016 20:48:36 +0500
+Subject: [PATCH 1/1] resize-helper.service: allow udevd to process device
+ creation events
+
+Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>
+---
+ resize-helper.service | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/resize-helper.service b/resize-helper.service
+index c1354a6..d62ecfe 100644
+--- a/resize-helper.service
++++ b/resize-helper.service
+@@ -4,6 +4,7 @@ After=systemd-remount-fs.service
+ 
+ [Service]
+ Type=oneshot
++ExecStartPre=-/bin/udevadm settle
+ ExecStart=-/usr/sbin/resize-helper
+ ExecStartPost=/bin/systemctl disable resize-helper.service
+ 
+-- 
+2.8.1
+


### PR DESCRIPTION
…ulevk-mel

resize-helper.service executes /usr/sbin/resize-helper script while udevd
is still processing events. As a result parameters like ID_PART_ENTRY_NUMBER
and ID_PART_TABLE_TYPE are not available for root device and script fails to
funciton properly. Running udevadm settle allows udevd to process device
creation events so that they are available before they are used.

Jira ID: SB-8359

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>