### PR TITLE
mpv: fix build-deps warnings for mesa and libdrm

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-multimedia/mplayer/mpv_0.15.0.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-multimedia/mplayer/mpv_0.15.0.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG[drm] = "--enable-drm,--disable-drm,libdrm"
+PACKAGECONFIG[gbm] = "--enable-gbm,--disable-gbm,mesa"


### PR DESCRIPTION
Add PACKAGECONFIGs for drm and gbm video output features.

JIRA: SB-8551

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>