### PR TITLE
wic-common.inc: move bits to meta-mentor-bsp

### DIFF
--- a/meta-mel/conf/include/wic-common.inc
+++ b/meta-mel/conf/include/wic-common.inc
@@ -1,7 +1,0 @@
-#This file contains the WIC bits that are common to all MEL BSPs
-
-# WIC image type support
-IMAGE_FSTYPES_append = " wic.bz2"
-
-# dosfstools is needed to create the boot partition, mtools to copy to it
-IMAGE_DEPENDS_wic_append = " dosfstools-native mtools-native"


### PR DESCRIPTION
Move dosfstools and mtools deps to bsp specific local.conf.append files
in meta-mentor-bsp. These tools are only common in systems that use dos
boot partitions so its better to set these on per BSP basis.

wic.bz2 is not needed in IMAGE_FSTYPES anymore as we are using wic now.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>