### PR TITLE
local.conf.sample: add var indirection for use of _remove

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -172,7 +172,8 @@ include conf/include/drop-toolchain-from-sdk.inc
 # autoconf, automake, etc. See the aforementioned warning about use of Windows
 # SDKMACHINE while setting TOOLCHAIN_HOST_TASK, if you're building a Windows
 # SDK/ADE.
-TOOLCHAIN_HOST_TASK_remove = "nativesdk-packagegroup-sdk-host"
+TOOLCHAIN_HOST_REMOVE ??= "nativesdk-packagegroup-sdk-host"
+TOOLCHAIN_HOST_TASK_remove = "${TOOLCHAIN_HOST_REMOVE}"
 
 # TOOLCHAIN_HOST_TASK is used to add host packages to the ADE/SDK, for
 # example, to add bash:


### PR DESCRIPTION
As `_remove` cannot be undone given bitbake's current capabilities
(though I've discussed adding an API for this with Richard in the past,
so we may add it in the future), add a variable indirection
(`TOOLCHAIN_HOST_REMOVE`) to enable one to undo the
`TOOLCHAIN_HOST_TASK_remove`.

JIRA: SB-11062