### PR TITLE
setup-mel-builddir: use ${TOPDIR} in BBLAYERS

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -150,7 +150,7 @@ configure_for_machine () {
         echo >&2 "Error in execution of bb-determine-layers, aborting"
         exit 1
     fi
-    sed 's,^,    ,; s,$, \\,' <$layersfile >>$BUILDDIR/conf/bblayers.conf
+    sed -e "s#^$BUILDDIR/#\${TOPDIR}/#g;" -e 's,^,    ,; s,$, \\,' <$layersfile >>$BUILDDIR/conf/bblayers.conf
     rm -f $layersfile
     echo '"' >> $BUILDDIR/conf/bblayers.conf
     unset layersfile


### PR DESCRIPTION
This improves readability, by using ${TOPDIR} rather than a full absolute path
for layers relative to TOPDIR. It should ideally also adjust paths relative to
COREBASE/OEROOT/MELDIR, but that's less of a concern given the new mel
installer setup, and adding more generic determination of relative paths would
add more complexity to the scripts.