### PR TITLE
mel: fix taskhash mismatch for wic templates

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -54,7 +54,7 @@ UBI_VOLNAME = "rootfs"
 
 # If a wks file exists for this BSP, use it to emit a wic image
 WKS_FULL_PATH ??= ""
-IMAGE_FSTYPES += "${@'wic.bz2 wic.bmap' if os.path.exists('${WKS_FULL_PATH}') else ''}"
+IMAGE_FSTYPES += "${@'wic.bz2 wic.bmap' if '${WKS_FULL_PATH}' else ''}"
 
 # Quadruple the normal. 'du' is not a good way to really see how much
 # space will be needed and fails badly as the fs size grows.


### PR DESCRIPTION
After WKS_FULL_PATH is set to the generated path, but before it's been
written, the os.path.exists() will fail, resulting in a different checksum
during that period, so operate based on WKS_FULL_PATH being set instead.

JIRA: SB-8410