### PR TITLE
setup-{rh,ubuntu}: drop 32-bit libs

### DIFF
--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -8,7 +8,7 @@
 
 packages="make gcc gcc-c++ patch texi2html diffstat texinfo tetex cvs git
           subversion gawk tar gzip bzip2 redhat-lsb sqlite ncurses-devel \
-          SDL-devel glibc-devel glibc-static glibc-devel.i686 libgcc.i686 \
+          SDL-devel glibc-devel glibc-static \
           chrpath python python34 wget perl-Thread-Queue python-virtualenv"
 
 set -e

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -21,11 +21,6 @@ PKGS="$PKGS libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev"
 # This is needed for Windows ADE
 PKGS="$PKGS zip"
 
-if [ "$(uname -m)" = "x86_64" ]; then
-    sudo dpkg --add-architecture i386
-    PKGS="$PKGS libc6-dev-i386 libncurses5:i386"
-fi
-
 echo "Installing packages required to build Mentor Embedded Linux"
 sudo apt-get update
 sudo apt-get -y install $PKGS


### PR DESCRIPTION
CodeBench toolchains are 64-bit now, so we no longer need this.

JIRA: SB-8429
Signed-off-by: Christopher Larson <chris_larson@mentor.com>