### PR TITLE
gcc: drop TARGET_SYS workaround

### DIFF
--- a/meta-mentor-staging/recipes-devtools/gcc/gcc_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/gcc/gcc_%.bbappend
@@ -1,4 +1,1 @@
-# Align TARGET_SYS and TARGET_PREFIX to avoid binary links which include both.
-TARGET_SYS := "${@TARGET_PREFIX[:-1]}"
-
 DEPENDS += "flex-native"


### PR DESCRIPTION
This is no longer needed, as the external toolchain no longer sets
TARGET_PREFIX.