### PR TITLE
mesa: Add GLES3 headers to libgles2-mesa-dev

### DIFF
--- a/meta-mentor-staging/recipes-graphics/mesa/mesa_%.bbappend
+++ b/meta-mentor-staging/recipes-graphics/mesa/mesa_%.bbappend
@@ -6,3 +6,6 @@ PROVIDES_remove = "\
 
 # gbm requires dri, so disable it when dri is disabled
 PACKAGECONFIG[dri] = "--enable-dri --with-dri-drivers=${DRIDRIVERS} --enable-gbm, --disable-dri --disable-gbm, dri2proto libdrm"
+
+# Adding GLES3 headers to libgles2-mesa-dev package
+FILES_libgles2-mesa-dev += "${includedir}/GLES3"


### PR DESCRIPTION
Adding GLES3 headers to libgles2-mesa-dev solves the
build issue of Qt examples with Qt Creator. The
libgles3-mesa-dev isn't picked up for ADE, so we have
to include the headers into libgles2-mesa-dev.

JIRA: SB-8626

Signed-off-by: Sujith Haridasan <Sujith_Haridasan@mentor.com>