### PR TITLE
archive-release: Fix prepare_release exiting with code 128.

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -331,20 +331,22 @@ do_prepare_release () {
                 done
                 cd - >/dev/null
                 layerpath="$(sed -n "s/^$name|//p" layermap.txt)" || exit 1
-                layerroot="$(repo_root "$layerpath")"
-                layerbase="${layerroot##*/}"
-                if echo "${LAYERS_OWN_DOWNLOADS}" | grep -Eq "\<$name\>"; then
-                    layer_relpath="${layerpath#${layerroot}/}"
-                    if [ "$layer_relpath" = "$layerroot" ]; then
-                        layer_relpath=$layerbase
+                if [ "${layerpath}" != "" ]; then 
+                    layerroot="$(repo_root "$layerpath")"
+                    layerbase="${layerroot##*/}"
+                    if echo "${LAYERS_OWN_DOWNLOADS}" | grep -Eq "\<$name\>"; then
+                        layer_relpath="${layerpath#${layerroot}/}"
+                        if [ "$layer_relpath" = "$layerroot" ]; then
+                            layer_relpath=$layerbase
+                        else
+                            layer_relpath=$layerbase/$layer_relpath
+                        fi
+                        release_tar "--transform=s,^downloads/$name,$layer_relpath/downloads," -chf \
+                                deploy/$name-downloads.tar${BINARY_ARTIFACTS_COMPRESSION} downloads/$name
                     else
-                        layer_relpath=$layerbase/$layer_relpath
+                        release_tar "--transform=s,^downloads/$name,downloads," -rhf \
+                                deploy/$layerbase-downloads.tar${BINARY_ARTIFACTS_COMPRESSION} downloads/$name
                     fi
-                    release_tar "--transform=s,^downloads/$name,$layer_relpath/downloads," -chf \
-                            deploy/$name-downloads.tar${BINARY_ARTIFACTS_COMPRESSION} downloads/$name
-                else
-                    release_tar "--transform=s,^downloads/$name,downloads," -rhf \
-                            deploy/$layerbase-downloads.tar${BINARY_ARTIFACTS_COMPRESSION} downloads/$name
                 fi
             done
             if [ -n "${UNINATIVE_TARBALL}" ]; then


### PR DESCRIPTION
* There was a scenario where first archive-release was excuted with
  meta-virtualization. First execution ran fine. The build was
  reconfigured and meta-virtualization was removed from setup-environment
  command. This was done to pull non GPLv3 sources and meta-virtualization
  does not have non GPLv3 recipes. When archiev-release was executed
  prepare_release exited with code 128. After enabling a log it was found
  that virtualization-layer was present in downloads it was not there in
  layermap.txt as it was remove from build configuration. Following log
  was received.

| + touch downloads/virtualization-layer/gitshallow_github.com.docker.
distribution.git_28602af-1_docker.1.13.tar.gz.done
| + read source
| + cd downloads/virtualization-layer
| + cd -
| ++ sed -n 's/^virtualization-layer|//p' layermap.txt
| + layerpath=
| ++ repo_root ''
| +++ cd
| +++ git rev-parse --show-toplevel
| ++ git_root=
| + layerroot=
| + bb_exit_handler
| + ret=128
| + case $ret in

  Follwing error was shown

 WARNING: /data/noor/mel/meif/build-advantech-meif-all/tmp/work/
 uno_2473g_mel-mel-linux/archive-release/1.0-r0/temp/
 run.do_prepare_release.19987:1 exit 128 from 'layerroot="$(repo_root "$layerpath")"'
 exit 128
 ERROR: Function failed: do_prepare_release (log file is located
 at /data/noor/mel/meif/build-advantech-meif-all/tmp/work/
 uno_2473g_mel-mel-linux/archive-release/1.0-r0/temp/log.do_prepare_release.19987)

*  Add a check to further process layerpath if it get value from layermap.txt.
* SBRM-867

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>