### PR TITLE
connman:rng-tools: fix sysvinit boot hang issue

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/connman/connman_%.bbappend
@@ -2,3 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://0001-connman-implement-network-interface-management-techn.patch"
 
 RDEPENDS_${PN} += "rng-tools"
+
+INITSCRIPT_PARAMS = "start 95 5 2 3 . stop 22 0 1 6 ."

--- a/meta-mentor-staging/recipes-support/rng-tools/rng-tools_%.bbappend
+++ b/meta-mentor-staging/recipes-support/rng-tools/rng-tools_%.bbappend
@@ -10,3 +10,5 @@ do_install_append() {
 	install -d ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/rngd.service ${D}${systemd_unitdir}/system
 }
+
+INITSCRIPT_PARAMS = "start 03 2 3 4 5 . stop 30 0 6 1 ."


### PR DESCRIPTION
JIRA-ID: SB-8351

during initialization of connman sufficient entropy is needed, rng-tools
provide entropy, boot hang issue occured during early init of connman and
late init of rng-tools. so to fix the boot hang issue early init rng-tools
and do late init of connman.

previous init sequence:
etc/rc5.d/S05connman -> ../init.d/connman
etc/rc5.d/S30rng-tools -> ../init.d/rng-tools

updated init sequence:
/etc/rc5.d/S03rng-tools -> ../init.d/rng-tools
/etc/rc5.d/S95connman -> ../init.d/connman

Signed-off-by: Shrikant Bobade <shrikant_bobade@mentor.com>