### PR TITLE
mel: enable the wayland distro feature by default

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -7,7 +7,8 @@ POKY_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
 POKY_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 POKY_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
-# Remove distro features: X11 is remvoed and replace by wayland
+# Ease distro feature removal via local.conf
+DISTRO_FEATURES_REMOVE ??= ""
 DISTRO_FEATURES_remove = "${DISTRO_FEATURES_REMOVE}"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${POKY_DEFAULT_DISTRO_FEATURES}"
@@ -189,8 +190,8 @@ OE_WORKDIR = "${WORKDIR}"
 OE_TERMINAL_EXPORTS += "OE_TOPDIR OE_WORKDIR COREBASE"
 
 ## Distro Features & Recipe Configuration {{{1
-# The user can enable ptest from local.conf, and wayland is not yet supported
-POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest wayland"
+# The user can enable ptest from local.conf
+POKY_DEFAULT_DISTRO_FEATURES_remove = "ptest"
 
 # We always want vfat support in our distro for external media
 DISTRO_FEATURES_append = " vfat"


### PR DESCRIPTION
Also add a fallback default for DISTRO_FEATURES_REMOVE to avoid referencing unset variables.