### PR TITLE
docker_git: Fix runtime issue for failed to load system roots issue.

### DIFF
--- a/meta-mentor-staging/virtualization-layer/recipes-containers/docker/docker_git.bbappend
+++ b/meta-mentor-staging/virtualization-layer/recipes-containers/docker/docker_git.bbappend
@@ -2,3 +2,6 @@
 # Specify the proper Host ARCH Flags for building
 CFLAGS  += "${HOST_CC_ARCH}"
 LDFLAGS += "${HOST_CC_ARCH}"
+
+RDEPENDS_${PN} += "ca-certificates \
+                  "


### PR DESCRIPTION
* While running following command on the target
  docker pull ubuntu
  this error pops up
  Get https://registry-1.docker.io/v2/: x509: failed to load system roots and no roots provided
  This is due to the reason that certificates are missing on the target.
  docker recipe is not depending on ca-certificate. Add ca-certificates in
  rdepends to resolve the issue.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>