### PR TITLE
archive-release: make git hashes deterministic for subdirs

### DIFF
--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -236,14 +236,16 @@ def git_archive(subdir, outdir, message=None):
         }
         if parent:
             try:
-                cdate = bb.process.run(['git', 'log', '--pretty=%ct', '-1', '--', os.path.relpath(subdir, parent)], cwd=parent)[0].rstrip()
+                cdate, adate = bb.process.run(['git', 'log', '--pretty=%ct\t%at', '-1', '--', os.path.relpath(subdir, parent)], cwd=parent)[0].rstrip().split('\t')
             except bb.process.CmdError:
-                bb.warn('Error determining commit date for %s' % subdir)
-                cdate = None, None
+                bb.warn('Error determining commit dates for %s' % subdir)
+                cdate, adate = None, None
 
             penv = dict(env)
             if cdate:
-                penv.update(GIT_AUTHOR_DATE=cdate, GIT_COMMITTER_DATE=cdate)
+                penv.update(GIT_COMMITTER_DATE=cdate)
+            if adate:
+                penv.update(GIT_AUTHOR_DATE=adate)
 
             head = bb.process.run(gitcmd + ['commit-tree', '-m', message, '-p', parent_head, tree], env=penv)[0].rstrip()
             with open(os.path.join(tmpdir, 'shallow'), 'w') as f:

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -235,15 +235,11 @@ def git_archive(subdir, outdir, message=None):
             'GIT_COMMITTER_EMAIL': 'build_user@build_host',
         }
         if parent:
-            # Walk the commits until we get a date, as merges don't seem to
-            # report a commit date.
-            cdate, distance = None, 0
-            while not cdate:
-                try:
-                    cdate = bb.process.run(['git', 'diff-tree', '--pretty=format:%ct', '-s', 'HEAD~%d' % distance], cwd=subdir)[0]
-                except bb.process.CmdError:
-                    break
-                distance += 1
+            try:
+                cdate = bb.process.run(['git', 'log', '--pretty=%ct', '-1', '--', os.path.relpath(subdir, parent)], cwd=parent)[0].rstrip()
+            except bb.process.CmdError:
+                bb.warn('Error determining commit date for %s' % subdir)
+                cdate = None, None
 
             penv = dict(env)
             if cdate:


### PR DESCRIPTION
The hashes listed in the manifests for layers which are subdirectories and
which are shipped individually were changing on every build. This fixes that
issue.

JIRA: SB-11566