### PR TITLE
mel: inherit cb-mbs-options by default

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -104,6 +104,9 @@ OE_TERMINAL_EXPORTS += "OE_TOPDIR OE_WORKDIR COREBASE"
 # Check PDK license
 INHERIT += "${@'pdk-license' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
 
+# Write cb-mbs-options for CodeBench
+INHERIT += "${@'cb-mbs-options' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+
 ## Distro Features & Recipe Configuration {{{1
 # The user can enable ptest from local.conf, and wayland is not yet supported
 POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest wayland"


### PR DESCRIPTION
Now that it's written for all BSPs, the inherit can be moved here rather than
in the machine.conf.

Depends on https://github.com/MentorEmbedded/mel-meta-mentor-private/pull/83