### PR TITLE
Fixed overlapping mounts causing unmount and installation failures

### DIFF
--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf/mount_modified.sh
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf/mount_modified.sh
@@ -19,9 +19,16 @@ done
 
 automount() {	
 	name="`basename "$DEVNAME"`"
-        if [ -z ${ID_FS_LABEL} ]; then
-		#Lets use UUID as the LABEL, as it will be unique for the $DEVNAME
-		ID_FS_LABEL=`/sbin/blkid | grep $DEVNAME | awk {'print $2'} | tr '=|"' ' ' | awk {'print $2'}`
+
+	# Get the LABEL or PARTLABEL
+        LABEL=`/sbin/blkid | grep "$DEVNAME" | grep -o 'LABEL=".*"' | cut -d '"' -f2`
+        # If the $DEVNAME does not have a LABEL or a PARTLABEL
+        if [ -z "$LABEL" ]; then
+                # Set the mount location dir name to $name e.g. sda (that would keep it unique)
+                ID_FS_LABEL="${name}"
+        else
+                # Set the mount location dir name to LABEL appended with $name e.g. sda
+                ID_FS_LABEL="${LABEL}-${name}"
         fi
 
 	! test -d "/run/media/${ID_FS_LABEL}" && mkdir -p "/run/media/${ID_FS_LABEL}"


### PR DESCRIPTION
The automounter udev script attempts to mount the block devices under
/run/media/partition-label. If two devices have same partition-label,
they will be mounted on the same location.

This causes two types of known issues:

1. MEL installation fails if a MEL image is already installed on a
media other than where attempted to install such as HDD/eMMC/SSD/USB
that is attached during installation.

2. Unmount fails on a device if attempted using the device node
e.g. "/dev/sda1" with the 'umount' command.

These changes fix such issues.

Associated issues: INTAMDDET-2258, INTAMDDET-2259

Signed-off-by: Arsalan-Awan <Arsalan_Awan@mentor.com>