### PR TITLE
mel-lite.conf: adjust SANITY_TESTED_DISTROS

### DIFF
--- a/meta-mel/conf/distro/mel-lite.conf
+++ b/meta-mel/conf/distro/mel-lite.conf
@@ -7,5 +7,5 @@ DISTROOVERRIDES = "${DISTRO}:mel"
 require conf/distro/include/mel.conf
 
 SANITY_TESTED_DISTROS = "\
-    Ubuntu-14.04 \n\
+    Ubuntu-16.04 \n\
 "


### PR DESCRIPTION
We only test MEL Lite on latest Ubuntu build hosts.

Signed-off-by: Awais Belal <awais_belal@mentor.com>