### PR TITLE
qtbase: pull in openssl10, not openssl

### DIFF
--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG_OPENSSL_remove = "openssl"
+PACKAGAECONFIG_OPENSSL_append = "openssl10"


### PR DESCRIPTION
Upstream has bumped the 'openssl' recipe to 1.1.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>