### PR TITLE
usdpaa: Use TARGET_CC_ARCH for powerpc64

### DIFF
--- a/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/files/0001-usdpaa-do-not-hardcode-flags-for-powerpc64.patch
+++ b/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/files/0001-usdpaa-do-not-hardcode-flags-for-powerpc64.patch
@@ -1,0 +1,30 @@
+From ba6ba85d3e27ac35fa1089f3b9da39ec599e3570 Mon Sep 17 00:00:00 2001
+From: Abdur Rehman <abdur_rehman@mentor.com>
+Date: Wed, 18 Jan 2017 16:06:50 +0500
+Subject: [PATCH 1/1] usdpaa: do not hardcode flags for powerpc64
+
+Use TARGET_CC_ARCH instead
+
+Upstream-Status: Pending
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 5b47cf7..c35b8b4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -46,7 +46,7 @@ ifneq (distclean,$(MAKECMDGOALS))
+     $(ARCH)_SPEC_DEFINE	 := CONFIG_PPC64
+     $(ARCH)_SPEC_INC_PATH:=
+     $(ARCH)_SPEC_LIB_PATH:=
+-    $(ARCH)_SPEC_CFLAGS	 := -mcpu=e500mc64 -m64
++    $(ARCH)_SPEC_CFLAGS         := $(TARGET_CC_ARCH)
+     $(ARCH)_SPEC_LDFLAGS :=
+     LIBDIR               ?= lib64
+ else ifeq (arm64,$(ARCH))                          
+-- 
+2.8.1
+

--- a/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/usdpaa_git.bbappend
+++ b/meta-mentor-staging/fsl-ppc/recipes-dpaa/usdpaa/usdpaa_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-usdpaa-do-not-hardcode-flags-for-powerpc64.patch"


### PR DESCRIPTION
instead of hardcoding flags. Similar change was made for powerpc 32 bit
targets in meta-fsl-ppc commit id 520c753.

JIRA: SB-8643

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>