### PR TITLE
bbpath-intercepts: fix broken debug output

### DIFF
--- a/meta-mentor-staging/classes/bbpath-intercepts.bbclass
+++ b/meta-mentor-staging/classes/bbpath-intercepts.bbclass
@@ -15,7 +15,7 @@ def find_intercepts(d):
 
 python assemble_intercepts () {
     intercepts = d.getVar('POSTINST_INTERCEPTS', True).split()
-    bb.debug(1, 'Collected intercepts:\n%s' % ('  %s\n' % i for i in intercepts))
+    bb.debug(1, 'Collected intercepts:\n%s' % ''.join('  %s\n' % i for i in intercepts))
     intercepts_dir = d.getVar('POSTINST_INTERCEPTS_DIR', True)
     bb.utils.mkdirhier(intercepts_dir)
     bb.process.run(['cp'] + intercepts + [intercepts_dir])


### PR DESCRIPTION
This was intended to dump the intercepts being used to the do_rootfs log, but
ended up printing a repr() of a generator, which was useless.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>