### PR TITLE
wic-bmap.inc: append wic.bmap to IMAGE_FSTYPES instead of setting _ap…

### DIFF
--- a/meta-mel/conf/distro/include/wic-bmap.inc
+++ b/meta-mel/conf/distro/include/wic-bmap.inc
@@ -6,7 +6,7 @@
 python add_wic_bmap () {
     image_fstypes = d.getVar('IMAGE_FSTYPES', True).split()
     if any(f == 'wic' or f.startswith('wic.') for f in image_fstypes):
-        d.setVar('IMAGE_FSTYPES_append', ' wic.bmap')
+        d.setVar('IMAGE_FSTYPES', " ".join (image_fstypes + ['wic.bmap']))
 }
 add_wic_bmap[eventmask] = "bb.event.ConfigParsed"
 addhandler add_wic_bmap


### PR DESCRIPTION
…pend

    and initramfs typically sets IMAGE_FSTYPES to INITRAMFS_FSTYPES and does not use
    WIC. If _append is used wic.bmap is appended and will fail on empty WKS_FULL_PATH