### PR TITLE
Use an event handler to add wic.bmap to IMAGE_FSTYPES

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -54,9 +54,8 @@ LOGO_pn-plymouth = "${PLYMOUTH_LOGO}"
 IMAGE_FSTYPES ?= "tar.bz2 ext3"
 UBI_VOLNAME = "rootfs"
 
-# If a wks file exists for this BSP, also write a .bmap file for bmaptool
-WKS_FULL_PATH ??= ""
-IMAGE_FSTYPES += "${@'wic.bmap' if '${WKS_FULL_PATH}' else ''}"
+# If a wic image type is enabled, also enable wic.bmap
+require conf/distro/include/wic-bmap.inc
 
 # Additional dependencies for deployed files are often pulled in via
 # do_image_wic[depends], to ensure the files are available for

--- a/meta-mel/conf/distro/include/wic-bmap.inc
+++ b/meta-mel/conf/distro/include/wic-bmap.inc
@@ -1,0 +1,12 @@
+# If a wic image type is enabled, also enable wic.bmap. We use an event
+# handler here, as we can't reference IMAGE_FSTYPES from inline python in the
+# same variable, and while we can reference WKS_FULL_PATH, then the value in
+# the config metadata would be different than in image recipes. This wouldn't
+# normally be a problem, but toaster is using the config metadata value.
+python add_wic_bmap () {
+    image_fstypes = d.getVar('IMAGE_FSTYPES', True).split()
+    if any(f == 'wic' or f.startswith('wic.') for f in image_fstypes):
+        d.setVar('IMAGE_FSTYPES_append', ' wic.bmap')
+}
+add_wic_bmap[eventmask] = "bb.event.ConfigParsed"
+addhandler add_wic_bmap


### PR DESCRIPTION
If a wic image type is enabled, also enable wic.bmap. We use an event handler,
as we can't reference IMAGE_FSTYPES from inline python in the same variable,
and while we can reference WKS_FULL_PATH, then the value in the config
metadata would be different than in image recipes. This wouldn't normally be
a problem, but toaster is using the config metadata value.

JIRA: SB-8685