### PR TITLE
mel-support: set default preferences for alternatives

### DIFF
--- a/meta-mel-support/conf/layer.conf
+++ b/meta-mel-support/conf/layer.conf
@@ -13,3 +13,6 @@ BBFILE_PATTERN_mel-support = "^${LAYERDIR_RE}/"
 LAYERDEPENDS_mel-support = "core"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
+
+PREFERRED_PROVIDER_virtual/nativesdk-update-alternatives ??= "nativesdk-opkg-utils"
+PREFERRED_PROVIDER_chkconfig-alternatives ??= "chkconfig-alternatives"


### PR DESCRIPTION
Given DEFAULT_PREFERENCE is lower priority than layer priority, we need some
way to default the preferences for the alternatives bits added in this layer,
so set weak defaults in the layer.conf.

This makes it possible to include the layer when DISTRO isn't mel without risking breakage of the build due to the unspecified preferences.