### PR TITLE
ca-certificates: work around pseudo bug

### DIFF
--- a/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates_20160104.bbappend
+++ b/meta-mentor-staging/recipes-support/ca-certificates/ca-certificates_20160104.bbappend
@@ -1,0 +1,6 @@
+pkg_postinst_${PN}_append () {
+    # Work around pseudo bug (see pseudo.log. when this isn't done, the
+    # symlinks created by update-ca-certificates end up with inode and symlink
+    # mismatches, resulting in host user contamination.
+    chown -h root:root "$D${sysconfdir}/ssl/certs/"*.pem
+}


### PR DESCRIPTION
update-ca-certificates creates symlinks in $D/etc/ssl/certs for the content in
$D/usr/share/ca-certificates, but somehow those links end up with wrong
ownership, and pseudo.log indicates it got confused -- there are symlink and
inode mismatches for all the files. Yet nothing special is happening here,
it's a shell script run by a postinst at do_rootfs time, under pseudo. Work
around the issue with a chown for now.

JIRA: SB-8525

Signed-off-by: Christopher Larson <chris_larson@mentor.com>