### PR TITLE
krb5 dependency fix

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-connectivity/krb5/krb5_1.15.1.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-connectivity/krb5/krb5_1.15.1.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "bison-native"


### PR DESCRIPTION
* yacc utility is required to build some package
* added bison-native package which contain yacc utility

Signed-off-by: sajjad238 <sajjad_ahmed@mentor.com>