### PR TITLE
gcc: fix target GCC being built for 32-bit x86 targets

### DIFF
--- a/meta-mentor-staging/recipes-devtools/gcc/gcc_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/gcc/gcc_%.bbappend
@@ -1,2 +1,4 @@
-# Align TARGET_SYS and TARGET_PREFIX to avoid binary links which include both.
-TARGET_SYS := "${@TARGET_PREFIX[:-1]}"
+do_install_append() {
+    # we end up with some weird pollution from cross-toolchain, remove them
+    rm -f ${D}${bindir}/${TARGET_SYS}-${TARGET_PREFIX}*
+}


### PR DESCRIPTION
The fix for preventing unused duplicate toolchain files for gcc, g++,
gcc-nm, gcc-ar and gcc-ranlib actually caused the x86 target toolchain
to be built so that it was able to produce 32-bit binaries only. This is
because the value passed to the tootlchain configuration option --target
ended being i686-pc-linux-gnu, inherited from the external toolchain.

Rather than trying to fix the values of TARGET_SYS and TARGET_PREFIX
from the mix of external toolchain and built toolchain, intead just
remove unused files from the rootfs. They are all of the name format:

    ${TARGET_SYS}-${TARGET_PREFIX}-<executable>

are the only files with that name format in the /usr/bin directory, and
are copies of existing files with the correct names from the same
directory.

Signed-off-by: Benjamin Walsh <Benjamin_Walsh@mentor.com>