### PR TITLE
resize-rootfs-gplv3: Warn for all WKS files

### DIFF
--- a/meta-mel/classes/resize-rootfs-gplv3.bbclass
+++ b/meta-mel/classes/resize-rootfs-gplv3.bbclass
@@ -17,7 +17,7 @@ python resize_gpl_check () {
     if (is_incompatible(d, ['96boards-tools'], 'GPL-3.0') and
             '96boards-tools' in rrecs):
         wks_file = d.getVar('WKS_FILE', True)
-        if wks_file.endswith('-sd.wks.in'):
+        if wks_file.endswith('-sd.wks.in') or wks_file.endswith('.wks'):
             d.setVar('WARN_RESIZE_GPL', '1')
         d.setVar('MACHINE_EXTRA_RRECOMMENDS_remove', '96boards-tools')
 }


### PR DESCRIPTION
JIRA: http://jira.alm.mentorg.com:8080/browse/SB-8734

The Minnowmax BSP uses -sd.wks.in file name, while other BSP's
use ${MACHINE}.wks as file name in general. So expand the file
check condition to include ".wks" file name as well.

Signed-off-by: Srikanth Krishnakar <Srikanth_Krishnakar@mentor.com>