### PR TITLE
toaster_configuration: Fix DL_DIR path and remove EXTERNAL_TOOLCHAIN

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -23,11 +23,6 @@ configured_layers () {
 create_toaster_configuration() {
 DISTRO=$(grep "DISTRO =" "$BUILDDIR/conf/local.conf"  | awk {'print $3'} | sed -e s:\'::g | head -n 1)
 MACHINE=$(grep -i "MACHINE ??=" "$BUILDDIR/conf/local.conf" | awk {'print $3'} | sed -e s:\"::g)
-EXTERNAL_TOOLCHAIN=$(grep -i "^EXTERNAL_TOOLCHAIN" "$BUILDDIR/conf/local.conf" | awk {'print $3'})
-
-if [ -n "$EXTERNAL_TOOLCHAIN" ]; then
-   EXTERNAL_TOOLCHAIN=$(eval echo "$EXTERNAL_TOOLCHAIN" &>/dev/null)
-fi
 
 cat <<EOF > "$BUILDDIR"/custom.xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -61,26 +56,22 @@ cat <<EOF > "$BUILDDIR"/custom.xml
     <field type="CharField" name="value">$DISTRO</field>
   </object>
   <object model="orm.toastersetting" pk="5">
-    <field type="CharField" name="name">DEFCONF_EXTERNAL_TOOLCHAIN</field>
-    <field type="CharField" name="value">$EXTERNAL_TOOLCHAIN</field>
-  </object>
-  <object model="orm.toastersetting" pk="6">
     <field type="CharField" name="name">DEFCONF_MGLS_LICENSE_FILE</field>
     <field type="CharField" name="value">$MGLS_LICENSE_FILE</field>
   </object>
-  <object model="orm.toastersetting" pk="7">
+  <object model="orm.toastersetting" pk="6">
     <field type="CharField" name="name">DEFCONF_ACCEPT_FSL_EULA</field>
     <field type="CharField" name="value"></field>
   </object>
-  <object model="orm.toastersetting" pk="8">
+  <object model="orm.toastersetting" pk="7">
     <field type="CharField" name="name">DEFCONF_SSTATE_DIR</field>
     <field type="CharField" name="value">${BUILDDIR}/../sstate-cache</field>
   </object>
-  <object model="orm.toastersetting" pk="9">
+  <object model="orm.toastersetting" pk="8">
     <field type="CharField" name="name">DEFCONF_DL_DIR</field>
-    <field type="CharField" name="value">${BUILDDIR}/../downloads</field>
+    <field type="CharField" name="value">${MELDIR}/downloads</field>
   </object>
-  <object model="orm.toastersetting" pk="10">
+  <object model="orm.toastersetting" pk="9">
     <field type="CharField" name="name">CUSTOM_BUILD_INIT_SCRIPT</field>
     <field type="CharField" name="value">${CMD_LINE}</field>
   </object>
@@ -215,9 +206,6 @@ POKYDIR=$(configured_layers | while read layer; do
     fi
 done)
 
-if [ -d "${MELDIR}/downloads" ]; then
-  ln -sf "${MELDIR}/downloads" "${BUILDDIR}/"
-fi
 
    cat <<EOF > "$BUILDDIR"/toaster-setup-environment
 if [ "\$#" -ne 1 ]; then


### PR DESCRIPTION
Fix DL_DIR path and remove EXTERNAL_TOOLCHAIN path from toaster
configuration

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>