### PR TITLE
python3-jsonschema: dep on python3-vcversioner-native

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python3-jsonschema_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python3-jsonschema_%.bbappend
@@ -1,0 +1,2 @@
+DEPENDS += "python3-vcversioner-native"
+DEPENDS_remove = "python3-vcversioner"


### PR DESCRIPTION
vcversioner is needed at build time, so we need to depend on the native recipe
to be able to import the module, not the target recipe.

JIRA: MEIF-855