### PR TITLE
mel: add recursive dependency of do_image_complete on do_populate_lic

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -63,6 +63,10 @@ require conf/distro/include/wic-bmap.inc
 # do_populate_lic. Add it for do_image_wic as well.
 do_image_wic[recrdeptask] += "do_populate_lic"
 
+# do_image_complete requires licenses, so add recursive dependency
+# on do_populate_lic
+do_image_complete[recrdeptask] += "do_populate_lic"
+
 # Quadruple the normal. 'du' is not a good way to really see how much
 # space will be needed and fails badly as the fs size grows.
 IMAGE_ROOTFS_EXTRA_SPACE = "40960"


### PR DESCRIPTION
do_image_complete requires the licenses, so we need to make sure that
the do_image_complete task of the image recipe starts after
do_populate_lic is executed for all the packages to be included in
that image.

http://jira.alm.mentorg.com:8080/browse/SB-8951

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>