### PR TITLE
Add initial production-image, development-image

### DIFF
--- a/meta-mel-support/recipes-core/images/development-image.bb
+++ b/meta-mel-support/recipes-core/images/development-image.bb
@@ -1,0 +1,9 @@
+require recipes-core/images/mel-image.inc
+
+SUMMARY = "A development/debugging image that fully supports the target \
+device hardware."
+
+IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks tools-profile"
+IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT}"
+IMAGE_FEATURES_DISABLED_DEVELOPMENT ?= ""
+IMAGE_FEATURES_remove = "${IMAGE_FEATURES_DISABLED_DEVELOPMENT}"

--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -1,0 +1,13 @@
+# We want a package manager in our base images
+IMAGE_FEATURES += "package-management"
+
+# We want libgcc to always be available, even if nothing needs it, as its size
+# is minimal, and it's often needed by third party (or QA) binaries
+IMAGE_INSTALL_append_mel = " libgcc"
+
+LICENSE = "MIT"
+
+inherit core-image image-sanity-incompatible
+
+IMAGE_FEATURES .= "${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
+IMAGE_INSTALL += " quota connman"

--- a/meta-mel-support/recipes-core/images/production-image.bb
+++ b/meta-mel-support/recipes-core/images/production-image.bb
@@ -1,0 +1,14 @@
+require recipes-core/images/mel-image.inc
+
+# By default, do not allow incompatibly-licensed packages in the
+# production-image, even when whitelisted. ALLOWED_INCOMPATIBLE_WHITELISTED
+# may be used to explicitly allow individual packages.
+ALLOW_ALL_INCOMPATIBLE_WHITELISTED = "0"
+
+SUMMARY = "A production image that fully supports the target device \
+hardware."
+
+IMAGE_FEATURES_PRODUCTION ?= ""
+IMAGE_FEATURES = "${IMAGE_FEATURES_PRODUCTION}"
+IMAGE_FEATURES_DISABLED_PRODUCTION ?= "debug-tweaks codebench-debug tools-profile"
+IMAGE_FEATURES_remove = "${IMAGE_FEATURES_DISABLED_PRODUCTION}"

--- a/meta-mel/classes/image-sanity-incompatible.bbclass
+++ b/meta-mel/classes/image-sanity-incompatible.bbclass
@@ -1,0 +1,79 @@
+# Add an image QA check which fails if any packages were installed which have
+# incompatible licenses, with a variable to control whether whitelisted
+# recipes/packages are allowed in the image.
+#
+# Usage: add to IMAGE_CLASSES or inherit directly in an image recpe.
+#
+# This acts both as a final sanity check to make sure incompatibly
+# licensed packages don't end up in the image (though they shouldn't
+# unless whitelisted already), and a way to create images which never
+# allow gplv3 packages and others which do, i.e. production vs
+# development.
+
+ALLOW_ALL_INCOMPATIBLE_WHITELISTED ?= "1"
+ALLOWED_INCOMPATIBLE_WHITELISTED ?= ""
+
+IMAGE_INCOMPATIBLE_MESSAGE = "Packages with incompatible licenses were installed: \
+%s. See INCOMPATIBLE_LICENSE. To allow this, either set ALLOW_ALL_INCOMPATIBLE_WHITELISTED \
+to 1 or add the packages to ALLOWED_INCOMPATIBLE_WHITELISTED"
+
+IMAGE_QA_COMMANDS += "image_check_incompatible_packages"
+python image_check_incompatible_packages () {
+    import oe.license
+    import oe.packagedata
+    manifest = d.getVar('IMAGE_MANIFEST')
+    pkgnames = []
+    with open(manifest, 'r') as f:
+        for l in f.readlines():
+            pkgnames.append(l.split()[0])
+
+    bad_licenses = (d.getVar('INCOMPATIBLE_LICENSE') or '').split()
+    if not bad_licenses:
+        return
+
+    bad_licenses = [canonical_license(d, l) for l in bad_licenses]
+    bad_licenses = expand_wildcard_licenses(d, bad_licenses)
+
+    whitelist = []
+    for lic in bad_licenses:
+        spdx_license = return_spdx(d, lic)
+        for w in ["LGPLv2_WHITELIST_", "WHITELIST_"]:
+            whitelist.extend((d.getVar(w + lic) or "").split())
+            if spdx_license:
+                whitelist.extend((d.getVar(w + spdx_license) or "").split())
+
+    allow_all_whitelisted = bb.utils.to_boolean(d.getVar('ALLOW_ALL_INCOMPATIBLE_WHITELISTED'))
+    allowed_whitelisted = d.getVar('ALLOWED_INCOMPATIBLE_WHITELISTED').split()
+
+    incompatible_packages = []
+    pkgdatadir = d.getVar('PKGDATA_DIR')
+    for pkgname in sorted(pkgnames):
+        pkginfo = os.path.join(pkgdatadir, 'runtime', pkgname)
+        pkginfor = os.path.join(pkgdatadir, 'runtime-reverse', pkgname)
+        pkgdata = oe.packagedata.read_pkgdatafile(pkginfor)
+        pkgdata.update(oe.packagedata.read_pkgdatafile(pkginfo))
+
+        pn = pkgdata['PN']
+        if (pn in whitelist and
+                (allow_all_whitelisted or pn in allowed_whitelisted)):
+            # License is irrelevent if it'll be allowed anyway, skip
+            continue
+
+        for k, v in pkgdata.items():
+            if k.startswith('PKG_') and v == pkgname:
+                # Renamed (i.e. debian.bbclass), get the original name
+                pkgname = k[4:]
+
+        if 'LICENSE' not in pkgdata and 'LICENSE_' + pkgname in pkgdata:
+            pkgdata['LICENSE'] = pkgdata['LICENSE_' + pkgname]
+        license = pkgdata['LICENSE']
+
+        l = d.createCopy()
+        l.setVar('LICENSE', license)
+        if incompatible_license(l, bad_licenses):
+            incompatible_packages.append(pkgname)
+
+    if incompatible_packages:
+        message = d.getVar('IMAGE_INCOMPATIBLE_MESSAGE')
+        raise oe.utils.ImageQAFailed(message % ' '.join(incompatible_packages), 'image_check_incompatible_packages')
+}

--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -1,3 +1,10 @@
+# Image features for development-image
+IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks codebench-debug ssh-server-openssh tools-profile"
+
+# Image features for production-image
+IMAGE_FEATURES_PRODUCTION ?= ""
+IMAGE_FEATURES_DISABLED_PRODUCTION ?= "${IMAGE_FEATURES_DEVELOPMENT} ssh-server-dropbear"
+
 # Uncomment to set a site name (shown in CodeBench) for the ADE
 # Default: ADE for ${ADE_IDENTIFIER}
 #ADE_SITENAME ?= "My Company's ADE for ${ADE_IDENTIFIER}"


### PR DESCRIPTION
Also adds and uses image-sanity-incompatible.bbclass, which may be
upstream-suitable, depending on interest.

Further improvements are likely, for example a default non-root user, prevent
root login at console, etc.