### PR TITLE
setup-environment/-mel-builddir: exclude mentor-private on mel-lite

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -8,7 +8,9 @@
 
 MEL_DISTRO="${MEL_DISTRO:-mel}"
 CORELAYERS="${CORELAYERS:-core mel-support mentor-staging}"
-OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
+if [ "${MEL_DISTRO}" != "mel-lite" ]; then
+    OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
+fi
 EXTRAMELLAYERS="${EXTRAMELLAYERS:-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery}"
 layer_priority_overrides="openembedded-layer=1"
 

--- a/setup-environment
+++ b/setup-environment
@@ -29,7 +29,11 @@ else
         esac
     done
 
-    OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private tracing-layer}"
+    if [ "${MEL_DISTRO}" == "mel-lite" ]; then
+        OPTIONALLAYERS="${OPTIONALLAYERS:-tracing-layer}"
+    else
+        OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private tracing-layer}"
+    fi
     EXCLUDEDLAYERS="$EXCLUDEDLAYERS"
     # Customer directory layers handling (e.g. <customername>-custom)
     for _layercheck in . $layerdir/..; do


### PR DESCRIPTION
meta-mentor-private only includes stuff related to ADE and
PDK license verification both of which are not supported
on MEL Lite so various issues are seen.
We now disable inclusion of meta-mentor-private in bblayers
rather than adjusting each feature according to DISTRO so
it can be maintained much cleanly.

Signed-off-by: Awais Belal <awais_belal@mentor.com>