### PR TITLE
python3: fix two multilib issues

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python3/0001-site.py-obey-sys.lib-for-sitepackages.patch
+++ b/meta-mentor-staging/recipes-devtools/python/python3/0001-site.py-obey-sys.lib-for-sitepackages.patch
@@ -1,0 +1,37 @@
+From 3676ed4021e7ceedb2e06c801910b919a0d732c4 Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Mon, 5 Dec 2016 20:47:42 -0700
+Subject: [PATCH] site.py: obey sys.lib for sitepackages
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ Lib/site.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Lib/site.py b/Lib/site.py
+index 3f78ef5..117741d 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -303,12 +303,16 @@ def getsitepackages(prefixes=None):
+         seen.add(prefix)
+ 
+         if os.sep == '/':
+-            sitepackages.append(os.path.join(prefix, "lib",
++            sitepackages.append(os.path.join(prefix, sys.lib,
+                                         "python" + sys.version[:3],
+                                         "site-packages"))
++            if sys.lib != "lib":
++                sitepackages.append(os.path.join(prefix, "lib",
++                                            "python" + sys.version[:3],
++                                            "site-packages"))
+         else:
+             sitepackages.append(prefix)
+-            sitepackages.append(os.path.join(prefix, "lib", "site-packages"))
++            sitepackages.append(os.path.join(prefix, sys.lib, "site-packages"))
+         if sys.platform == "darwin":
+             # for framework builds *only* we add the standard Apple
+             # locations.
+-- 
+2.8.0
+

--- a/meta-mentor-staging/recipes-devtools/python/python3/correct-python3-lib-pathes-for-multilib-support.patch
+++ b/meta-mentor-staging/recipes-devtools/python/python3/correct-python3-lib-pathes-for-multilib-support.patch
@@ -1,0 +1,49 @@
+When enable multilib, it fails to run python3:
+
+| Could not find platform independent libraries <prefix>
+| Could not find platform dependent libraries <exec_prefix>
+| Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
+| Fatal Python error: Py_Initialize: Unable to get the locale encoding
+| ImportError: No module named 'encodings'
+|
+| Current thread 0x00007f62ea5b2700 (most recent call first):
+| Aborted (core dumped)
+
+The root cause is the module search path /usr/lib is wrong for x86-64 when
+multilib is enabled. So replace fixed path string with right macro.
+
+Upstream-Status: Pending
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+diff --git a/Modules/getpath.c b/Modules/getpath.c
+index 18deb60..d22af53 100644
+--- a/Modules/getpath.c
++++ b/Modules/getpath.c
+@@ -494,7 +494,7 @@ calculate_path(void)
+     _pythonpath = Py_DecodeLocale(PYTHONPATH, NULL);
+     _prefix = Py_DecodeLocale(PREFIX, NULL);
+     _exec_prefix = Py_DecodeLocale(EXEC_PREFIX, NULL);
+-    lib_python = Py_DecodeLocale("lib/python" VERSION, NULL);
++    lib_python = Py_DecodeLocale(LIB_PYTHON, NULL);
+ 
+     if (!_pythonpath || !_prefix || !_exec_prefix || !lib_python) {
+         Py_FatalError(
+@@ -683,7 +683,7 @@ calculate_path(void)
+     }
+     else
+         wcsncpy(zip_path, _prefix, MAXPATHLEN);
+-    joinpath(zip_path, L"lib/python00.zip");
++    joinpath(zip_path, LIB L"/python00.zip");
+     bufsz = wcslen(zip_path);   /* Replace "00" with version */
+     zip_path[bufsz - 6] = VERSION[0];
+     zip_path[bufsz - 5] = VERSION[2];
+@@ -695,7 +695,7 @@ calculate_path(void)
+             fprintf(stderr,
+                 "Could not find platform dependent libraries <exec_prefix>\n");
+         wcsncpy(exec_prefix, _exec_prefix, MAXPATHLEN);
+-        joinpath(exec_prefix, L"lib/lib-dynload");
++        joinpath(exec_prefix, LIB L"/lib-dynload");
+     }
+     /* If we found EXEC_PREFIX do *not* reduce it!  (Yet.) */
+ 

--- a/meta-mentor-staging/recipes-devtools/python/python3_3.5.2.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python3_3.5.2.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "\
+    file://correct-python3-lib-pathes-for-multilib-support.patch \
+    file://0001-site.py-obey-sys.lib-for-sitepackages.patch \
+"


### PR DESCRIPTION
- Apply the pending oe-core patch to fix the encodings import
- Adjust site.py to search both sys.lib and 'lib', to align with the behavior
  of the python 2.7 multilib patch and fix the import of non-core modules

Closes #905
JIRA: INTAMDDET-1723