### PR TITLE
initrdscripts/init-live.sh: Fixed mounts fail to move to real root fs

### DIFF
--- a/meta-mentor-staging/recipes-core/initrdscripts/files/0001-initrdscripts-init-live.sh-Fixed-mounts-fail-to-move.patch
+++ b/meta-mentor-staging/recipes-core/initrdscripts/files/0001-initrdscripts-init-live.sh-Fixed-mounts-fail-to-move.patch
@@ -1,0 +1,65 @@
+From f8d1c573897825f8ffcc68263b9379ca9c2f775c Mon Sep 17 00:00:00 2001
+From: "Arsalan H. Awan" <Arsalan_Awan@mentor.com>
+Date: Fri, 20 Apr 2018 19:06:48 +0500
+Subject: [PATCH] initrdscripts/init-live.sh: Fixed mounts fail to move to real
+ root fs
+
+When there are spaces in the mount points of devices e.g.:
+
+ a partition mounted at "/run/media/My Root Partition-sda1",
+
+the initrd fails to move such mount points over to the
+corresponding directories at /media under the real root filesystem,
+and the mount points would appear at the same location as they were
+mounted on when detected by initrd, for example:
+ here: "/run/media/My Root Partition-sda1"
+ instead of here: "/media/My Root Partition-sda1"
+
+This causes issues such as:
+
+  * The disks/partitions cannot be formated with any filesystem
+    using e.g. mkfs.ext4 or mke2fs in general. When tried to do so
+    by making sure the device is not mounted, it failed with
+    errors such as:
+
+    > /dev/sda1 is apparently in use by the system; will not make a
+      filesystem here!
+    > /dev/sda1: Device or resource busy while setting up superblock
+
+  * The read/write operations become extremely slow. e.g. Under testing,
+    it took approx. 2 hours just to copy 700 MB of data to the partition,
+    and it took more than 40 minutes to delete that data from it.
+    Same operations took under 5 minutes on a partition that had no
+    spaces in its mount point (or that was successfully moved to real
+    root by initrd and appeared under /media instead of /run/media).
+
+This commit fixes such issues by quoting the arguments of failing mount
+move commands and by parsing OCT or HEX encoded special characters
+such as spaces to ASCII characters in the mount points.
+
+Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>
+---
+ init-live.sh | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/init-live.sh b/init-live.sh
+index 441b41c9d6..e58df12061 100644
+--- a/init-live.sh
++++ b/init-live.sh
+@@ -91,8 +91,11 @@ boot_live_root() {
+     # Move the mount points of some filesystems over to
+     # the corresponding directories under the real root filesystem.
+     for dir in `awk '/\/dev.* \/run\/media/{print $2}' /proc/mounts`; do
+-        mkdir -p  ${ROOT_MOUNT}/media/${dir##*/}
+-        mount -n --move $dir ${ROOT_MOUNT}/media/${dir##*/}
++        # Parse any OCT or HEX encoded chars such as spaces
++        # in the mount points to actual ASCII chars
++        dir=`printf $dir`
++        mkdir -p "${ROOT_MOUNT}/media/${dir##*/}"
++        mount -n --move "$dir" "${ROOT_MOUNT}/media/${dir##*/}"
+     done
+     mount -n --move /proc ${ROOT_MOUNT}/proc
+     mount -n --move /sys ${ROOT_MOUNT}/sys
+-- 
+2.11.1
+

--- a/meta-mentor-staging/recipes-core/initrdscripts/initramfs-live-boot_1.0.bbappend
+++ b/meta-mentor-staging/recipes-core/initrdscripts/initramfs-live-boot_1.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://0001-initrdscripts-init-live.sh-Fixed-mounts-fail-to-move.patch"


### PR DESCRIPTION
When there are spaces in the mount points of devices e.g.:

 a partition mounted at "/run/media/My Root Partition-sda1",

the initrd fails to move such mount points over to the
corresponding directories at /media under the real root filesystem,
and the mount points would appear at the same location as they were
mounted on when detected by initrd, for example:
 here: "/run/media/My Root Partition-sda1"
 instead of here: "/media/My Root Partition-sda1"

This causes issues such as:

  * The disks/partitions cannot be formated with any filesystem
    using e.g. mkfs.ext4 or mke2fs in general. When tried to do so
    by making sure the device is not mounted, it failed with
    errors such as:

    > /dev/sda1 is apparently in use by the system; will not make a
      filesystem here!
    > /dev/sda1: Device or resource busy while setting up superblock

  * The read/write operations become extremely slow. e.g. Under testing,
    it took approx. 2 hours just to copy 700 MB of data to the partition,
    and it took more than 40 minutes to delete that data from it.
    Same operations took under 5 minutes on a partition that had no
    spaces in its mount point (or which was successfully moved to real
    root by initrd and appeared under /media instead of /run/media).

This commit fixes such issues by quoting the arguments of failing mount
move commands and by parsing OCT or HEX encoded special characters
such as spaces to ASCII characters in the mount points.

Associated issue: INTAMDDET-2361

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>