### PR TITLE
recipetool.kernel: fix kernel_set_configs

### DIFF
--- a/meta-mel/lib/recipetool/kernel.py
+++ b/meta-mel/lib/recipetool/kernel.py
@@ -155,7 +155,7 @@ def _kernel_add_fragments(destlayer, rd, fragments, files=None, extralines=None)
 
 def get_next_fragment_name(src_uri):
     fragpat = re.compile('file://recipetool([0-9]+)\.cfg$')
-    matches = filter(None, [re.match(fragpat, u) for u in src_uri])
+    matches = list(filter(None, [re.match(fragpat, u) for u in src_uri]))
     if matches:
         fragnums = sorted((int(m.group(1)) for m in matches), reverse=True)
         num = fragnums[0] + 1


### PR DESCRIPTION
This was fallout from python3, I believe.

    Traceback (most recent call last):
      File ".../poky/scripts/recipetool", line 120, in <module>
        ret = main()
      File ".../poky/scripts/recipetool", line 109, in main
        ret = args.func(args)
      File ".../meta-mentor/meta-mel/lib/recipetool/kernel.py", line 173, in kernel_set_configs
        args.name = get_next_fragment_name(src_uri)
      File ".../meta-mentor/meta-mel/lib/recipetool/kernel.py", line 160, in get_next_fragment_name
        num = fragnums[0] + 1
    IndexError: list index out of range

Signed-off-by: Christopher Larson <chris_larson@mentor.com>