### PR TITLE
bmap-tools: Downgrade bmap-tools recipe to version 2.5

### DIFF
--- a/meta-mel-support/recipes-support/bmap-tools/bmap-tools_2.5.bb
+++ b/meta-mel-support/recipes-support/bmap-tools/bmap-tools_2.5.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Tools to generate block map (AKA bmap) and flash images using bmap"
+DESCRIPTION = "Bmap-tools - tools to generate block map (AKA bmap) and flash images using \
+bmap. Bmaptool is a generic tool for creating the block map (bmap) for a file, \
+and copying files using the block map. The idea is that large file containing \
+unused blocks, like raw system image files, can be copied or flashed a lot \
+faster with bmaptool than with traditional tools like "dd" or "cp"."
+HOMEPAGE = "http://git.infradead.org/users/dedekind/bmap-tools.git"
+SECTION = "console/utils"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "ftp://ftp.infradead.org/pub/${BPN}/${BPN}-${PV}.tgz"
+SRC_URI[md5sum] = "843522001b2aa2f7718f254f6942ad80"
+SRC_URI[sha256sum] = "40fb0022ea5475e392fb2ef74b1e086e570951caec1745565e1a50ca35e75616"
+
+RDEPENDS_${PN} = "python-core python-compression"
+
+inherit setuptools
+
+BBCLASSEXTEND = "native"
+
+do_install_append_class-native() {
+    sed -i -e 's|^#!.*/usr/bin/env python|#! /usr/bin/env nativepython|' ${D}${bindir}/bmaptool
+}

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -364,6 +364,9 @@ require conf/blocks/speech-recognition.conf
 include conf/distro/include/qt5-mel.conf
 include conf/distro/include/qt5-versions.inc
 
+# Install bmap-tools version 2.5 inorder to support both Ubuntu 14.04 and 16.04 respectively.
+PREFERRED_VERSION_bmap-tools-native = "2.5"
+
 # Security / SELinux configuration.
 include conf/distro/include/mel-security.conf
 ## }}}1


### PR DESCRIPTION
We are downgrading bmap-tools recipe from the version
available at poky, which is 3.2. The reason is it generates
wic.bmap file with version 2 which is not supported in Ubuntu
14.04. So if we keep version 2.5 then it works on Ubuntu 14.04
and 16.04.

JIRA: SB-8621

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>