### PR TITLE
bitbake-layers.dump-downloads: fix bug with recipe names with a period

### DIFF
--- a/meta-mel/lib/bblayers/dl.py
+++ b/meta-mel/lib/bblayers/dl.py
@@ -151,9 +151,9 @@ class DownloadsPlugin(LayerPlugin):
 
         for task, taskdeps in tdepends.items():
             for dep in taskdeps:
-                recipe, deptask = dep.split('.', 1)
+                deprecipe, deptask = dep.rsplit('.', 1)
                 if deptask == 'do_fetch':
-                    fetch_recipes.add(recipe)
+                    fetch_recipes.add(deprecipe)
 
         self.tinfoil.run_command('enableDataTracking')
 


### PR DESCRIPTION
Due to how we were splitting the string entries in bitbake's generated
depgraph, we ended up with a recipe name of 'glib-2' and a task name of
'0.do_fetch', which resulted in leaving out downloads for any recipe
with a period in its name. Fix the splitting.

JIRA: SB-11889