### PR TITLE
mel.conf: Reverted PDK_DISTRO_VERSION changes due to license failuer.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -1,7 +1,8 @@
 ## MEL Base Configuration {{{1
 DISTRO = "mel"
 DISTRO_NAME = "Mentor Embedded Linux"
-DISTRO_VERSION = "11"
+DISTRO_VERSION = "next+snapshot-${DATE}"
+DISTRO_VERSION[vardepsexclude] = "DATE"
 MAINTAINER = "Mentor Graphics Corporation <embedded_support@mentor.com>"
 TARGET_VENDOR = "-mel"
 SDK_VENDOR = "-melsdk"
@@ -445,8 +446,8 @@ INHERIT += "archive-release-downloads"
 #BSP version and PATCH version will be redefined in respective layers. Just giving it default values.
 BSP_VERSION ?= "0"
 PATCH_VERSION ?= "0"
-PDK_DISTRO_VERSION ?= "${DISTRO_VERSION}.${PATCH_VERSION}.${BSP_VERSION}"
-ARCHIVE_RELEASE_VERSION ?= "${PDK_DISTRO_VERSION}"
+PDK_DISTRO_VERSION ?= "${DISTRO_VERSION}"
+ARCHIVE_RELEASE_VERSION ?= "11.${PATCH_VERSION}.${BSP_VERSION}"
 
 INDIVIDUAL_MANIFEST_LAYERS ?= " \
     update-* \


### PR DESCRIPTION
* PDK_DISTRO_VERSION is used to checkout license. Faced the following error
  ERROR: MEL PDK license check failed: error: (null)
  cs-license failed, aborting

  Reverted old value of PDK_DISTRO_VERSION. Set ARCHIVE_RELEASE_VERSION to
  3 number scheme temprarily.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>