### PR TITLE
archive-release: handle layerdirs not being in INHERIT

### DIFF
--- a/meta-mel/classes/layerdirs.bbclass
+++ b/meta-mel/classes/layerdirs.bbclass
@@ -1,4 +1,4 @@
-python save_layerdirs() {
+def save_layerdirs(d):
     for layerpath in d.getVar('BBLAYERS', True).split():
         layerconf = os.path.join(layerpath, 'conf', 'layer.conf')
 
@@ -9,6 +9,9 @@ python save_layerdirs() {
 
         for layername in (l.getVar('BBFILE_COLLECTIONS', True) or '').split():
             d.setVar('LAYERDIR_%s' % layername, layerpath)
+
+python cfg_save_layerdirs () {
+    save_layerdirs(d)
 }
-save_layerdirs[eventmask] = "bb.event.ConfigParsed"
-addhandler save_layerdirs
+cfg_save_layerdirs[eventmask] = "bb.event.ConfigParsed"
+addhandler cfg_save_layerdirs

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -61,6 +61,9 @@ python do_archive_mel_layers () {
     import configparser
     import fnmatch
 
+    if 'layerdirs' not in d.getVar('INHERIT').split():
+        save_layerdirs(d)
+
     directories = d.getVar('BBLAYERS').split()
     bitbake_path = bb.utils.which(d.getVar('PATH'), 'bitbake')
     bitbake_bindir = os.path.dirname(bitbake_path)


### PR DESCRIPTION
mel inherits it, so it's not an issue for us -- this is just a correctness fix.