### PR TITLE
Allow gplv3 binutils for aarch64, for tools-profile

### DIFF
--- a/meta-mel/conf/local.conf.append
+++ b/meta-mel/conf/local.conf.append
@@ -1,6 +1,14 @@
 # Install binutils with tools-profile, as our tracing scripts need ld
 CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'binutils', '', d)}"
 
+# The gplv2 binutils does not support aarch64, so the gplv3 version is built
+# and installed with tools-profile on that architecture by default, even in
+# a non-gplv3 build. Comment this out, comment the line which installs
+# binutils, or remove tools-profile from EXTRA_IMAGE_FEATURES to disable this
+# behavior.
+WHITELIST_BINUTILS = "${@'binutils' if d.getVar('PN') == 'binutils' or (bb.data.inherits_class('image', d) and bb.utils.filter('IMAGE_FEATURES', 'tools-profile', d) == 'tools-profile') else ''}"
+WHITELIST_GPL-3.0_append_aarch64 = " ${WHITELIST_BINUTILS}"
+
 # Image features for development-image
 IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks codebench-debug ssh-server-openssh tools-profile"
 

--- a/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
+++ b/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
@@ -3,4 +3,4 @@ DEPENDS += "flex-native bison-native"
 inherit incompatible-recipe-check
 
 REMOVE_INCOMPATIBLE_MAN = "${@'man' if is_incompatible(d, ['libpipeline'], 'GPL-3.0') else ''}"
-RDEPENDS_${PN}-doc_remove_mel = "${REMOVE_INCOMPATIBLE_MAN}"
+RDEPENDS_${PN}-doc_remove = "${REMOVE_INCOMPATIBLE_MAN}"

--- a/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
+++ b/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
@@ -1,3 +1,6 @@
 DEPENDS += "flex-native bison-native"
-REMOVE_MAN_RDEPENDS = "${@bb.utils.contains('INCOMPATIBLE_LICENSE', 'GPLv3','man', '', d)}"
-RDEPENDS_${PN}-doc_remove_mel = "${REMOVE_MAN_RDEPENDS}"
+
+inherit incompatible-recipe-check
+
+REMOVE_INCOMPATIBLE_MAN = "${@'man' if is_incompatible(d, ['libpipeline'], 'GPL-3.0') else ''}"
+RDEPENDS_${PN}-doc_remove_mel = "${REMOVE_INCOMPATIBLE_MAN}"


### PR DESCRIPTION
The gplv2 binutils does not support aarch64, so the gplv3 version is built and
installed with tools-profile on that architecture by default, even in
a non-gplv3 build. This is kept in local.conf next to the bits which install
binutils with tools-profile by default, to keep it both user-visible and easy
to disable.

Also show a warning when whitelisted incompatible packages are installed in an
image, to ensure the user stays aware of it.

JIRA: SB-11714