### PR TITLE
lttng-modules: Pull in upstream commit to fix error handling

### DIFF
--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/0001-Fix-preemptible-and-migratable-context-error-handlin.patch
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules/0001-Fix-preemptible-and-migratable-context-error-handlin.patch
@@ -1,0 +1,49 @@
+From d0e59d6f099f4663cc62bffb59d960cd4235064f Mon Sep 17 00:00:00 2001
+From: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Date: Mon, 24 Oct 2016 13:27:01 -0400
+Subject: [PATCH] Fix: preemptible and migratable context error handling
+
+When built against preempt-rt and preempt kernels, the "return 0" case
+means success, but lttng-modules incorrectly prints an error in the
+kernel log.
+
+Given that we handle the -ENOSYS error in lttng_context_init, there is
+no need to keep the ifdefs in that function.
+
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Upstream-status: Backport
+
+Signed-off-by: Fahad Usman <fahad_usman@mentor.com>
+---
+ lttng-context.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/lttng-context.c b/lttng-context.c
+index d299d5e..406f479 100644
+--- a/lttng-context.c
++++ b/lttng-context.c
+@@ -300,18 +300,14 @@ int lttng_context_init(void)
+ 	if (ret) {
+ 		printk(KERN_WARNING "Cannot add context lttng_add_need_reschedule_to_ctx");
+ 	}
+-#if defined(CONFIG_PREEMPT_RT_FULL) || defined(CONFIG_PREEMPT)
+ 	ret = lttng_add_preemptible_to_ctx(&lttng_static_ctx);
+-	if (ret != -ENOSYS) {
++	if (ret && ret != -ENOSYS) {
+ 		printk(KERN_WARNING "Cannot add context lttng_add_preemptible_to_ctx");
+ 	}
+-#endif
+-#ifdef CONFIG_PREEMPT_RT_FULL
+ 	ret = lttng_add_migratable_to_ctx(&lttng_static_ctx);
+-	if (ret != -ENOSYS) {
++	if (ret && ret != -ENOSYS) {
+ 		printk(KERN_WARNING "Cannot add context lttng_add_migratable_to_ctx");
+ 	}
+-#endif
+ 	/* TODO: perf counters for filtering */
+ 	return 0;
+ }
+-- 
+2.8.1
+

--- a/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
+++ b/meta-mentor-staging/recipes-kernel/lttng/lttng-modules_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/lttng-modules:"
 SRC_URI_append = " file://work-around_upstream_Linux_timekeeping_bug.patch \
                    file://show_warning_for_broken_clock_workaround.patch \
                    file://nmi-safe_clock_on_32-bit_systems.patch \
+                   file://0001-Fix-preemptible-and-migratable-context-error-handlin.patch \
 "


### PR DESCRIPTION
Backport the following upstream commit to fix  preemptible and migratable context 
error handling;
https://github.com/lttng/lttng-modules/commit/d0e59d6f099f4663cc62bffb59d960cd4235064f

Jira: jira.alm.mentorg.com:8080/browse/SB-8925

Signed-off-by: Fahad Usman <fahad_usman@mentor.com>