### PR TITLE
init-boot.sh: fix runtime warnings

### DIFF
--- a/meta-mel/recipes-core/initrdscripts/files/init-boot.sh
+++ b/meta-mel/recipes-core/initrdscripts/files/init-boot.sh
@@ -2,8 +2,8 @@
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
-mkdir /proc
-mkdir /sys
+mkdir -p /proc
+mkdir -p /sys
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 


### PR DESCRIPTION
Following warnings are observed on booting
core-image-minimal-initramfs:
mkdir: can't create directory '/proc': File exists
mkdir: can't create directory '/sys': File exists
This commit fixes these warnings.

Jira ID: http://jira.alm.mentorg.com:8080/browse/SB-9640

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>