### PR TITLE
toaster-layers-recipes-config: Fix issue for Ubuntu 16.04

### DIFF
--- a/scripts/toaster-layers-recipes-config.py
+++ b/scripts/toaster-layers-recipes-config.py
@@ -40,9 +40,14 @@ with open(recipeListFile, 'r') as f:
 
 # Now time to populate custom.xml
 
-for layername in layer_and_recipes:
+del_layers = []
+
+for layername in list(layer_and_recipes):
     if len(layer_and_recipes[layername]) == 1:
-        del layer_and_recipes[layername]
+        del_layers.append(layername)
+
+for layername in del_layers:
+    del layer_and_recipes[layername]
 
 pk = len(bblayers) + 1
 


### PR DESCRIPTION
Instead of passing layer_and_recipes to iterator, it's
better to convert it into list and pass the keys explicitely.
This fixes the issue caused:

Creating toaster configuration
Traceback (most recent call last):
  File "/home/qatools/akif/mpsoc_tc3/mel/2017.02.67/meta-mentor/scripts/toaster-layers-recipes-config.py", line 43, in <module>
    for layername in layer_and_recipes:
RuntimeError: OrderedDict mutated during iteration

JIRA: SB-8480

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>