### PR TITLE
ConsoleKit: ensure fs is still mounted when logging stop/restart

### DIFF
--- a/meta-mel/recipes-support/consolekit/consolekit/0001-Ensure-filesystems-are-still-mounted-when-consolekit.patch
+++ b/meta-mel/recipes-support/consolekit/consolekit/0001-Ensure-filesystems-are-still-mounted-when-consolekit.patch
@@ -1,0 +1,25 @@
+--- a/data/console-kit-log-system-restart.service.in
++++ b/data/console-kit-log-system-restart.service.in
+@@ -2,7 +2,7 @@
+ Description=Console System Reboot Logging
+ DefaultDependencies=no
+ After=sysinit.target console-kit-log-system-start.service
+-Before=shutdown.target
++Before=shutdown.target umount.target
+ 
+ [Service]
+ Type=oneshot
+--- a/data/console-kit-log-system-stop.service.in
++++ b/cdata/onsole-kit-log-system-stop.service.in
+@@ -2,7 +2,7 @@
+ Description=Console System Shutdown Logging
+ DefaultDependencies=no
+ After=sysinit.target console-kit-log-system-start.service
+-Before=shutdown.target
++Before=shutdown.target umount.target
+ 
+ [Service]
+ Type=oneshot
+-- 
+2.7.4
+

--- a/meta-mel/recipes-support/consolekit/consolekit_%.bbappend
+++ b/meta-mel/recipes-support/consolekit/consolekit_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " \
+    file://0001-Ensure-filesystems-are-still-mounted-when-consolekit.patch \
+"


### PR DESCRIPTION
/var/volatile could have disappeared, and that is where ConsoleKit logs
its start/stop/restart entries.

Signed-off-by: Benjamin Walsh <Benjamin_Walsh@mentor.com>