### PR TITLE
archive-release: fix non-submodule/worktree handling

### DIFF
--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -184,7 +184,7 @@ def git_archive(subdir, outdir, message=None):
     if os.path.exists(os.path.join(subdir, '.git')):
         parent = subdir
         # Handle .git as a file i.e. submodules
-        parent_git = bb.process.run(['git', 'rev-parse', '--git-dir'], cwd=subdir)[0].rstrip()
+        parent_git = os.path.join(parent, bb.process.run(['git', 'rev-parse', '--git-dir'], cwd=subdir)[0].rstrip())
         # Handle git worktrees
         _commondir = os.path.join(parent_git, 'commondir')
         if os.path.exists(_commondir):


### PR DESCRIPTION
This was causing failures for regular builds.