### PR TITLE
sdk_auto_relocate,sdk-relocate: revamp auto relocation

### DIFF
--- a/meta-mentor-staging/classes/sdk_auto_relocate.bbclass
+++ b/meta-mentor-staging/classes/sdk_auto_relocate.bbclass
@@ -9,46 +9,8 @@
 
 SDK_AUTO_RELOCATE_SOURCE ?= "1"
 SDK_AUTO_RELOCATE_HOST_DEPENDS = "nativesdk-sdk-relocate"
-
-SDK_PACKAGING_COMMAND_prepend = "auto_reloc_source;"
+TOOLCHAIN_HOST_TASK_append = " ${@d.getVar('SDK_AUTO_RELOCATE_HOST_DEPENDS') if bb.utils.to_boolean(d.getVar('SDK_AUTO_RELOCATE_SOURCE')) else ''}"
 
 # Ensure that the shar installer writes .installpath, so we don't relocate the
 # first time the user sources the environment setup script in that case.
 SDK_POST_INSTALL_COMMAND_append = 'echo "${env_setup_script%/*}" >"${env_setup_script%/*}/.installpath";'
-
-sdkpath_to_bindir = "${@os.path.relpath('${SDKPATHNATIVE}${bindir_nativesdk}', '${SDKPATH}')}"
-
-toolchain_env_script_reloc_fragment () {
-    mv "$script" "$script.fragment"
-    cat >"$script" <<END
-if [ -z "\$SDK_RELOCATING" ]; then
-    if [ -n "\$BASH_SOURCE" ] || [ -n "\$ZSH_NAME" ]; then
-        if [ -n "\$BASH_SOURCE" ]; then
-            scriptdir="\$(cd "\$(dirname "\$BASH_SOURCE")" && pwd)"
-        elif [ -n "\$ZSH_NAME" ]; then
-            scriptdir="\$(cd "\$(dirname "\$0")" && pwd)"
-        fi
-
-        if [ "\$scriptdir" != "${SDKPATH}" ]; then
-            if [ -e "\$scriptdir/${sdkpath_to_bindir}/sdk-auto-relocate" ]; then
-                env -i "\$scriptdir/${sdkpath_to_bindir}/sdk-auto-relocate" && SDK_RELOCATING=1 . "\$scriptdir/environment-setup-${REAL_MULTIMACH_TARGET_SYS}"
-            else
-                echo >&2 "Warning: Unable to find sdk-auto-relocate script"
-            fi
-        fi
-    else
-        echo >&2 "Warning: Unable to determine SDK install path from environment setup script location. Please run <installdir>/${sdkpath_to_bindir}/sdk-auto-relocate manually."
-    fi
-else
-    unset SDK_RELOCATING
-fi
-END
-    cat "$script.fragment" >>"$script"
-    rm "$script.fragment"
-}
-
-python auto_reloc_source () {
-    if bb.utils.to_boolean(d.getVar('SDK_AUTO_RELOCATE_SOURCE', True)):
-        d.appendVar('toolchain_create_sdk_env_script', '\n${toolchain_env_script_reloc_fragment}')
-        d.appendVar('TOOLCHAIN_HOST_TASK', ' ${SDK_AUTO_RELOCATE_HOST_DEPENDS}')
-}

--- a/meta-mentor-staging/recipes-core/meta/nativesdk-sdk-relocate.bb
+++ b/meta-mentor-staging/recipes-core/meta/nativesdk-sdk-relocate.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 INHIBIT_DEFAULT_DEPS = "1"
 REAL_MULTIMACH_TARGET_SYS := "${MULTIMACH_TARGET_SYS}"
 
-inherit nativesdk
+inherit nativesdk toolchain_shar_relocate_bbpath
 
 SDKTARGETSYSROOT = "${SDKPATH}/sysroots/${REAL_MULTIMACH_TARGET_SYS}"
 
@@ -33,7 +33,7 @@ target_sdk_dir="\$(cd "\$scriptdir/${bindir_to_sdkpath}" && pwd -P)"
 sed -i -e "s#\$DEFAULT_INSTALL_DIR\>#\$installdir#g" "\$env_setup_script"
 ####
 END
-    cat "${COREBASE}/meta/files/toolchain-shar-relocate.sh" >>sdk-relocate
+    cat "${TOOLCHAIN_SHAR_RELOCATE}" >>sdk-relocate
     sed -i -e 's#grep -v "\$target_sdk_dir/.*"#grep -Ev "(sdk-relocate|$target_sdk_dir/(environment-setup-*|\.installpath))"#' sdk-relocate
     sed -i -e '/native_sysroot=/a native_sysroot=$($SUDO_EXEC echo $native_sysroot | sed -e "s:\\$scriptdir:$target_sdk_dir:")' sdk-relocate
     chmod +x sdk-relocate

--- a/meta-mentor-staging/recipes-core/meta/nativesdk-sdk-relocate.bb
+++ b/meta-mentor-staging/recipes-core/meta/nativesdk-sdk-relocate.bb
@@ -36,7 +36,7 @@ END
     cat "${TOOLCHAIN_SHAR_RELOCATE}" >>sdk-relocate
     sed -i -e 's#grep -v "\$target_sdk_dir/.*"#grep -Ev "(sdk-relocate|$target_sdk_dir/(environment-setup-*|\.installpath))"#' sdk-relocate
     sed -i -e '/native_sysroot=/a native_sysroot=$($SUDO_EXEC echo $native_sysroot | sed -e "s:\\$scriptdir:$target_sdk_dir:")' sdk-relocate
-    chmod +x sdk-relocate
+
     cat <<END >sdk-auto-relocate
 #!/bin/sh
 set -eu
@@ -54,11 +54,31 @@ fi
 sh "\$scriptdir/sdk-relocate" "\$from_path" "\$installdir"
 echo "\$installdir" >"\$installdir/.installpath"
 END
-    chmod +x sdk-auto-relocate
+
+    cat >sdk-relocate.sh <<END
+if [ -z "\$SDK_RELOCATING" ]; then
+    if [ -n "\$BASH_SOURCE" ] || [ -n "\$ZSH_NAME" ]; then
+        if [ -n "\$BASH_SOURCE" ]; then
+            scriptdir="\$(cd "\$(dirname "\$BASH_SOURCE")" && pwd)"
+        elif [ -n "\$ZSH_NAME" ]; then
+            scriptdir="\$(cd "\$(dirname "\$0")" && pwd)"
+        fi
+
+        env -i "\$scriptdir/${sdkpath_to_bindir}/sdk-auto-relocate" && SDK_RELOCATING=1 . "\$scriptdir/environment-setup-${REAL_MULTIMACH_TARGET_SYS}"
+    else
+        echo >&2 "Warning: Unable to determine SDK install path from environment setup script location. Please run <installdir>/${sdkpath_to_bindir}/sdk-auto-relocate manually."
+    fi
+else
+    unset SDK_RELOCATING
+fi
+END
 }
 
 do_install () {
-    install -d "${D}${bindir}"
+    install -d "${D}${bindir}" "${D}${SDKPATHNATIVE}/environment-setup.d"
     install -m 0755 sdk-relocate "${D}${bindir}/"
     install -m 0755 sdk-auto-relocate "${D}${bindir}/"
+    install -m 0755 sdk-relocate.sh "${D}${SDKPATHNATIVE}/environment-setup.d/"
 }
+
+FILES_${PN} += "${SDKPATHNATIVE}/environment-setup.d"


### PR DESCRIPTION
The script we were appending no longer runs during sdk construction, so we
had to use a different mechanism. Now we ship the shell fragment for
environment-setup via environment-setup.d and let our codebench hack
concatenate that into the main script.

Also ensure our auto relocation scripts obey the fix from SB-11482.

JIRA: SB-11689