### PR TITLE
lttng-modules: import patches to fix clock issues

### DIFF
--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/nmi-safe_clock_on_32-bit_systems.patch
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/nmi-safe_clock_on_32-bit_systems.patch
@@ -1,0 +1,202 @@
+From 16200240252178bf016a18eddd39be03a3bdca18 Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Thu, 9 Feb 2017 20:46:44 -0500
+Subject: [PATCH] Fix: nmi-safe clock on 32-bit systems
+
+On 32-bit systems, the algorithm within lttng-modules that ensures the
+nmi-safe clock increases monotonically on a CPU assumes to have one
+clock read per 32-bit LSB overflow period, which is not guaranteed. It
+also has an issue on the first clock reads after module load, because
+the initial value for the last LSB is 0. It can cause the time to stay
+stuck at the same value for a few seconds at the beginning of the trace,
+which is unfortunate for the first trace after module load, because this
+is where the offset between realtime and trace_clock is sampled, which
+prevents correlation of kernel and user-space traces for that session.
+
+It only affects 32-bit systems with kernels >= 3.17.
+
+Fix this by using the non-nmi-safe clock source on 32-bit systems.
+
+While we are there, remove an implementation-defined c99 behavior
+regarding casting u64 to long by using unsigned arithmetic instead:
+
+turn:
+  if (((long) now - (long) last) < 0)
+into:
+  if (U64_MAX / 2 < now - last)
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Upstream-Status: Backport
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ wrapper/trace-clock.c |  6 ++--
+ wrapper/trace-clock.h | 81 +++++++++++++++++----------------------------------
+ 2 files changed, 29 insertions(+), 58 deletions(-)
+
+diff --git a/wrapper/trace-clock.c b/wrapper/trace-clock.c
+index d9bc956..6ec952b 100644
+--- a/wrapper/trace-clock.c
++++ b/wrapper/trace-clock.c
+@@ -23,10 +23,10 @@
+ 
+ #include <wrapper/trace-clock.h>
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+-DEFINE_PER_CPU(local_t, lttng_last_tsc);
++#ifdef LTTNG_USE_NMI_SAFE_CLOCK
++DEFINE_PER_CPU(u64, lttng_last_tsc);
+ EXPORT_PER_CPU_SYMBOL(lttng_last_tsc);
+-#endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)) */
++#endif /* #ifdef LTTNG_USE_NMI_SAFE_CLOCK */
+ 
+ #ifdef LTTNG_CLOCK_NMI_SAFE_BROKEN
+ #warning "Your kernel implements a bogus nmi-safe clock source. Falling back to the non-nmi-safe clock source, which discards events traced from NMI context. Upgrade your kernel to resolve this situation."
+diff --git a/wrapper/trace-clock.h b/wrapper/trace-clock.h
+index 496fec4..7f17ccd 100644
+--- a/wrapper/trace-clock.h
++++ b/wrapper/trace-clock.h
+@@ -59,65 +59,36 @@ extern struct lttng_trace_clock *lttng_trace_clock;
+ #define LTTNG_CLOCK_NMI_SAFE_BROKEN
+ #endif
+ 
++/*
++ * We need clock values to be monotonically increasing per-cpu, which is
++ * not strictly guaranteed by ktime_get_mono_fast_ns(). It is
++ * straightforward to do on architectures with a 64-bit cmpxchg(), but
++ * not so on architectures without 64-bit cmpxchg. For now, only enable
++ * this feature on 64-bit architectures.
++ */
++
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) \
++	&& BITS_PER_LONG == 64 \
+ 	&& !defined(LTTNG_CLOCK_NMI_SAFE_BROKEN))
++#define LTTNG_USE_NMI_SAFE_CLOCK
++#endif
+ 
+-DECLARE_PER_CPU(local_t, lttng_last_tsc);
++#ifdef LTTNG_USE_NMI_SAFE_CLOCK
+ 
+-#if (BITS_PER_LONG == 32)
+-/*
+- * Fixup "src_now" using the 32 LSB from "last". We need to handle overflow and
+- * underflow of the 32nd bit. "last" can be above, below or equal to the 32 LSB
+- * of "src_now".
+- */
+-static inline u64 trace_clock_fixup(u64 src_now, u32 last)
+-{
+-	u64 now;
+-
+-	now = src_now & 0xFFFFFFFF00000000ULL;
+-	now |= (u64) last;
+-	/* Detect overflow or underflow between now and last. */
+-	if ((src_now & 0x80000000U) && !(last & 0x80000000U)) {
+-		/*
+-		 * If 32nd bit transitions from 1 to 0, and we move forward in
+-		 * time from "now" to "last", then we have an overflow.
+-		 */
+-		if (((s32) now - (s32) last) < 0)
+-			now += 0x0000000100000000ULL;
+-	} else if (!(src_now & 0x80000000U) && (last & 0x80000000U)) {
+-		/*
+-		 * If 32nd bit transitions from 0 to 1, and we move backward in
+-		 * time from "now" to "last", then we have an underflow.
+-		 */
+-		if (((s32) now - (s32) last) > 0)
+-			now -= 0x0000000100000000ULL;
+-	}
+-	return now;
+-}
+-#else /* #if (BITS_PER_LONG == 32) */
+-/*
+- * The fixup is pretty easy on 64-bit architectures: "last" is a 64-bit
+- * value, so we can use last directly as current time.
+- */
+-static inline u64 trace_clock_fixup(u64 src_now, u64 last)
+-{
+-	return last;
+-}
+-#endif /* #else #if (BITS_PER_LONG == 32) */
++DECLARE_PER_CPU(u64, lttng_last_tsc);
+ 
+ /*
+  * Sometimes called with preemption enabled. Can be interrupted.
+  */
+ static inline u64 trace_clock_monotonic_wrapper(void)
+ {
+-	u64 now;
+-	unsigned long last, result;
+-	local_t *last_tsc;
++	u64 now, last, result;
++	u64 *last_tsc_ptr;
+ 
+ 	/* Use fast nmi-safe monotonic clock provided by the Linux kernel. */
+ 	preempt_disable();
+-	last_tsc = lttng_this_cpu_ptr(&lttng_last_tsc);
+-	last = local_read(last_tsc);
++	last_tsc_ptr = lttng_this_cpu_ptr(&lttng_last_tsc);
++	last = *last_tsc_ptr;
+ 	/*
+ 	 * Read "last" before "now". It is not strictly required, but it ensures
+ 	 * that an interrupt coming in won't artificially trigger a case where
+@@ -126,9 +97,9 @@ static inline u64 trace_clock_monotonic_wrapper(void)
+ 	 */
+ 	barrier();
+ 	now = ktime_get_mono_fast_ns();
+-	if (((long) now - (long) last) < 0)
+-		now = trace_clock_fixup(now, last);
+-	result = local_cmpxchg(last_tsc, last, (unsigned long) now);
++	if (U64_MAX / 2 < now - last)
++		now = last;
++	result = cmpxchg64_local(last_tsc_ptr, last, now);
+ 	preempt_enable();
+ 	if (result == last) {
+ 		/* Update done. */
+@@ -139,11 +110,11 @@ static inline u64 trace_clock_monotonic_wrapper(void)
+ 		 * "result", since it has been sampled concurrently with our
+ 		 * time read, so it should not be far from "now".
+ 		 */
+-		return trace_clock_fixup(now, result);
++		return result;
+ 	}
+ }
+ 
+-#else /* #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)) */
++#else /* #ifdef LTTNG_USE_NMI_SAFE_CLOCK */
+ static inline u64 trace_clock_monotonic_wrapper(void)
+ {
+ 	ktime_t ktime;
+@@ -158,7 +129,7 @@ static inline u64 trace_clock_monotonic_wrapper(void)
+ 	ktime = ktime_get();
+ 	return ktime_to_ns(ktime);
+ }
+-#endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)) */
++#endif /* #else #ifdef LTTNG_USE_NMI_SAFE_CLOCK */
+ 
+ static inline u64 trace_clock_read64_monotonic(void)
+ {
+@@ -185,19 +156,19 @@ static inline const char *trace_clock_description_monotonic(void)
+ 	return "Monotonic Clock";
+ }
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
++#ifdef LTTNG_USE_NMI_SAFE_CLOCK
+ static inline int get_trace_clock(void)
+ {
+ 	printk_once(KERN_WARNING "LTTng: Using mainline kernel monotonic fast clock, which is NMI-safe.\n");
+ 	return 0;
+ }
+-#else /* #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)) */
++#else /* #ifdef LTTNG_USE_NMI_SAFE_CLOCK */
+ static inline int get_trace_clock(void)
+ {
+ 	printk_once(KERN_WARNING "LTTng: Using mainline kernel monotonic clock. NMIs will not be traced.\n");
+ 	return 0;
+ }
+-#endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)) */
++#endif /* #else #ifdef LTTNG_USE_NMI_SAFE_CLOCK */
+ 
+ static inline void put_trace_clock(void)
+ {
+

--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/show_warning_for_broken_clock_workaround.patch
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/show_warning_for_broken_clock_workaround.patch
@@ -1,0 +1,52 @@
+From 5b06448bb01e44326c1579a9c6b9457aeb73fed7 Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Thu, 6 Oct 2016 07:45:35 -0400
+Subject: [PATCH] Fix: show warning for broken clock work-around
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Upstream-Status: Backport
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ wrapper/trace-clock.c |  4 ++++
+ wrapper/trace-clock.h | 12 ++++++++----
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/wrapper/trace-clock.c b/wrapper/trace-clock.c
+index 23869ca..d9bc956 100644
+--- a/wrapper/trace-clock.c
++++ b/wrapper/trace-clock.c
+@@ -27,3 +27,7 @@
+ DEFINE_PER_CPU(local_t, lttng_last_tsc);
+ EXPORT_PER_CPU_SYMBOL(lttng_last_tsc);
+ #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,16,0)) */
++
++#ifdef LTTNG_CLOCK_NMI_SAFE_BROKEN
++#warning "Your kernel implements a bogus nmi-safe clock source. Falling back to the non-nmi-safe clock source, which discards events traced from NMI context. Upgrade your kernel to resolve this situation."
++#endif
+diff --git a/wrapper/trace-clock.h b/wrapper/trace-clock.h
+index 649c93f..14d41af 100644
+--- a/wrapper/trace-clock.h
++++ b/wrapper/trace-clock.h
+@@ -52,11 +52,15 @@ extern struct lttng_trace_clock *lttng_trace_clock;
+  * CONFIG_DEBUG_TIMEKEEPING") introduces a buggy ktime_get_mono_fast_ns().
+  * This is fixed by patch "timekeeping: Fix __ktime_get_fast_ns() regression".
+  */
++#if (LTTNG_KERNEL_RANGE(4,8,0, 4,8,1) \
++	|| LTTNG_KERNEL_RANGE(4,7,4, 4,7,7) \
++	|| LTTNG_KERNEL_RANGE(4,4,20, 4,4,24) \
++	|| LTTNG_KERNEL_RANGE(4,1,32, 4,1,34))
++#define LTTNG_CLOCK_NMI_SAFE_BROKEN
++#endif
++
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) \
+-	&& !LTTNG_KERNEL_RANGE(4,8,0, 4,8,1) \
+-	&& !LTTNG_KERNEL_RANGE(4,7,4, 4,7,7) \
+-	&& !LTTNG_KERNEL_RANGE(4,4,20, 4,4,24) \
+-	&& !LTTNG_KERNEL_RANGE(4,1,32, 4,1,34))
++	&& !defined(LTTNG_CLOCK_NMI_SAFE_BROKEN))
+ 
+ DECLARE_PER_CPU(local_t, lttng_last_tsc);
+ 
+

--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/work-around_upstream_Linux_timekeeping_bug.patch
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/work-around_upstream_Linux_timekeeping_bug.patch
@@ -1,0 +1,55 @@
+From 1d2aa29ef8287d3972fd3fe90dbe9bfd46ec51ef Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Wed, 5 Oct 2016 07:20:32 -0400
+Subject: [PATCH] Fix: work-around upstream Linux timekeeping bug
+
+Linux commit 27727df240c7 ("Avoid taking lock in NMI path with
+CONFIG_DEBUG_TIMEKEEPING"), changed the logic to open-code
+the timekeeping_get_ns() function, but forgot to include
+the unit conversion from cycles to nanoseconds, breaking the
+function's output, which impacts LTTng.
+
+The following kernel versions are affected: 4.8, 4.7.4+, 4.4.20+,
+4.1.32+
+
+We expect that the upstream fix will reach the master and stable
+branches timely before the next releases, so we use 4.8.1, 4.7.7,
+4.4.24, and 4.1.34 as upper bounds (exclusive).
+
+Fall-back to the non-NMI-safe trace clock for those kernel versions.
+We simply discard events from NMI context with a in_nmi() check,
+as we did before Linux 3.17.
+
+Link: http://lkml.kernel.org/r/1475636148-26539-1-git-send-email-john.stultz@linaro.org
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Upstream-Status: Backport
+
+Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>
+---
+ wrapper/trace-clock.h | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/wrapper/trace-clock.h b/wrapper/trace-clock.h
+index 3e8780d..649c93f 100644
+--- a/wrapper/trace-clock.h
++++ b/wrapper/trace-clock.h
+@@ -47,7 +47,16 @@
+ 
+ extern struct lttng_trace_clock *lttng_trace_clock;
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
++/*
++ * Upstream Linux commit 27727df240c7 ("Avoid taking lock in NMI path with
++ * CONFIG_DEBUG_TIMEKEEPING") introduces a buggy ktime_get_mono_fast_ns().
++ * This is fixed by patch "timekeeping: Fix __ktime_get_fast_ns() regression".
++ */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) \
++	&& !LTTNG_KERNEL_RANGE(4,8,0, 4,8,1) \
++	&& !LTTNG_KERNEL_RANGE(4,7,4, 4,7,7) \
++	&& !LTTNG_KERNEL_RANGE(4,4,20, 4,4,24) \
++	&& !LTTNG_KERNEL_RANGE(4,1,32, 4,1,34))
+ 
+ DECLARE_PER_CPU(local_t, lttng_last_tsc);
+ 
+

--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/lttng-modules:"
+
+SRC_URI_append = " file://work-around_upstream_Linux_timekeeping_bug.patch \
+                   file://show_warning_for_broken_clock_workaround.patch \
+                   file://nmi-safe_clock_on_32-bit_systems.patch \
+"


### PR DESCRIPTION
Import following patches from upstream to fix incorrect timestamps seen
in lttng traces:
  * 1d2aa29 Fix: work-around upstream Linux timekeeping bug
  * 5b06448 Fix: show warning for broken clock work-around
  * 1620024 Fix: nmi-safe clock on 32-bit systems

JIRA: SB-8881

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>