### PR TITLE
deploy-license-manifest.bbclass: use IMGDEPLOYDIR

### DIFF
--- a/meta-mel/classes/deploy-license-manifest.bbclass
+++ b/meta-mel/classes/deploy-license-manifest.bbclass
@@ -3,14 +3,14 @@ IMAGE_POSTPROCESS_COMMAND += "link_license_manifest;"
 
 deploy_license_manifest () {
     if [ -e "${LICENSE_DIRECTORY}/${IMAGE_NAME}/license.manifest" ]; then
-        cp ${LICENSE_DIRECTORY}/${IMAGE_NAME}/license.manifest ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest
-        sed -n '/PACKAGE NAME/{: start; /^ *$/b done; /LICENSE:/{s/: /: "/; s/$/"/;}; s/^.*://; H; n; b start; : done; x; s/^[\n ]*//; s/ *\n */,/g; p}' ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest >${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest.csv
+        cp ${LICENSE_DIRECTORY}/${IMAGE_NAME}/license.manifest ${IMGDEPLOYDIR}/${IMAGE_NAME}.license_manifest
+        sed -n '/PACKAGE NAME/{: start; /^ *$/b done; /LICENSE:/{s/: /: "/; s/$/"/;}; s/^.*://; H; n; b start; : done; x; s/^[\n ]*//; s/ *\n */,/g; p}' ${IMGDEPLOYDIR}/${IMAGE_NAME}.license_manifest >${IMGDEPLOYDIR}/${IMAGE_NAME}.license_manifest.csv
     fi
 }
 
 link_license_manifest () {
-    if [ -e "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.license_manifest" ]; then
-        ln -sf ${IMAGE_NAME}.license_manifest ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest
-        ln -sf ${IMAGE_NAME}.license_manifest.csv ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.license_manifest.csv
+    if [ -e "${IMGDEPLOYDIR}/${IMAGE_NAME}.license_manifest" ]; then
+        ln -sf ${IMAGE_NAME}.license_manifest ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.license_manifest
+        ln -sf ${IMAGE_NAME}.license_manifest.csv ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.license_manifest.csv
     fi
 }


### PR DESCRIPTION
The upstream commit
http://cgit.openembedded.org/openembedded-core/commit?id=6d969bacc718e21a5246d4da9bf9639dcae29b02
changed the image deployment directory from DEPLOY_IMAGE_DIR
to IMGDEPLOYDIR so we need to conform to the change for
license manifest deployment in order to cope with issues
such as a non-existent deployment dir when license deployment
is done.

Signed-off-by: Awais Belal <awais_belal@mentor.com>