### PR TITLE
dhcp: fix build issue with libxml2 support

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/dhcp/dhcp/0001-dhcp-correct-the-intention-for-xml2-lib-search.patch
+++ b/meta-mentor-staging/recipes-connectivity/dhcp/dhcp/0001-dhcp-correct-the-intention-for-xml2-lib-search.patch
@@ -1,0 +1,34 @@
+From 98ade56cd632c7355fc2b3c40e24d8d81355df25 Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Wed, 25 Oct 2017 19:42:37 +0500
+Subject: [PATCH] dhcp: correct the intention for xml2 lib search
+
+A missing case breaks the build when libxml2 is
+required and found appropriately. The third argument
+to the function AC_SEARCH_LIB is action-if-found which
+was mistakenly been used for the case where the library
+is not found and hence breaks the configure phase
+where it shoud actually pass.
+We now pass on silently when action-if-found is
+executed.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1684df1..f67bbb6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -723,7 +723,7 @@ AC_ARG_WITH(libxml2,
+ 	with_libxml2="$withval", with_libxml2="no")
+ 
+ if test x$with_libxml2 != xno; then
+-    AC_SEARCH_LIBS(xmlTextWriterStartElement, [xml2],
++    AC_SEARCH_LIBS(xmlTextWriterStartElement, [xml2],,
+                    [if test x$with_libxml2 != xauto; then
+                         AC_MSG_FAILURE([*** Cannot find xmlTextWriterStartElement with -lxml2 and libxml2 was requested])
+                     fi])
+-- 
+2.7.4

--- a/meta-mentor-staging/recipes-connectivity/dhcp/dhcp_4.3.4.bbappend
+++ b/meta-mentor-staging/recipes-connectivity/dhcp/dhcp_4.3.4.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://0001-dhcp-correct-the-intention-for-xml2-lib-search.patch"


### PR DESCRIPTION
A missing case breaks the build when libxml2 is
required and found appropriately. The third argument
to the function AC_SEARCH_LIB is action-if-found which
was mistakenly been used for the case where the library
is not found and hence breaks the configure phase
where it shoud actually pass.
We now pass on silently when action-if-found is
executed.
Already accepted upstream: http://cgit.openembedded.org/openembedded-core/commit/?id=a17f3ec910366e9e7551fa24fbc07929b9584341

JIRA: SB-10251

Signed-off-by: Awais Belal <awais_belal@mentor.com>