### PR TITLE
mel: add default for SOURCERY_VERSION

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -305,7 +305,8 @@ IMAGE_CLASSES += "${ADE_IMAGE_CLASS}"
 
 # Add extra bits to the SDK/ADE environment setup scripts for CodeBench
 gdb_serverpath ?= "${bindir}/gdbserver"
-SOURCERY_BASE_VERSION = "${@'${SOURCERY_VERSION}'.split('-', 1)[0] if 'SOURCERY_VERSION' in d else ''}"
+SOURCERY_VERSION ?= ""
+SOURCERY_BASE_VERSION = "${@'${SOURCERY_VERSION}'.split('-', 1)[0]}"
 EXTRA_SDK_VARS += "\
     MACHINE \
     DISTRO \


### PR DESCRIPTION
We need SOURCERY_BASE_VERSION to be expandable so the sdk can be built
properly, whether SOURCERY_VERSION is defined or not.

JIRA: SB-8875