### PR TITLE
volatile-binds: let user-data handle ROOT_HOME bind when enabled

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -143,8 +143,16 @@ PACKAGECONFIG_REMOVE_pn-mesa-demos = "glx"
 PACKAGECONFIG_REMOVE_pn-plymouth = "initrd"
 
 # Ensure we have the writable paths we need in a read-only rootfs
-VOLATILE_BINDS_append = "\
+
+# If the user-data feature is in the picture, it takes over ownership of
+# determining what to do with ROOT_HOME and bind mounts.
+# See logic for USER_DATA_BINDS in meta-mentor-swupdate/conf/local.conf.append.
+
+ROOT_HOME_BIND = "\
     /var/volatile/root-home ${ROOT_HOME}\n\
+"
+VOLATILE_BINDS_append = "\
+    ${@bb.utils.contains('COMBINED_FEATURES', 'user-data', '', d.getVar('ROOT_HOME_BIND', True), d)} \
 "
 ## }}}1
 ## Inherits {{{1


### PR DESCRIPTION
MEL was always asking for a bind mount on ${ROOT_HOME} (/home/root by
default). The user-data feature enabled by swupdate is asking for a bind
mount on /home, but is also making sure that, if ${ROOT_HOME} is
/home/root, to not ask for a second bind mount on /home/root. However,
it does nothing to prevent a bind mount on both /home and /home/root.

What can happen is that /home/root gets a bind mount first, then /home
gets a bind mount. When this happens, the var-volatile* services handle
the mounting part correctly, copying data from the mounted directory to
the mount point as necessary, and the operation works as expected.

However, the umounting is broken in this case. The system thinks that
/home/root is still a mount point, while it is now a directory under the
/home mount point. When trying to unmount everything during shutdown,
unmounting of /home/root fails since it is now simply a directory.

To prevent this, MEL now leaves the logic of handling /home and
/home/root bind mounts to the user-data feature when it is present.

Signed-off-by: Benjamin Walsh <Benjamin_Walsh@mentor.com>