### PR TITLE
archive-release: Add space while appending runqemu.in in SRC_URI.

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -9,7 +9,7 @@ PACKAGES = ""
 EXCLUDE_FROM_WORLD = "1"
 
 SRC_URI += "${@' '.join(uninative_urls(d)) if 'downloads' in '${RELEASE_ARTIFACTS}'.split() else ''}"
-SRC_URI_append_qemuall = "file://runqemu.in"
+SRC_URI_append_qemuall = " file://runqemu.in"
 
 UNINATIVE_BUILD_ARCHES ?= "x86_64 i686"
 MELDIR ?= "${COREBASE}/.."


### PR DESCRIPTION
* runqemu.in was added to SRC_URI using append and space was not added
  at the beginning. So the URL got corrupted and it did not pick runqemu.in.
  This resulted it failure when do_prepare_release accessed runqemu.in in
  sed command. Got following error

  sed: can't read /var/jenkins/workspace/mel/qemux86-64/build_qemux86-64/tmp
  /work/qemux86_64-mel-linux/archive-release/1.0-r0/runqemu.in: No such file
  or directory

  Added a space while adding runqemu.in to correct SRC_URI so that it get picked.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>