### PR TITLE
local.conf.sample: fsl -> xilinx

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -95,10 +95,10 @@ USER_FEATURES += "~nfc"
 # Uncomment to exclude GPLv3 software from the build
 #INCOMPATIBLE_LICENSE = "GPLv3"
 
-# Uncomment to indicate your acceptance of the Freescale end user license
-# agreement. This is needed to use the proprietary components for Freescale
+# Uncomment to indicate your acceptance of the Xilinx end user license
+# agreement. This is needed to use the proprietary components for Xilinx
 # hardware.
-#ACCEPT_FSL_EULA = "1"
+#ACCEPT_XILINX_EULA = "1"
 
 # Download files from a mirror
 # Uncomment this INHERIT, and define SOURCE_MIRROR_URL

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -186,6 +186,7 @@ MEL_DEFAULT_DISTRO_FEATURES += "${@'vulkan' if not bb.utils.to_boolean(d.getVar(
 # This violates typical MACHINE/DISTRO boundaries, but is part of MEL's
 # supported features. If the vendor supports x11 and not wayland for its
 # machines, so do we.
+DISTRO_FEATURES_DEFAULT_remove = "x11"
 MEL_DEFAULT_DISTRO_FEATURES += "${@'' if bb.utils.to_boolean(d.getVar('ENABLE_EGLFS')) \
                                   else bb.utils.contains('MACHINE_FEATURES', 'x11', \
                                   bb.utils.contains('MACHINE_FEATURES', 'wayland', 'wayland', 'x11', d), 'wayland', d)}"


### PR DESCRIPTION
The variable for accepting the eula has changed names, so we needed
to update our sample.