### PR TITLE
release/setup-environment: fix passing of -b to setup-env

### DIFF
--- a/scripts/release/setup-environment
+++ b/scripts/release/setup-environment
@@ -60,8 +60,10 @@ EOF
                     echo >&2 "-b requires an argument"
                     mel_fail=1
                 else
+                    mel_argnum="$(expr $mel_argnum + 1)"
                     BUILDDIR="$(mel_abspath "$BUILDDIR")"
                 fi
+                continue
                 ;;
             -m)
                 mel_manifest="$(eval printf "%s" "\$$mel_argnum")"
@@ -141,7 +143,7 @@ EOF
             "$scriptdir/scripts/mel-checkout" -X "$BUILDDIR" "$mel_manifest"
         else
             "$scriptdir/scripts/mel-checkout" "$BUILDDIR" "$mel_manifest" $mel_extra_manifests
-        fi && cd "$BUILDDIR" && . ./meta-mentor/setup-environment "$@" -b .
+        fi && cd "$BUILDDIR" && . ./meta-mentor/setup-environment -b . "$@"
         mel_fail=$?
     fi
     unset mel_manifest mel_extra_manifests mel_extra_disabled scriptdir


### PR DESCRIPTION
- If we pass `-b .` after `$@`, then it won't be obeyed when a MACHINE is
  explicitly specified, as getopts won't handle options after arguments
- Since we moved `-b .` to before `$@`, we need to ensure that any explicitly
  passed `-b` isn't passed along to the underlying setup-environment script