### PR TITLE
rng-tools: avoid hardcoding connman

### DIFF
--- a/meta-mentor-staging/recipes-support/rng-tools/rng-tools/10-sysinit.conf
+++ b/meta-mentor-staging/recipes-support/rng-tools/rng-tools/10-sysinit.conf
@@ -1,0 +1,4 @@
+[Unit]
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=sysinit.target

--- a/meta-mentor-staging/recipes-support/rng-tools/rng-tools/rngd.service
+++ b/meta-mentor-staging/recipes-support/rng-tools/rng-tools/rngd.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Hardware RNG Entropy Gatherer Daemon
-Before=connman.service
-
-[Service]
-ExecStart=/usr/sbin/rngd -f
-
-[Install]
-WantedBy=multi-user.target

--- a/meta-mentor-staging/recipes-support/rng-tools/rng-tools_%.bbappend
+++ b/meta-mentor-staging/recipes-support/rng-tools/rng-tools_%.bbappend
@@ -1,14 +1,12 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/rng-tools:"
+SRC_URI += "file://10-sysinit.conf"
 
-SRC_URI += "file://rngd.service"
-
-inherit systemd
-
-SYSTEMD_SERVICE_${PN} = "rngd.service"
-
-do_install_append() {
-	install -d ${D}${systemd_unitdir}/system
-	install -m 0644 ${WORKDIR}/rngd.service ${D}${systemd_unitdir}/system
+do_install_append () {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d "${D}${systemd_unitdir}/system/rngd.service.d"
+        install -m 0644 ${WORKDIR}/10-sysinit.conf "${D}${systemd_unitdir}/system/rngd.service.d/"
+    fi
 }
 
+FILES_${PN} +=  "${systemd_unitdir}/system/*.service.d"
 INITSCRIPT_PARAMS = "start 03 2 3 4 5 . stop 30 0 6 1 ."


### PR DESCRIPTION
The systemd service exists in oe-core now, we just want it to run
earlier, so adjust it using a drop-in unit rather than overriding the
service file, and also adjust it to run before sysinit.target, rather
than hardcoding connman.