### PR TITLE
mel.conf: add RHEL to sanity tested distro

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -21,6 +21,7 @@ SANITY_TESTED_DISTROS = "\
     Ubuntu-16.04 \n\
     Ubuntu-14.04 \n\
     CentOS-7.* \n \
+    RedHatEnterprise*-7.* \n \
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)


### PR DESCRIPTION
JIRA: SB-8437

fix for RHEL distro not sanity tested warning.

WARNING: Host distribution "RedHatEnterpriseWorkstation-7.3" has not been
validated with this version of the build system; you may possibly
experience unexpected failures. It is recommended that you use a tested
distribution.

Signed-off-by: Shrikant Bobade <shrikant_bobade@mentor.com>