### PR TITLE
Fix issues with the non-GPLv3 builds

### DIFF
--- a/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
+++ b/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
@@ -44,4 +44,10 @@ do_install_append () {
 }
 
 # This version doesn't provide these
-USE_ALTERNATIVES_FOR := "${@oe_filter_out('ld.bfd|elfedit', USE_ALTERNATIVES_FOR, d)}"
+USE_ALTERNATIVES_FOR_remove = "ld.bfd elfedit"
+
+python () {
+    '''This binutils version has no elfedit.'''
+    compilefunc = d.getVar('do_compile', False).replace('chrpath -d ${B}/binutils/elfedit', '')
+    d.setVar('do_compile', compilefunc)
+}

--- a/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
+++ b/meta-mel-support/recipes-devtools/binutils/binutils_2.17.50.0.12.bb
@@ -44,7 +44,7 @@ do_install_append () {
 }
 
 # This version doesn't provide these
-USE_ALTERNATIVES_FOR_remove = "ld.bfd elfedit"
+USE_ALTERNATIVES_FOR_remove = "ld.bfd elfedit ld.gold dwp"
 
 python () {
     '''This binutils version has no elfedit.'''

--- a/meta-mel/classes/incompatible-recipe-check.bbclass
+++ b/meta-mel/classes/incompatible-recipe-check.bbclass
@@ -1,0 +1,16 @@
+def is_incompatible(d, recipes, license='GPL-3.0'):
+    '''Return True if license is incompatible and none of the specified recipes are whitelisted.'''
+    return incompatible_license_contains(license, not any_whitelisted(d, recipes, license), False, d)
+
+def any_whitelisted(d, recipes, license='GPL-3.0'):
+    '''Return True if any of the recipes were whitelisted for the specified license.'''
+    lics = [license]
+    for flag, value in d.getVarFlags('SPDXLICENSEMAP').items():
+        if value == license:
+            lics.append(flag)
+
+    for lic in lics:
+        whitelisted = (d.getVar('WHITELIST_' + lic, True) or '').split()
+        if any(recipe in whitelisted for recipe in recipes):
+            return True
+    return False

--- a/meta-mel/conf/distro/include/gdbserver-gplv3.inc
+++ b/meta-mel/conf/distro/include/gdbserver-gplv3.inc
@@ -1,21 +1,25 @@
-# If ALLOW_GPLV3_GDBSERVER is enabled, gdbserver-external will become
-# buildable even when GPLv3 is in INCOMPATIBLE_LICENSE, to make it available
-# for debugging.
-#
-# FIXME: obey the gdb version from the external toolchain, if possible
-
+# If ALLOW_GPLV3_GDBSERVER is set, whitelist {L,}GPLv3 for the gdb recipes
 ALLOW_GPLV3_GDBSERVER ?= ""
+WHITELIST_GPL-3.0 += "${@'gdbserver-external gdb' if '${ALLOW_GPLV3_GDBSERVER}' else ''}"
+WHITELIST_LGPL-3.0 += "${@'gdb' if '${ALLOW_GPLV3_GDBSERVER}' else ''}"
 
-python adjust_packagegroup_gdbserver () {
-    if 'GPLv3' in (d.getVar('INCOMPATIBLE_LICENSE', True) or ''):
-        if not d.getVar('ALLOW_GPLV3_GDBSERVER', True):
-            # Remove installation of gdbserver from codebench-debug
-            pkggroup = d.getVar('FEATURE_PACKAGES_codebench-debug', True).split()
-            pkggroup.remove('gdbserver')
-            d.setVar('FEATURE_PACKAGES_codebench-debug', ' '.join(pkggroup))
-        else:
-            # Allow gdbserver-external to build despite its license
-            d.setVar('INCOMPATIBLE_LICENSE_pn-gdbserver-external', '')
-}
-adjust_packagegroup_gdbserver[eventmask] = "bb.event.ConfigParsed"
-addhandler adjust_packagegroup_gdbserver
+# If GPL-3.0 is in INCOMPATIBLE_LICENSE, and gdbserver/gdb isn't whitelisted,
+# then remove gdbserver from the codebench-debug image feature, otherwise the
+# build will fail.
+FEATURE_PACKAGES_codebench-debug_remove = "${@'gdbserver' if gdbserver_is_incompatible(d) else ''}"
+
+def gdbserver_is_incompatible(d):
+    return incompatible_license_contains('GPL-3.0', not gdbserver_is_whitelisted(d), False, d)
+
+def gdbserver_is_whitelisted(d):
+    gdbserver_recipes = ['gdbserver-external', 'gdb']
+    gplv3_lics = ['GPL-3.0']
+    for flag, value in d.getVarFlags('SPDXLICENSEMAP').items():
+        if value == 'GPL-3.0':
+            gplv3_lics.append(flag)
+
+    for lic in gplv3_lics:
+        wval = (d.getVar('WHITELIST_' + lic, True) or '').split()
+        if any(i in wval for i in gdbserver_recipes):
+            return True
+    return False

--- a/meta-mel/conf/distro/include/gdbserver-gplv3.inc
+++ b/meta-mel/conf/distro/include/gdbserver-gplv3.inc
@@ -6,20 +6,6 @@ WHITELIST_LGPL-3.0 += "${@'gdb' if '${ALLOW_GPLV3_GDBSERVER}' else ''}"
 # If GPL-3.0 is in INCOMPATIBLE_LICENSE, and gdbserver/gdb isn't whitelisted,
 # then remove gdbserver from the codebench-debug image feature, otherwise the
 # build will fail.
-FEATURE_PACKAGES_codebench-debug_remove = "${@'gdbserver' if gdbserver_is_incompatible(d) else ''}"
+FEATURE_PACKAGES_codebench-debug_remove = "${@'gdbserver' if is_incompatible(d, ['gdbserver-external', 'gdb'], 'GPL-3.0') else ''}"
 
-def gdbserver_is_incompatible(d):
-    return incompatible_license_contains('GPL-3.0', not gdbserver_is_whitelisted(d), False, d)
-
-def gdbserver_is_whitelisted(d):
-    gdbserver_recipes = ['gdbserver-external', 'gdb']
-    gplv3_lics = ['GPL-3.0']
-    for flag, value in d.getVarFlags('SPDXLICENSEMAP').items():
-        if value == 'GPL-3.0':
-            gplv3_lics.append(flag)
-
-    for lic in gplv3_lics:
-        wval = (d.getVar('WHITELIST_' + lic, True) or '').split()
-        if any(i in wval for i in gdbserver_recipes):
-            return True
-    return False
+INHERIT += "incompatible-recipe-check"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -202,6 +202,9 @@ DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 
 KERNEL_IMAGETYPES_append = " vmlinux"
 ## }}}1
 ## Workarounds & Overrides {{{1
+# We aren't supporting meta-intel's RMC
+BBMASK += "/meta-intel/common/recipes-bsp/systemd-boot/"
+
 # Align the external toolchain with the internal one. This is also needed for
 # Sourcery Analyzer with lttng-ust
 TARGET_LDFLAGS += "-Wl,--build-id=sha1"

--- a/meta-mel/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
+++ b/meta-mel/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
@@ -1,0 +1,3 @@
+inherit incompatible-recipe-check
+
+PROFILE_TOOLS_X_remove = "${@'sysprof' if is_incompatible(d, ['sysprof'], 'GPL-3.0') else ''}"

--- a/meta-mentor-staging/openembedded-layer/recipes-support/lvm2/lvm2_%.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-support/lvm2/lvm2_%.bbappend
@@ -1,0 +1,4 @@
+# thin-provisioning-tools are gplv3. if that's incompatible, we don't want to
+# enable the packageconfig, otherwise the rdepend on it will fail the build
+REMOVE_THIN = "${@incompatible_license_contains('GPL-3.0', 'thin-provisioning-tools', '', d)}"
+PACKAGECONFIG_remove_mel = "${REMOVE_THIN}"


### PR DESCRIPTION
This fixes the issues other than the rootfs resizing, as the old parted as
different commands and syntax, so resize-helper needs to be altered to support
it.