### PR TITLE
local.conf.append: Introduce MEL_ENABLE_JTAG_SUPPORT flag

### DIFF
--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -7,3 +7,9 @@
 # build gets its own identifier, so is self-contained already.
 # Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}
 #ADE_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}.customized"
+
+# Uncomment The following flag to enable certain changes required for Linux 
+# Kernel debugging through JTAG interface. 
+# Note: This flag may not be implemented for some BSPs and will have no affect
+# in those cases.
+# MEL_ENABLE_JTAG_SUPPORT = "1"


### PR DESCRIPTION
Adding this flag to common local.conf.append in meta-mel for future use, in Dogwood-Async3, this flag would be added via bsp-specific local.conf.append files.