### PR TITLE
iperf: ensure we check for stdbool.h

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-benchmark/iperf/iperf/0001-Ensure-we-check-for-stdbool.h.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-benchmark/iperf/iperf/0001-Ensure-we-check-for-stdbool.h.patch
@@ -1,0 +1,44 @@
+From 5d93e1325e015b0810f813af0060cbcfda77a634 Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Tue, 6 Dec 2016 08:42:42 -0700
+Subject: [PATCH] Ensure we check for stdbool.h
+
+We were conditionally checking for the size of bool based upon
+ac_cv_header_stdbool_h, but weren't actually calling AC_CHECK_HEADERS to make
+sure that variable is set. Explicitly check for stdbool.h with
+AC_CHECK_HEADERS and operate based upon that result.
+
+Also correctly quote the first AC_DEFUN argument, while I'm here, to avoid the
+warning from autoconf.
+
+Upstream-Status: Pending
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ m4/dast.m4 | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/m4/dast.m4 b/m4/dast.m4
+index d2cfdad..a525600 100644
+--- a/m4/dast.m4
++++ b/m4/dast.m4
+@@ -9,13 +9,11 @@ AH_TEMPLATE([bool])
+ AH_TEMPLATE([true])
+ AH_TEMPLATE([false])
+ 
+-AC_DEFUN(DAST_CHECK_BOOL, [
++AC_DEFUN([DAST_CHECK_BOOL], [
+ 
+-if test "$ac_cv_header_stdbool_h" = yes; then
+-  AC_CHECK_SIZEOF(bool,,[#include <stdbool.h>])
+-else
+-    AC_CHECK_SIZEOF(bool)
+-fi
++AC_CHECK_HEADERS([stdbool.h],
++    [AC_CHECK_SIZEOF(bool,,[#include <stdbool.h>])],
++    [AC_CHECK_SIZEOF(bool)], [])
+ 
+ if test "$ac_cv_sizeof_bool" = 0 ; then
+   AC_DEFINE(bool, int)
+-- 
+2.8.0
+

--- a/meta-mentor-staging/openembedded-layer/recipes-benchmark/iperf/iperf_2.0.5.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-benchmark/iperf/iperf_2.0.5.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Ensure-we-check-for-stdbool.h.patch"
+


### PR DESCRIPTION
iperf was conditionally checking for the size of bool based upon
ac_cv_header_stdbool_h, but wasn't actually calling AC_CHECK_HEADERS to make
sure that variable is set. Explicitly check for stdbool.h with
AC_CHECK_HEADERS and operate based upon that result.

Also correctly quote the first AC_DEFUN argument, while I'm here, to avoid the
warning from autoconf.

This issue was causing failures for MEL builds.

JIRA: SB-8356