### PR TITLE
recipetool.kernel: align with newappend / oe.recipeutils

### DIFF
--- a/meta-mel/lib/recipetool/kernel.py
+++ b/meta-mel/lib/recipetool/kernel.py
@@ -64,15 +64,14 @@ def _get_recipe_file(cooker, pn):
     return recipefile
 
 
-def _parse_recipe(provide, tinfoil):
+def _parse_recipe(pn, tinfoil):
     import oe.recipeutils
-    recipefile = _get_recipe_file(tinfoil.cooker, provide)
+    recipefile = _get_recipe_file(tinfoil.cooker, pn)
     if not recipefile:
         # Error already logged
         return None
     append_files = tinfoil.cooker.collection.get_file_appends(recipefile)
-    rd = oe.recipeutils.parse_recipe(recipefile, append_files,
-                                     tinfoil.config_data)
+    rd = oe.recipeutils.parse_recipe(tinfoil.cooker, recipefile, append_files)
     return rd
 
 


### PR DESCRIPTION
Without this, we'd see failures like:

    Traceback (most recent call last):
      File ".../poky/scripts/recipetool", line 120, in <module>
        ret = main()
      File ".../poky/scripts/recipetool", line 109, in main
        ret = args.func(args)
      File ".../meta-mentor/meta-mel/lib/recipetool/kernel.py", line 12, in kernel_add_fragments
        rd = _parse_recipe(args.recipe, tinfoil)
      File ".../meta-mentor/meta-mel/lib/recipetool/kernel.py", line 75 in _parse_recipe
        tinfoil.config_data)
      File ".../poky/meta/lib/oe/recipeutils.py", line 59, in parse_recpe
        parser = bb.cache.NoCache(cooker.databuilder)
    AttributeError: 'str' object has no attribute 'databuilder'

JIRA: SB-8415