### PR TITLE
volatile-binds: fix list when root-home is last in list

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -146,13 +146,12 @@ PACKAGECONFIG_REMOVE_pn-plymouth = "initrd"
 
 # If the user-data feature is in the picture, it takes over ownership of
 # determining what to do with ROOT_HOME and bind mounts.
-# See logic for USER_DATA_BINDS in meta-mentor-swupdate/conf/local.conf.append.
 
 ROOT_HOME_BIND = "\
     /var/volatile/root-home ${ROOT_HOME}\n\
 "
 VOLATILE_BINDS_append = "\
-    ${@bb.utils.contains('COMBINED_FEATURES', 'user-data', '', d.getVar('ROOT_HOME_BIND', True), d)} \
+    ${@bb.utils.contains('COMBINED_FEATURES', 'user-data', '', d.getVar('ROOT_HOME_BIND', True), d)}\
 "
 ## }}}1
 ## Inherits {{{1


### PR DESCRIPTION
That trailing space was causing a failure if the entry ended up as the
last in the list, which happends when user-data is not in
COMBINED_FEATURES.

Also remove a confusing comment.

Signed-off-by: Benjamin Walsh <Benjamin_Walsh@mentor.com>