### PR TITLE
SB-11567: Added gstreamer base plugin

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -299,7 +299,7 @@ FEATURE_PACKAGES_print-server    ?= "packagegroup-role-print-server"
 FEATURE_PACKAGES_router          ?= "packagegroup-role-router"
 FEATURE_PACKAGES_tools-audio     ?= "packagegroup-tools-audio"
 FEATURE_PACKAGES_tools-benchmark ?= "packagegroup-tools-benchmark"
-FEATURE_PACKAGES_multimedia      ?= "gstreamer1.0"
+FEATURE_PACKAGES_multimedia      ?= "gstreamer1.0 gstreamer1.0-plugins-base"
 
 # Analogous to the nfs-server group
 FEATURE_PACKAGES_samba-server    ?= "samba swat"


### PR DESCRIPTION
Gstreamer base plugin is added and ogg audio container (codec: vorbis) ogv video container (codec: theora) is tested successfully with the resulting image.
Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>