### PR TITLE
mel: only add wic.bmap, not wic.bz2

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -54,9 +54,9 @@ LOGO_pn-plymouth = "${PLYMOUTH_LOGO}"
 IMAGE_FSTYPES ?= "tar.bz2 ext3"
 UBI_VOLNAME = "rootfs"
 
-# If a wks file exists for this BSP, use it to emit a wic image
+# If a wks file exists for this BSP, also write a .bmap file for bmaptool
 WKS_FULL_PATH ??= ""
-IMAGE_FSTYPES += "${@'wic.bz2 wic.bmap' if '${WKS_FULL_PATH}' else ''}"
+IMAGE_FSTYPES += "${@'wic.bmap' if '${WKS_FULL_PATH}' else ''}"
 
 # Additional dependencies for deployed files are often pulled in via
 # do_image_wic[depends], to ensure the files are available for


### PR DESCRIPTION
Plenty of machines are now adding wic to IMAGE_FSTYPES themselves. We don't
want or need to duplicate that, and IMAGE_FSTYPES is generally in the
machine's control anyway, so let them do it. Keep wic.bmap, as that's more of
a distro choice, and doesn't result in duplication.

JIRA: SB-8529