### PR TITLE
bmap-tools: apply workaround for FIEMAP issue

### DIFF
--- a/meta-mel-support/recipes-support/bmap-tools/bmap-tools/Fiemap-synchronize-the-file-before-invoking-the-ioct.patch
+++ b/meta-mel-support/recipes-support/bmap-tools/bmap-tools/Fiemap-synchronize-the-file-before-invoking-the-ioct.patch
@@ -1,0 +1,61 @@
+From 97d34f7cce264a9447d02e8554d90eb006687cd5 Mon Sep 17 00:00:00 2001
+From: Artem Bityutskiy <artem.bityutskiy@intel.com>
+Date: Tue, 17 Sep 2013 14:57:35 +0300
+Subject: [PATCH] Fiemap: synchronize the file before invoking the ioctl
+
+Early FIEMAP implementations had many bugs related to cached dirty data. And
+this is why it is safer to synchronize the file before invoking FIEMAP for it.
+Let's start using the 'FIEMAP_FLAG_SYNC' FIEMAP ioctl flag which does exactly
+that.
+
+Change-Id: I1698b88ed3978ffa632502ba72ad345ec8708ce0
+Signed-off-by: Artem Bityutskiy <artem.bityutskiy@intel.com>
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+Upstream-Status: Backport [commit 5b1a916 on branch release-3.0, tag v3.0]
+---
+ bmaptools/Fiemap.py | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/bmaptools/Fiemap.py b/bmaptools/Fiemap.py
+index 76857b8..7d8fea2 100644
+--- a/bmaptools/Fiemap.py
++++ b/bmaptools/Fiemap.py
+@@ -39,6 +39,9 @@ _FIEMAP_EXTENT_FORMAT = "=QQQQQLLLL"
+ _FIEMAP_EXTENT_SIZE = struct.calcsize(_FIEMAP_EXTENT_FORMAT)
+ # The FIEMAP ioctl number
+ _FIEMAP_IOCTL = 0xC020660B
++# This FIEMAP ioctl flag which instructs the kernel to sync the file before
++# reading the block map
++_FIEMAP_FLAG_SYNC = 0x00000001
+ 
+ # Minimum buffer which is required for 'class Fiemap' to operate
+ MIN_BUFFER_SIZE = _FIEMAP_SIZE + _FIEMAP_EXTENT_SIZE
+@@ -78,6 +81,9 @@ class Fiemap:
+         fiemap_extent' elements which will be used when invoking the FIEMAP
+         ioctl. The larger is the buffer, the less times the FIEMAP ioctl will
+         be invoked.
++
++        This class synchronizes the image file every time it invokes the FIEMAP
++        ioctl in order to work-around early FIEMAP implementation kernel bugs.
+         """
+ 
+         self._f_image_needs_close = False
+@@ -148,9 +154,13 @@ class Fiemap:
+             raise Error("bad block number %d, should be within [0, %d]"
+                         % (block, self.blocks_cnt))
+ 
+-        # Initialize the 'struct fiemap' part of the buffer
++        # Initialize the 'struct fiemap' part of the buffer. We use the
++        # '_FIEMAP_FLAG_SYNC' flag in order to make sure the file is
++        # synchronized. The reason for this is that early FIEMAP
++        # implementations had many bugs related to cached dirty data, and
++        # synchronizing the file is a necessary work-around.
+         struct.pack_into(_FIEMAP_FORMAT, self._buf, 0, block * self.block_size,
+-                         count * self.block_size, 0, 0,
++                         count * self.block_size, _FIEMAP_FLAG_SYNC, 0,
+                          self._fiemap_extent_cnt, 0)
+ 
+         try:
+-- 
+1.9.1
+

--- a/meta-mel-support/recipes-support/bmap-tools/bmap-tools_2.5.bb
+++ b/meta-mel-support/recipes-support/bmap-tools/bmap-tools_2.5.bb
@@ -9,7 +9,8 @@ SECTION = "console/utils"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "ftp://ftp.infradead.org/pub/${BPN}/${BPN}-${PV}.tgz"
+SRC_URI = "ftp://ftp.infradead.org/pub/${BPN}/${BPN}-${PV}.tgz \
+           file://Fiemap-synchronize-the-file-before-invoking-the-ioct.patch"
 SRC_URI[md5sum] = "843522001b2aa2f7718f254f6942ad80"
 SRC_URI[sha256sum] = "40fb0022ea5475e392fb2ef74b1e086e570951caec1745565e1a50ca35e75616"
 


### PR DESCRIPTION
This was causing .bmap files to be written with zero blocks in the map in some
cases, which caused failures for `bmaptool copy`. We encountered this when
building on Ubuntu 14.04 LTS hosts while using bmap-tools version 2.5. The
patch is cherry-picked from the bmap-tools 3.0 branch.

JIRA: SB-8678

Signed-off-by: Christopher Larson <chris_larson@mentor.com>