### PR TITLE
mel-support:archive-release: Rename setup-builddir to archive-release

### DIFF
--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS_append = ":${@':'.join('%s/../scripts/release:%s/../scripts' % (l, l) for l in '${BBPATH}'.split(':'))}"
-MEL_SCRIPTS_FILES = "mel-checkout version-sort setup-mel setup-builddir setup-ubuntu setup-rh"
+MEL_SCRIPTS_FILES = "mel-checkout version-sort setup-mel setup-workspace setup-ubuntu setup-rh"
 SRC_URI += "${@' '.join(uninative_urls(d)) if 'mel_downloads' in '${RELEASE_ARTIFACTS}'.split() else ''}"
 SRC_URI += "${@' '.join('file://%s' % s for s in d.getVar('MEL_SCRIPTS_FILES').split())}"
 


### PR DESCRIPTION
* setup-builddir script was rename in following commit
  setup-mel/setup-builddir: only setup a workspace
  Need to update in archive-release recipe as well so that correct script is bundled.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>