### PR TITLE
setup-{environment,mel-builddir}: use :- not - until we rework the logic

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -9,9 +9,9 @@
 DISTRO="${DISTRO:-mel}"
 CORELAYERS="${CORELAYERS:-core mel-support mentor-staging}"
 if [ "${DISTRO}" != "mel-lite" ]; then
-    OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private}"
+    OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private}"
 fi
-EXTRAMELLAYERS="${EXTRAMELLAYERS-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery gplv2}"
+EXTRAMELLAYERS="${EXTRAMELLAYERS:-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery gplv2}"
 layer_priority_overrides="openembedded-layer=1"
 
 

--- a/setup-environment
+++ b/setup-environment
@@ -39,9 +39,9 @@ else
     done
 
     if [ "${DISTRO}" = "mel-lite" ]; then
-        OPTIONALLAYERS="${OPTIONALLAYERS-tracing-layer}"
+        OPTIONALLAYERS="${OPTIONALLAYERS:-tracing-layer}"
     else
-        OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private tracing-layer}"
+        OPTIONALLAYERS="${OPTIONALLAYERS:-mentor-private tracing-layer}"
     fi
     EXCLUDEDLAYERS="$EXCLUDEDLAYERS"
     # Customer directory layers handling (e.g. <customername>-custom)


### PR DESCRIPTION
These vars are always set by setup-environment right now, so changing to
- resulted in not including layers we want to include by default. I intend to
shortly refactor setup-environment similar to how I recently refactored
setup-mel, we can fix this issue after that.