### PR TITLE
mel: pull in do_populate_lic for do_image_wic deps

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -57,6 +57,12 @@ UBI_VOLNAME = "rootfs"
 WKS_FULL_PATH ??= ""
 IMAGE_FSTYPES += "${@'wic.bz2 wic.bmap' if '${WKS_FULL_PATH}' else ''}"
 
+# Additional dependencies for deployed files are often pulled in via
+# do_image_wic[depends], to ensure the files are available for
+# IMAGE_BOOT_FILES, but this bypasses the do_image[recrdeptask] on
+# do_populate_lic. Add it for do_image_wic as well.
+do_image_wic[recrdeptask] += "do_populate_lic"
+
 # Quadruple the normal. 'du' is not a good way to really see how much
 # space will be needed and fails badly as the fs size grows.
 IMAGE_ROOTFS_EXTRA_SPACE = "40960"


### PR DESCRIPTION
Additional dependencies for deployed files are often pulled in via
do_image_wic[depends], to ensure the files are available for IMAGE_BOOT_FILES,
but this bypasses the do_image[recrdeptask] on do_populate_lic. Add it for
do_image_wic as well.

Ideally, EXTRA_IMAGEDEPENDS and IMAGE_DEPENDS_wic would also pull in
do_deploy, not just do_populate_sysroot, so we could avoid explicitly having
to list these things in `do_image_wic[depends]`.

JIRA: SB-8574