### PR TITLE
meta-environment: fix MULTILIB_VARIANTS recursion

### DIFF
--- a/meta-mel/recipes-core/meta/meta-environment.bbappend
+++ b/meta-mel/recipes-core/meta/meta-environment.bbappend
@@ -1,2 +1,7 @@
 SDK_MULTILIB_VARIANTS ?= "${MULTILIB_VARIANTS}"
-MULTILIB_VARIANTS_task-generate-content = "${SDK_MULTILIB_VARIANTS}"
+python set_multilib_variants () {
+    variants = d.getVar('SDK_MULTILIB_VARIANTS', True)
+    if variants:
+        d.setVar('MULTILIB_VARIANTS', variants)
+}
+do_generate_content[prefuncs] += "set_multilib_variants"


### PR DESCRIPTION
This was breaking do_generate_contents, due to the lack of forced expansion of
SDK_MULTILIB_VARIANTS for its default.

JIRA: SB-8469