### PR TITLE
local.conf.sample: Add initramfs for encrypted-fs

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -292,8 +292,10 @@ BB_DISKMON_DIRS = "\
 # enabling dmcrypt-initramfs-image if the encrypted-fs image feature is added to EXTRA_IMAGE_FEATURES variable.
 INITRAMFS_IMAGE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', '', d)}"
 INITRAMFS_IMAGE_BUNDLE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '1', '', d)}"
-# removing 96boards-tools package so that rootfs does not occupy entire available space over theboot media.
-PACKAGE_INSTALL_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', ' 96boards-tools ', '', d)}"
+# removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
+MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
+# Add initramfs image to the boot partition.
+MACHINE_BOOT_FILES += "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if


### PR DESCRIPTION
Adding a couple of things:
1) Removing 96boards-tools from PACKAGE_INSTALL doesn't remove it as MACHINE_EXTRA_RRECOMMENDS is not a subset-variable to IMAGE_INSTALL.
2) MACHINE_BOOT_FILES adds initramfs image to boot partition to make the encrypted-fs workflow simpler. Manual replacement of kernel won't be needed after it.
Linked PR: https://github.com/MentorEmbedded/meta-mentor-bsp/pull/298

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>