### PR TITLE
toaster_configuration: Fix for RHEL7 using virtualenv

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -189,6 +189,12 @@ EOF
 }
 
 create_toaster_venv () {
+    if [ -f /etc/redhat-release ]; then
+        # If its RHEL 7 there is a bug in virtualenv which has to be tweaked
+        if [ $(cat /etc/redhat-release  | awk {'print $7'} | cut -d "." -f1) -eq 7 ]; then
+            easy_install --user --upgrade virtualenv
+        fi
+    fi
     python -m virtualenv -p python3 "$BUILDDIR/venv"
     python -m virtualenv -p python2 "$BUILDDIR/venv"
     (


### PR DESCRIPTION
There is a potential bug in the virtualenv residing in
RHEL 7.3 version. The bug is listed here:
https://github.com/pypa/virtualenv/issues/463

So inorder to overcome this issue, a work around created.

JIRA: SB-8485

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>