### PR TITLE
Warn and disable rootfs resizing for non-GPLv3 builds

### DIFF
--- a/meta-mel/classes/resize-rootfs-gplv3.bbclass
+++ b/meta-mel/classes/resize-rootfs-gplv3.bbclass
@@ -1,0 +1,25 @@
+# Warn the user and disable rootfs resizing for non-GPLv3 configurations
+#
+# We use two events, as it seems ConfigParsed is firing multiple times in
+# a build at the moment.
+
+inherit incompatible-recipe-check
+
+python resize_gpl_warn () {
+    if d.getVar('WARN_RESIZE_GPL', True):
+        bb.warn('Resizing the root filesystem to the capacity of the media has been enabled in local.conf (WKS_FILE set to a non-fixed-size image, and 96boards-tools included in MACHINE_EXTRA_RECOMMENDS), however this is a GPL-3.0 incompatible build. This configuration is invalid, as the script we use requires recent GNU Parted, which is GPL-3.0. Removing 96boards-tools from MACHINE_EXTRA_RECOMMENDS. You may wish to alter WKS_FILE to a fixed size image in conf/local.conf, as otherwise the rootfs will not be the size of the media. Doing so, or commenting out the line which adds 96boards-tools, will silence this warning.')
+}
+resize_gpl_warn[eventmask] = "bb.event.BuildStarted"
+addhandler resize_gpl_warn
+
+python resize_gpl_check () {
+    rrecs = d.getVar('MACHINE_EXTRA_RRECOMMENDS', True).split()
+    if (is_incompatible(d, ['96boards-tools'], 'GPL-3.0') and
+            '96boards-tools' in rrecs):
+        wks_file = d.getVar('WKS_FILE', True)
+        if wks_file.endswith('-sd.wks.in'):
+            d.setVar('WARN_RESIZE_GPL', '1')
+        d.setVar('MACHINE_EXTRA_RRECOMMENDS_remove', '96boards-tools')
+}
+resize_gpl_check[eventmask] = "bb.event.ConfigParsed"
+addhandler resize_gpl_check

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -108,12 +108,6 @@ OE_TOPDIR = "${TOPDIR}"
 OE_WORKDIR = "${WORKDIR}"
 OE_TERMINAL_EXPORTS += "OE_TOPDIR OE_WORKDIR COREBASE"
 
-# Check PDK license
-INHERIT += "${@'pdk-license' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
-
-# Write cb-mbs-options for CodeBench
-INHERIT += "${@'cb-mbs-options' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
-
 ## Distro Features & Recipe Configuration {{{1
 # The user can enable ptest from local.conf, and wayland is not yet supported
 POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest wayland"
@@ -167,6 +161,12 @@ OE_IMPORTS += "oe.terminal"
 # Warn if there are available update layers which are not included in the
 # current configuration
 INHERIT += "mentor-updates-check"
+
+# Check PDK license
+INHERIT += "${@'pdk-license' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+
+# Write cb-mbs-options for CodeBench
+INHERIT += "${@'cb-mbs-options' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
 ## }}}1
 ## Preferences & Package Selection {{{1
 # Prefer the chkconfig C implementation of alternatives

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -167,6 +167,9 @@ INHERIT += "${@'pdk-license' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.spli
 
 # Write cb-mbs-options for CodeBench
 INHERIT += "${@'cb-mbs-options' if 'mentor-private' in '${BBFILE_COLLECTIONS}'.split() else ''}"
+
+# Warn the user and disable rootfs resizing for non-GPLv3 builds
+INHERIT += "resize-rootfs-gplv3"
 ## }}}1
 ## Preferences & Package Selection {{{1
 # Prefer the chkconfig C implementation of alternatives


### PR DESCRIPTION
Rootfs resizing relies on a script which needs recent parted, which is GPLv3,
so we can't build in non-GPLv3 without disabling it or reworking the script.

JIRA: SB-8334