### PR TITLE
packagegroup-tools-benchmark: Remove dbench and tbench in case of non…

### DIFF
--- a/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
+++ b/meta-mel-support/recipes-core/packagegroups/packagegroup-tools-benchmark.bb
@@ -12,3 +12,6 @@ RDEPENDS_${PN} += "\
     tbench \
     tiobench \
 "
+
+RDEPENDS_${PN}_remove = "${@'dbench' if is_incompatible(d, ['dbench'], 'GPL-3.0') else ''}"
+RDEPENDS_${PN}_remove = "${@'tbench' if is_incompatible(d, ['tbench'], 'GPL-3.0') else ''}"


### PR DESCRIPTION
… GPLV3.

* We only have GPLV3 version of tbench and dbench. So when we set
  INCOMPATIBLE_LICENSE = "GPLv3" this recipe complaint that tbench and
  dbench has GPLV3 license so this can not be built. Removed these packages
  from packagegroup in case of incompatible license set to GPLv3.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>