### PR TITLE
Rework release downloads handling to work with git layer delivery

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -131,7 +131,7 @@ def uninative_urls(d):
         chksum = d.getVarFlag("UNINATIVE_CHECKSUM", arch)
         if chksum:
             l.setVar('BUILD_ARCH', arch)
-            srcuri = l.expand("${UNINATIVE_URL}${UNINATIVE_TARBALL};sha256sum=%s;unpack=no;subdir=uninative/%s" % (chksum, chksum))
+            srcuri = l.expand("${UNINATIVE_URL}${UNINATIVE_TARBALL};sha256sum=%s;unpack=no;subdir=uninative/%s;downloadfilename=uninative/%s/${UNINATIVE_TARBALL}" % (chksum, chksum, chksum))
             yield srcuri
 
 release_tar () {

--- a/meta-mel/classes/archive-release-downloads.bbclass
+++ b/meta-mel/classes/archive-release-downloads.bbclass
@@ -76,6 +76,9 @@ python do_archive_release_downloads () {
                 bb.warn('No mirror tarball found for %s, using %s' % (p, local))
 
         oe.path.symlink(local, os.path.join(sources_dir, os.path.basename(local)), force=True)
+        donestamp = local + '.done'
+        if os.path.exists(donestamp):
+            oe.path.symlink(donestamp, os.path.join(sources_dir, os.path.basename(donestamp)), force=True)
 }
 
 do_archive_release_downloads[dirs] = "${WORKDIR}"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -337,8 +337,7 @@ RECIPE_LAYERDIR = "${LAYERDIR_${RECIPE_LAYERNAME}}"
 LAYERDIR_UNKNOWN = 'UNKNOWN'
 
 # Populate a tree of downloads organized by layer
-ARCHIVE_RELEASE_DL_TOPDIR ?= "${DEPLOY_DIR}/release-downloads"
-ARCHIVE_RELEASE_DL_DIR = "${ARCHIVE_RELEASE_DL_TOPDIR}/${RECIPE_LAYERNAME}"
+ARCHIVE_RELEASE_DL_DIR ?= "${DEPLOY_DIR}/release-downloads"
 DL_LICENSE_INCLUDE ?= "*"
 INHERIT += "archive-release-downloads"
 

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -336,13 +336,6 @@ RECIPE_LAYERNAME = "${@bb.utils.get_file_layer('${FILE}', d) or 'UNKNOWN'}"
 RECIPE_LAYERDIR = "${LAYERDIR_${RECIPE_LAYERNAME}}"
 LAYERDIR_UNKNOWN = 'UNKNOWN'
 
-# Support pulling downloads and sstate from inside individual layers. This
-# will let us ship self contained layers to a release without risking file
-# conflicts between them.
-PREMIRRORS_prepend = "${@'.*://.*/.* file://${RECIPE_LAYERDIR}/downloads\n' if '${RECIPE_LAYERDIR}' != 'UNKNOWN' else ''}"
-LAYER_SSTATE_MIRRORS = "${@" ".join('file://%s' % sl for sl in ('%s/sstate-cache' % l for l in '${BBLAYERS}'.split()) if os.path.exists(sl))}"
-SSTATE_MIRROR_SITES_prepend = "${LAYER_SSTATE_MIRRORS} "
-
 # Populate a tree of downloads organized by layer
 ARCHIVE_RELEASE_DL_TOPDIR ?= "${DEPLOY_DIR}/release-downloads"
 ARCHIVE_RELEASE_DL_DIR = "${ARCHIVE_RELEASE_DL_TOPDIR}/${RECIPE_LAYERNAME}"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -323,7 +323,7 @@ INHERIT += "sdk_extra_vars"
 ## MEL Releases {{{1
 # Default image for our installers
 RELEASE_IMAGE ?= "console-image"
-RELEASE_ARTIFACTS ?= "mel_layers templates images downloads probeconfigs"
+RELEASE_ARTIFACTS ?= "mel_layers mel_downloads templates images probeconfigs"
 
 # Apply any release-time srcrev lockdowns for AUTOREV recipes
 include ${MELDIR}/${MACHINE}/conf/autorevs.conf

--- a/meta-mel/lib/bblayers/dl.py
+++ b/meta-mel/lib/bblayers/dl.py
@@ -1,0 +1,201 @@
+# TODO: add an argument to enable/disable dependency traversal vs just the
+# specified recipes
+import argparse
+import logging
+import os
+import sys
+import tempfile
+
+from collections import defaultdict
+
+import bb.command
+import bb.cookerdata
+import bb.fetch
+import bb.utils
+
+from bblayers.common import LayerPlugin
+
+logger = logging.getLogger('bitbake-layers')
+
+
+def plugin_init(plugins):
+    return DownloadsPlugin()
+
+
+def iter_except(func, exception, first=None):
+      """Call a function repeatedly until an exception is raised.
+
+      Converts a call-until-exception interface to an iterator interface.
+      Like __builtin__.iter(func, sentinel) but uses an exception instead
+      of a sentinel to end the loop.
+
+      Examples:
+          bsddbiter = iter_except(db.next, bsddb.error, db.first)
+          heapiter = iter_except(functools.partial(heappop, h), IndexError)
+          dictiter = iter_except(d.popitem, KeyError)
+          dequeiter = iter_except(d.popleft, IndexError)
+          queueiter = iter_except(q.get_nowait, Queue.Empty)
+          setiter = iter_except(s.pop, KeyError)
+
+      """
+      try:
+          if first is not None:
+              yield first()
+          while 1:
+              yield func()
+      except exception:
+          pass
+
+
+class DownloadsPlugin(LayerPlugin):
+    def _get_depgraph(self, targets, task='do_build'):
+        depgraph = None
+
+        self.tinfoil.set_event_mask(['bb.event.DepTreeGenerated', 'bb.command.CommandCompleted', 'bb.event.NoProvider', 'bb.command.CommandFailed', 'bb.command.CommandExit'])
+        if not self.tinfoil.run_command('generateDepTreeEvent', targets, task):
+            logger.critical('Error starting dep tree event command')
+            return 1
+
+        for event in iter_except(lambda: self.tinfoil.wait_event(0.25), Exception):
+            if event is None:
+                continue
+            if isinstance(event, bb.command.CommandCompleted):
+                break
+            elif isinstance(event, bb.command.CommandFailed):
+                return None, 'Error running command: %s' % event.error
+            elif isinstance(event, bb.command.CommandExit):
+                return None, 'Error running command: exited with %s' % event.exitcode
+            elif isinstance(event, bb.event.NoProvider):
+                if event._reasons:
+                    return None, 'Nothing provides %s: %s' % (event._item, event._reasons)
+                else:
+                    return None, 'Nothing provides %s.' % event._item
+            elif isinstance(event, bb.event.DepTreeGenerated):
+                depgraph = event._depgraph
+                break
+            elif isinstance(event, logging.LogRecord):
+                logger.handle(event)
+            else:
+                logger.warning('Unhandled event %s: %s' % (event.__class__.__name__, event))
+        return depgraph, None
+
+    def _localpaths_by_layer(self, data, layer_for_file, mirrortarballs=False):
+        src_uri = data.getVar('SRC_URI').split()
+        fetcher = bb.fetch.Fetch(src_uri, data)
+        urldata = fetcher.ud
+
+        items_by_layer = defaultdict(set)
+        items_files = data.varhistory.get_variable_items_files('SRC_URI', data)
+        for item, filename in items_files.items():
+            ud = urldata[item]
+            decoded = bb.fetch.decodeurl(item)
+            if decoded[0] == 'file':
+                continue
+
+            ud.setup_localpath(data)
+            localpath = ud.localpath
+
+            if mirrortarballs and hasattr(ud, 'mirrortarballs'):
+                dldir = data.getVar('DL_DIR')
+                for mt in ud.mirrortarballs:
+                    mt_abs = os.path.join(dldir, mt)
+                    if os.path.exists(mt_abs):
+                        localpath = mt_abs
+                        break
+
+            layer_name = layer_for_file(filename)
+            if not layer_name:
+                # Possibly it referred to a .inc or similar, but the layer
+                # inclusion pattern was too specific to pick it up, in
+                # that case just use the layer for the recipe itself
+                layer_name = recipe_layer
+            items_by_layer[layer_name].add(os.path.normpath(localpath))
+
+        return items_by_layer
+
+    def _gather_downloads(self, args):
+        if args.task is None:
+            args.task = self.tinfoil.config_data.getVar('BB_DEFAULT_TASK') or 'build'
+        if not args.task.startswith('do_'):
+            args.task = 'do_' + args.task
+
+        depgraph, error = self._get_depgraph(args.targets, args.task)
+        if not depgraph:
+            if error:
+                logger.critical('Failed to get the dependency graph: %s' % error)
+                return 1
+            else:
+                logger.critical('Failed to get the dependency graph')
+                return 1
+
+        tdepends = depgraph['tdepends']
+        layer_data = depgraph['layer-priorities']
+
+        def layer_for_file(filename):
+            for name, pattern, re, priority in layer_data:
+                if re.match(filename):
+                    return name
+
+        fetch_recipes = set()
+        for target in args.targets:
+            if ':' in target:
+                recipe, task = target.split(':', 1)
+            else:
+                recipe, task = target, args.task
+
+            if not task.startswith('do_'):
+                task = 'do_' + task
+
+            if task == 'do_fetch':
+                fetch_recipes.add(recipe)
+
+        for task, taskdeps in tdepends.items():
+            for dep in taskdeps:
+                recipe, deptask = dep.split('.', 1)
+                if deptask == 'do_fetch':
+                    fetch_recipes.add(recipe)
+
+        self.tinfoil.run_command('enableDataTracking')
+
+        items_by_layer = defaultdict(set)
+        for recipe in fetch_recipes:
+            fn = depgraph['pn'][recipe]['filename']
+            real_fn, cls, mc = bb.cache.virtualfn2realfn(fn)
+            recipe_layer = layer_for_file(real_fn)
+            appends = self.tinfoil.get_file_appends(fn)
+            data = self.tinfoil.parse_recipe_file(fn, appendlist=appends)
+
+            for layer, items in self._localpaths_by_layer(data, lambda f: layer_for_file(f) or recipe_layer, args.mirrortarballs).items():
+                items_by_layer[layer] |= items
+
+        # If a given download is used by multiple layers, prefer the lowest
+        # priority, i.e. associating it with oe-core vs some random layer
+        seen = set()
+        layer_priorities = {l: p for l, _, _, p in layer_data}
+        for layer in sorted(layer_priorities, key=lambda i: layer_priorities[i]):
+            for item in sorted(items_by_layer[layer]):
+                if item not in seen:
+                    seen.add(item)
+                    yield layer, item
+
+    def do_gather_downloads(self, args):
+        """Gather up downloads for the specified targets, grouped by layer."""
+        for layer, item in self._gather_downloads(args):
+            print('%s\t%s' % (layer, item))
+
+    def do_dump_downloads(self, args):
+        """Dump downloads by layer into ${TMPDIR}/downloads-by-layer.txt."""
+        items = self._gather_downloads(args)
+        tmpdir = self.tinfoil.config_data.getVar('TMPDIR')
+        with open(os.path.join(tmpdir, 'downloads-by-layer.txt'), 'w') as f:
+            for layer, item in items:
+                f.write('%s\t%s\n' % (layer, item))
+
+    def register_commands(self, sp):
+        common = argparse.ArgumentParser(add_help=False)
+        common.add_argument('--mirrortarballs', '-m', help='show existing mirror tarball paths rather than git clone paths', action='store_true')
+        common.add_argument('--task', '-c', help='specify the task to use when not expicitly specified for a target (default: BB_DEFAULT_TASK or "build")')
+        common.add_argument('targets', nargs='+')
+
+        gather = self.add_command(sp, 'gather-downloads', self.do_gather_downloads, parents=[common], parserecipes=True)
+        dump = self.add_command(sp, 'dump-downloads', self.do_dump_downloads, parents=[common], parserecipes=True)

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_append = ":${@':'.join('%s/../scripts/release' % l for l in '${BBPATH}'.split(':'))}"
 SRC_URI += "\
     file://mel-checkout \
+    file://version-sort \
     file://setup-environment \
 "
 
@@ -159,10 +160,8 @@ python do_archive_mel_layers () {
                 files.append(os.path.relpath(infofn, outdir))
         bb.process.run(['tar', '-cf', os.path.basename(fn) + '.tar'] + files, cwd=outdir)
 
-    envpath = './setup-mel'
-    checkoutpath = './scripts/mel-checkout'
     bb.process.run(['rm', '-r', 'objects'], cwd=outdir)
-    bb.process.run(['tar', '--transform=s,mel-checkout,%s,' % checkoutpath, '--transform=s,setup-environment,%s,' % envpath, '-cf', d.expand('%s/${DISTRO}-scripts.tar' % outdir), 'mel-checkout', 'setup-environment'], cwd=d.getVar('WORKDIR'))
+    bb.process.run(['tar', '--transform=s,^,scripts/,', '--transform=s,scripts/setup-environment,setup-mel,', '-cvf', d.expand('%s/${DISTRO}-scripts.tar' % outdir), 'mel-checkout', 'version-sort', 'setup-environment'], cwd=d.getVar('WORKDIR'))
 }
 do_archive_mel_layers[dirs] = "${S}/do_archive_mel_layers ${S}"
 do_archive_mel_layers[vardeps] += "${GET_REMOTES_HOOK}"

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -3,6 +3,8 @@ SRC_URI += "\
     file://mel-checkout \
     file://version-sort \
     file://setup-environment \
+    \
+    ${@' '.join(uninative_urls(d)) if 'mel_downloads' in '${RELEASE_ARTIFACTS}'.split() else ''} \
 "
 
 inherit layerdirs
@@ -19,6 +21,9 @@ GET_REMOTES_HOOK ?= ""
 INDIVIDUAL_MANIFEST_LAYERS ?= ""
 FORKED_REPOS ?= ""
 PUBLIC_REPOS ?= "${FORKED_REPOS}"
+
+ARCHIVE_RELEASE_DL_DIR ?= "${DL_DIR}"
+ARCHIVE_RELEASE_DL_BY_LAYER_PATH = '${TMPDIR}/downloads-by-layer.txt'
 
 def mel_get_remotes(subdir, d):
     """Any non-public github repo or url including a mentor domain
@@ -56,11 +61,42 @@ def mel_get_remotes(subdir, d):
 
 GET_REMOTES_HOOK_mel ?= "mel_get_remotes"
 
+def get_release_info(layerdir, layername, topdir, oedir, indiv_only=None, indiv_only_toplevel=None, indiv_manifests=None):
+    import fnmatch
+
+    if indiv_only is None:
+        indiv_only = set()
+    if indiv_only_toplevel is None:
+        indiv_only_toplevel = set()
+    if indiv_manifests is None:
+        indiv_manifests = []
+
+    parent = os.path.dirname(layerdir)
+    relpath = None
+    if (layerdir not in indiv_only and
+            not os.path.exists(os.path.join(layerdir, '.git')) and
+            parent not in (oedir, topdir) and
+            os.path.exists(os.path.join(parent, '.git'))):
+        ls = bb.process.run(['git', 'ls-tree', '-d', 'HEAD', layerdir], cwd=parent)
+        if ls:
+            return parent, os.path.basename(parent), False
+
+    if layername and any(fnmatch.fnmatchcase(layername, pat) for pat in indiv_manifests):
+        indiv_layer = True
+    else:
+        indiv_layer = False
+
+    if (layerdir not in indiv_only_toplevel and
+            not layerdir.startswith(topdir + os.sep) and
+            layerdir.startswith(oedir + os.sep)):
+        return layerdir, os.path.relpath(layerdir, oedir), indiv_layer
+    else:
+        return layerdir, os.path.basename(layerdir), indiv_layer
+
 python do_archive_mel_layers () {
     """Archive the layers used to build, as git pack files, with a manifest."""
     import collections
     import configparser
-    import fnmatch
 
     if 'layerdirs' not in d.getVar('INHERIT').split():
         save_layerdirs(d)
@@ -94,26 +130,10 @@ python do_archive_mel_layers () {
     path = d.getVar('PATH') + ':' + ':'.join(os.path.join(l, '..', 'scripts') for l in directories)
     for subdir in directories:
         subdir = os.path.realpath(subdir)
-        parent = os.path.dirname(subdir)
-        relpath = None
-        if (subdir not in indiv_only and
-                not os.path.exists(os.path.join(subdir, '.git')) and
-                parent not in (oedir, topdir) and
-                os.path.exists(os.path.join(parent, '.git'))):
-            ls = bb.process.run(['git', 'ls-tree', '-d', 'HEAD', subdir], cwd=parent)
-            if ls:
-                to_archive.add((parent, os.path.basename(parent)))
-                continue
-
-        if (subdir not in indiv_only_toplevel and
-                not subdir.startswith(topdir + os.sep) and
-                subdir.startswith(oedir + os.sep)):
-            to_archive.add((subdir, os.path.relpath(subdir, oedir)))
-        else:
-            to_archive.add((subdir, os.path.basename(subdir)))
-
         layername = layernames.get(subdir)
-        if layername and any(fnmatch.fnmatchcase(layername, pat) for pat in indiv_manifests):
+        archive_path, dest_path, is_indiv = get_release_info(subdir, layername, topdir, oedir, indiv_only=indiv_only, indiv_only_toplevel=indiv_only_toplevel, indiv_manifests=indiv_manifests)
+        to_archive.add((archive_path, dest_path))
+        if is_indiv:
             indiv_manifest_dirs.add(subdir)
 
     outdir = d.expand('${S}/do_archive_mel_layers')
@@ -247,3 +267,122 @@ def git_archive(subdir, outdir, message=None):
         bb.process.run(['cp', '-f'] + packfiles + [outdir])
         return base, head
 
+def checksummed_downloads(dl_by_layer_fn, dl_by_layer_dl_dir, dl_dir):
+    with open(dl_by_layer_fn, 'r') as f:
+        lines = f.readlines()
+
+    for layer_name, dl_path in (l.rstrip('\n').split('\t', 1) for l in lines):
+        rel_path = os.path.relpath(dl_path, dl_by_layer_dl_dir)
+        if rel_path.startswith('..'):
+            bb.fatal('Download %s (in %s) is not relative to DL_DIR' % (dl_path, dl_by_layer_fn))
+
+        dl_path = os.path.join(dl_dir, rel_path)
+        if not os.path.exists(dl_path):
+            # download is missing, probably excluded for license reasons
+            bb.warn('Download %s does not exist, excluding' % dl_path)
+            continue
+
+        checksum = chksum_dl(dl_path)
+        yield layer_name, dl_path, rel_path, checksum
+
+def uninative_downloads(workdir, dldir):
+    for path in oe.path.find(os.path.join(workdir, 'uninative')):
+        relpath = os.path.relpath(path, workdir)
+        dlpath = os.path.join(dldir, relpath)
+        checksum = chksum_dl(path, dlpath)
+        yield None, path, relpath, checksum
+
+def chksum_dl(path, dlpath=None):
+    import pickle
+
+    if dlpath is None:
+        dlpath = path
+
+    donefile = dlpath + '.done'
+    checksum = None
+    if os.path.exists(donefile):
+        with open(donefile, 'rb') as cachefile:
+            try:
+                checksums = pickle.load(cachefile)
+            except EOFError:
+                pass
+            else:
+                checksum = checksums['sha256']
+
+    if not checksum:
+        checksum = bb.utils.sha256_file(path)
+
+    return checksum
+
+python do_archive_mel_downloads () {
+    import collections
+    import pickle
+    import oe.path
+
+    dl_dir = d.getVar('DL_DIR')
+    archive_dl_dir = d.getVar('ARCHIVE_RELEASE_DL_DIR') or dl_dir
+    dl_by_layer_fn = d.getVar('ARCHIVE_RELEASE_DL_BY_LAYER_PATH')
+    if not os.path.exists(dl_by_layer_fn):
+        bb.fatal('%s does not exist, but mel_downloads requires it. Please run `bitbake-layers dump-downloads` with appropriate arguments.' % dl_by_layer_fn)
+
+    downloads = list(checksummed_downloads(dl_by_layer_fn, dl_dir, archive_dl_dir))
+    downloads.extend(uninative_downloads(d.getVar('WORKDIR'), d.getVar('DL_DIR')))
+    outdir = d.expand('${S}/do_archive_mel_downloads')
+    mandir = os.path.join(outdir, 'manifests')
+    dldir = os.path.join(outdir, 'downloads')
+    bb.utils.mkdirhier(mandir)
+    bb.utils.mkdirhier(os.path.join(mandir, 'extra'))
+    bb.utils.mkdirhier(dldir)
+
+    layer_manifests = {}
+    corebase = os.path.realpath(d.getVar('COREBASE'))
+    oedir = os.path.dirname(corebase)
+    topdir = os.path.realpath(d.getVar('TOPDIR'))
+    indiv_only_toplevel = d.getVar('SUBLAYERS_INDIVIDUAL_ONLY_TOPLEVEL').split()
+    indiv_only = d.getVar('SUBLAYERS_INDIVIDUAL_ONLY').split() + indiv_only_toplevel
+    indiv_manifests = d.getVar('INDIVIDUAL_MANIFEST_LAYERS').split()
+
+    layers = set(i[0] for i in downloads)
+    for layername in layers:
+        if not layername:
+            continue
+
+        layerdir = d.getVar('LAYERDIR_%s' % layername)
+        archive_path, dest_path, is_indiv = get_release_info(layerdir, layername, topdir, oedir, indiv_only=indiv_only, indiv_only_toplevel=indiv_only_toplevel, indiv_manifests=indiv_manifests)
+        if is_indiv:
+            extra_name = dest_path.replace('/', '_')
+            bb.utils.mkdirhier(os.path.join(mandir, 'extra', extra_name))
+            manifestfn = d.expand('%s/extra/%s/${EXTRA_MANIFEST_NAME}-%s.downloads' % (mandir, extra_name, extra_name))
+            layer_manifests[layername] = manifestfn
+
+    main_manifest = d.expand('%s/${MANIFEST_NAME}.downloads' % mandir)
+    manifests = collections.defaultdict(set)
+    for layername, path, dest_path, checksum in downloads:
+        manifestfn = layer_manifests.get(layername) or main_manifest
+        manifests[manifestfn].add((layername, path, dest_path, checksum))
+
+    for manifest, manifest_downloads in manifests.items():
+        with open(manifest, 'w') as f:
+            for _, _, download_path, checksum in manifest_downloads:
+                f.write('%s\t%s\n' % (download_path, checksum))
+
+        bb.process.run(['tar', '-cf', os.path.basename(manifest) + '.tar', os.path.relpath(manifest, outdir)], cwd=outdir)
+
+        for name, path, dest_path, checksum in manifest_downloads:
+            dest = os.path.join(dldir, checksum)
+            oe.path.symlink(path, dest, force=True)
+            bb.process.run(['tar', '-chf', '%s/download-%s.tar' % (dldir, checksum), os.path.relpath(dest, outdir)], cwd=outdir)
+            os.unlink(dest)
+}
+do_archive_mel_downloads[depends] += "${@'${RELEASE_IMAGE}:${FETCHALL_TASK}' if '${RELEASE_IMAGE}' else ''}"
+
+archive_uninative_downloads () {
+    # Ensure that uninative downloads are in ARCHIVE_RELEASE_DL_DIR, since
+    # they're listed in the manifest
+    find uninative -type f | while read -r fn; do
+        mkdir -p "${ARCHIVE_RELEASE_DL_DIR}/$(dirname "$fn")"
+        ln -sf "${DL_DIR}/$fn" "${ARCHIVE_RELEASE_DL_DIR}/$fn"
+    done
+}
+archive_uninative_downloads[dirs] = "${WORKDIR}"
+do_archive_mel_downloads[prefuncs] += "archive_uninative_downloads"

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -192,11 +192,7 @@ if [ -e "$infofn" ]; then
     fi
 fi
 
-for dir in downloads cached-binaries; do
-    if [ -e "$installdir/$dir" ]; then
-        ln -sf "$installdir/$dir" . || :
-    fi
-done
+mkdir -p downloads
 
 for manifest;  do
     printf '%s\t%s\n' "${manifest##*/}" "$manifest"
@@ -248,4 +244,16 @@ done | (
 
             cd - >/dev/null
         done
+
+        downloads="${manifest%.manifest}.downloads"
+        if [ -e "$downloads" ]; then
+            cat "$downloads" | while read -r path checksum; do
+                destdir="$(dirname "$path")"
+                if [ -n "$destdir" ]; then
+                    mkdir -p "downloads/$destdir"
+                fi
+                ln -sf "$installdir/downloads/$checksum" "downloads/$path"
+                touch "downloads/${path}.done"
+            done
+        fi
     done

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -138,7 +138,9 @@ if [ $# -eq 0 ]; then
     usage
 fi
 
-installdir="$(cd "$(dirname "$0")" && pwd -P)/.."
+scriptdir="$(cd "$(dirname "$0")" && pwd -P)"
+installdir="$(dirname "$scriptdir")"
+
 project="$1"
 shift
 
@@ -196,47 +198,54 @@ for dir in downloads cached-binaries; do
     fi
 done
 
-for manifest; do
-    cat "$manifest" | while read -r checkout_path commit remotes; do
-        if [ ! -d "$checkout_path/.git" ]; then
-            git init "$checkout_path"
-        fi
-
-        cd "$checkout_path"
-        echo "$installdir/objects" >.git/objects/info/alternates
-        echo "$commit" >.git/shallow
-
-        echo "$remotes" | tr '\t' '\n' | while IFS== read -r name url; do
-            if [ -n "$name" ]; then
-                if git remote | grep -qxF "$name"; then
-                    git remote set-url "$name" "$url"
-                else
-                    git remote add "$name" "$url"
-                fi
+for manifest;  do
+    printf '%s\t%s\n' "${manifest##*/}" "$manifest"
+done | (
+    read -r base_manifest
+    printf '%s\n' "$base_manifest"
+    "$scriptdir/version-sort"
+) | cut -d"$(printf '\t')" -f2 | \
+    while read -r manifest; do
+        cat "$manifest" | while read -r checkout_path commit remotes; do
+            if [ ! -d "$checkout_path/.git" ]; then
+                git init "$checkout_path"
             fi
-        done
 
-        # Create branches for all manifests, for reference
-        manifestdir="$(dirname "$manifest")"
-        for otherfn in "$manifestdir/"*.manifest; do
-            while read -r other_checkout_path other_commit _; do
-                if [ "$other_checkout_path" = "$checkout_path" ]; then
-                    branch="$(basename "${otherfn%.manifest}")"
-                    if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
-                        git update-ref "refs/heads/$branch" "$other_commit"
+            cd "$checkout_path"
+            echo "$installdir/objects" >.git/objects/info/alternates
+            echo "$commit" >.git/shallow
+
+            echo "$remotes" | tr '\t' '\n' | while IFS== read -r name url; do
+                if [ -n "$name" ]; then
+                    if git remote | grep -qxF "$name"; then
+                        git remote set-url "$name" "$url"
+                    else
+                        git remote add "$name" "$url"
                     fi
-                    echo "$other_commit" >>.git/shallow
                 fi
-            done <"$otherfn"
-        done
-        branch="$(basename "${manifest%.manifest}")"
-        if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
-            git update-ref "refs/heads/$branch" "$commit"
-        fi
-        if [ "$(git rev-parse -q --verify --symbolic-full-name HEAD 2>/dev/null)" != "refs/heads/$branch" ]; then
-            git checkout "$branch"
-        fi
+            done
 
-        cd - >/dev/null
+            # Create branches for all manifests, for reference
+            manifestdir="$(dirname "$manifest")"
+            for otherfn in "$manifestdir/"*.manifest; do
+                while read -r other_checkout_path other_commit _; do
+                    if [ "$other_checkout_path" = "$checkout_path" ]; then
+                        branch="$(basename "${otherfn%.manifest}")"
+                        if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
+                            git update-ref "refs/heads/$branch" "$other_commit"
+                        fi
+                        echo "$other_commit" >>.git/shallow
+                    fi
+                done <"$otherfn"
+            done
+            branch="$(basename "${manifest%.manifest}")"
+            if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
+                git update-ref "refs/heads/$branch" "$commit"
+            fi
+            if [ "$(git rev-parse -q --verify --symbolic-full-name HEAD 2>/dev/null)" != "refs/heads/$branch" ]; then
+                git checkout "$branch"
+            fi
+
+            cd - >/dev/null
+        done
     done
-done

--- a/scripts/release/version-sort
+++ b/scripts/release/version-sort
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+from distutils.version import LooseVersion as Version
+
+lines = sys.stdin.readlines()
+sorted_lines = sorted(lines, key=lambda l: Version(l))
+sys.stdout.write(''.join(sorted_lines))


### PR DESCRIPTION
In the new release setup, we want the ability to install a BSP on top of the baseline, rather than in its own isolated install, so we needed to resolve any issues with file conflicts in the MEL install. For the layers, we chose to ship pack files and set up checkouts using them when the user sets up a build directory. This does the same thing for downloads, but without git. Downloads are named by checksum in the install directory and referenced in downloads manifests which are used to set up `DL_DIR` for the new project directory alongside the layer checkouts.

This does now require use of a new script, `bitbake-layers dump-downloads`, which is used to gather information about what downloads belong to which layers, as this information is required to ensure they're associated with the correct manifests. This will require changes for our automated builds. For example:
```
$ echo 'BB_GENERATE_MIRROR_TARBALLS = "1"' >>conf/auto.conf
$ bitbake -c archive_release_downloads_all archive-release
$ bitbake-layers dump-downloads -m archive-release
$ bitbake archive-release
```

Unfortunately, it was not possible to gather the layer mapping information from within a task in `archive_release_downloads.bbclass`, so this was the only option to get it right.

JIRA: SB-9461, SB-9462, SB-9463