### PR TITLE
local.conf.sample: Remove the lines related to rebuilding glibc

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -12,11 +12,6 @@ MACHINE ??= "qemux86"
 # from the CodeBench we're installed in.
 #EXTERNAL_TOOLCHAIN ?= "/path/to/toolchain"
 
-# Uncomment these, adjusting the path appropriately, to use an external
-# toolchain, but rebuild the toolchain's C library from source.
-#TCMODE = "external-sourcery-rebuild-libc"
-#SOURCERY_SRC_FILE = "/path/to/sourcery/src.tar.gz"
-
 # Uncomment to use the oe/yocto-built toolchain rather than the external
 #TCMODE = "default"
 


### PR DESCRIPTION
* Now we build glibc from sources. No need to set anything in local.conf.
  So remove old lines from local.conf.sample file.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>