### PR TITLE
mel: lowercase the SANITY_TESTED_DISTROS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -18,9 +18,9 @@ PACKAGE_CLASSES ?= "package_ipk"
 
 # MEL's supported hosts
 SANITY_TESTED_DISTROS = "\
-    Ubuntu-16.04 \n\
-    Ubuntu-14.04 \n\
-    CentOS-7.* \n \
+    ubuntu-16.04 \n\
+    ubuntu-14.04 \n\
+    centos-7.* \n \
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)


### PR DESCRIPTION
Upstream now lowercases the NATIVELSBSTRING, but not the entries in
SANITY_TESTED_DISTROS, so do so ourselves to avoid untested warnings.