### PR TITLE
Revert "setup-{rh,ubuntu}: drop 32-bit libs"

### DIFF
--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -8,7 +8,7 @@
 
 packages="make gcc gcc-c++ patch texi2html diffstat texinfo tetex cvs git
           subversion gawk tar gzip bzip2 redhat-lsb sqlite ncurses-devel \
-          SDL-devel glibc-devel glibc-static \
+          SDL-devel glibc-devel glibc-static glibc-devel.i686 libgcc.i686 \
           chrpath python python34 wget perl-Thread-Queue python-virtualenv"
 
 set -e

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -24,6 +24,11 @@ PKGS="$PKGS bmap-tools"
 # This is needed for Windows ADE
 PKGS="$PKGS zip"
 
+if [ "$(uname -m)" = "x86_64" ]; then
+    sudo dpkg --add-architecture i386
+    PKGS="$PKGS libc6-dev-i386 libncurses5:i386"
+fi
+
 echo "Installing packages required to build Mentor Embedded Linux"
 sudo apt-get update
 sudo apt-get -y install $PKGS


### PR DESCRIPTION
CB Lite is a 32 bit toolchain and we provide installers for
MEL Lite with the same so these are still needed.

This reverts commit 2e3857c5c75ee5606bfe5352d9863863a9e3a2f9.

JIRA Ticket: SB-8954.