### PR TITLE
mel.conf:archive-release" Add 3 number version scheme.

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -377,7 +377,7 @@ do_archive_images () {
         echo ${BUILDHISTORY_DIR} >>include
     fi
 
-    release_tar --files-from=include -cf ${MACHINE}.tar
+    release_tar --files-from=include -cf ${MACHINE}-${ARCHIVE_RELEASE_VERSION}.tar
 
     echo "--transform=s,-${MACHINE},,i" >include
     echo "--transform=s,${DEPLOY_DIR_IMAGE},${BINARY_INSTALL_PATH}," >>include
@@ -414,7 +414,7 @@ do_archive_images () {
     chmod +x "${WORKDIR}/bmaptool"
     echo "--transform=s,${WORKDIR}/bmaptool,${BINARY_INSTALL_PATH}/bmaptool," >>include
     echo "${WORKDIR}/bmaptool" >>include
-    release_tar --files-from=include -rhf ${MACHINE}.tar
+    release_tar --files-from=include -rhf ${MACHINE}-${ARCHIVE_RELEASE_VERSION}.tar
     rm -rf runqemu conf-notes.txt local.conf.sample bblayers.conf.sample include
 }
 

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -1,8 +1,7 @@
 ## MEL Base Configuration {{{1
 DISTRO = "mel"
 DISTRO_NAME = "Mentor Embedded Linux"
-DISTRO_VERSION = "next+snapshot-${DATE}"
-DISTRO_VERSION[vardepsexclude] = "DATE"
+DISTRO_VERSION = "11"
 MAINTAINER = "Mentor Graphics Corporation <embedded_support@mentor.com>"
 TARGET_VENDOR = "-mel"
 SDK_VENDOR = "-melsdk"
@@ -443,7 +442,10 @@ DL_LICENSE_INCLUDE ?= "*"
 INHERIT += "archive-release-downloads"
 
 # Further archive-release configuration
-PDK_DISTRO_VERSION ?= "${DISTRO_VERSION}"
+#BSP version and PATCH version will be redefined in respective layers. Just giving it default values.
+BSP_VERSION ?= "0"
+PATCH_VERSION ?= "0"
+PDK_DISTRO_VERSION ?= "${DISTRO_VERSION}.${PATCH_VERSION}.${BSP_VERSION}"
 ARCHIVE_RELEASE_VERSION ?= "${PDK_DISTRO_VERSION}"
 
 INDIVIDUAL_MANIFEST_LAYERS ?= " \


### PR DESCRIPTION
* Update PDK_DISTRO_VERSION to DISTRO_VERSION.PATCH_VERSION.BSP_VERSION
  to follow 3 number version scheme. PATCH_VERSION should be updated
  in mel update layers. BSP_VERSION should be updated in BSP layer.
* In archive-release add version in machine tar file. Just to distinguish
  between machine tar files if we have to.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>