### PR TITLE
setup-environment: handle ${TOPDIR} in BBLAYERS

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -87,7 +87,7 @@ else
         configured_layers () {
             tac $BUILDDIR/conf/bblayers.conf | \
                 sed -n -e '/^"/,/^BBLAYERS = /{ /^BBLAYERS =/d; /^"/d; p;}' | \
-                awk {'print $1'}
+                awk {'print $1'} | sed -e "s#\${TOPDIR}/#$BUILDDIR/#"
         }
 
         load_lconf_snippet () {


### PR DESCRIPTION
In the case of the new git delivery mechanism, TOPDIR==MELDIR, so we end
up with `${TOPDIR}` references in BBLAYERS, but `configured_layers` in
setup-environment wasn't converting that to a reference to BUILDDIR, and
hence failed to find any layers for handling layer.conf.append or
post-setup-environment, resulting in much configuration missing from
local.conf. This broke builds of just about all of our BSPs.

JIRA: SB-11836