### PR TITLE
archive-release: inherit image_types.bbclass

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -11,6 +11,10 @@ EXCLUDE_FROM_WORLD = "1"
 SRC_URI += "${@' '.join(uninative_urls(d)) if 'downloads' in '${RELEASE_ARTIFACTS}'.split() else ''}"
 SRC_URI_append_qemuall = " file://runqemu.in"
 
+# We're using image fstypes data, inherit the class in case variables from it
+# are needed for IMAGE_FSTYPES
+inherit image_types
+
 UNINATIVE_BUILD_ARCHES ?= "x86_64 i686"
 MELDIR ?= "${COREBASE}/.."
 TEMPLATECONF ?= "${FILE_DIRNAME}/../../../conf"


### PR DESCRIPTION
We're using image fstypes data, inherit the class in case variables from it
are needed for IMAGE_FSTYPES. In the case of current mel, wic.bmap is added to
IMAGE_FSTYPES based upon WKS_FULL_PATH, which is defined in image_types.

JIRA: SB-8529