### PR TITLE
volatile-binds: fix service disable in read-only file system

### DIFF
--- a/meta-mel/classes/remove-systemd-bind.bbclass
+++ b/meta-mel/classes/remove-systemd-bind.bbclass
@@ -1,0 +1,5 @@
+remove_systemd_bind () {
+        if [ -L ${IMAGE_ROOTFS}/etc/systemd/system/local-fs.target.wants/var-volatile-systemd.service ]; then
+                rm ${IMAGE_ROOTFS}/etc/systemd/system/local-fs.target.wants/var-volatile-systemd.service
+        fi
+}

--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -14,7 +14,5 @@ IMAGE_FEATURES_DISABLED_PRODUCTION ?= "${IMAGE_FEATURES_DEVELOPMENT} ssh-server-
 # build gets its own identifier, so is self-contained already.
 # Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}
 #ADE_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}.customized"
-SYSTEMD_BINDS = "\
-/var/volatile/systemd /etc/systemd\n\
- "
-VOLATILE_BINDS_append = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'read-only-rootfs', d.getVar('SYSTEMD_BINDS', True), '', d)}"
+IMAGE_CLASSES += "remove-systemd-bind"
+ROOTFS_POSTPROCESS_COMMAND_append = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'read-only-rootfs', '','remove_systemd_bind;', d)}"

--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -14,3 +14,7 @@ IMAGE_FEATURES_DISABLED_PRODUCTION ?= "${IMAGE_FEATURES_DEVELOPMENT} ssh-server-
 # build gets its own identifier, so is self-contained already.
 # Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}
 #ADE_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}.customized"
+SYSTEMD_BINDS = "\
+/var/volatile/systemd /etc/systemd\n\
+ "
+VOLATILE_BINDS_append = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'read-only-rootfs', d.getVar('SYSTEMD_BINDS', True), '', d)}"

--- a/meta-mentor-staging/recipes-core/volatile-binds/volatile-binds.bbappend
+++ b/meta-mentor-staging/recipes-core/volatile-binds/volatile-binds.bbappend
@@ -1,0 +1,4 @@
+# mount /etc/systemd with rw rights.
+VOLATILE_BINDS += "\
+/var/volatile/systemd /etc/systemd\n\
+"


### PR DESCRIPTION
systemd manages services by maintaining an elaborate tree under /etc/systemd.
When /etc/systemd is mounted as read-only, user cannot disable or enable services,
this caused error when opkg-configure tried to disable itself after first boot.
This fix mounts /etc/systemd in read-only mode allowing services to be disabled
or enabled at runtime.

Jira: http://jira.alm.mentorg.com:8080/browse/SB-11200
Signed-off-by: abdulkarim17 <hafizabdul_karim@mentor.com>