### PR TITLE
[RFC] Tie workspace to machine/BSP

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -150,7 +150,7 @@ echo "$installdir" >"$project/.installpath"
 
 for install_subdir in ../../codebench ../../codebench-lite; do
     if [ -d "$installdir/$install_subdir" ]; then
-        ln -s "$installdir/$install_subdir" .
+        ln -sf "$installdir/$install_subdir" .
     fi
 done
 

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -30,6 +30,26 @@ evalf () {
     eval "$(printf "$fmt" "$@")"
 }
 
+verify_machine () {
+    workspace="$1"
+    manifest_name=$(basename "$2")
+    manifest_machine=$(echo "$manifest_name" | cut -d'-' -f3- | cut -d'.' -f1)
+    workspace_machine=$(cat "$workspace/.machine")
+    if [ "$workspace_machine" != "$manifest_machine" ]; then
+        echo >&2 "Error: workspace in $workspace is already setup for $workspace_machine."
+        echo >&2 "Please specify a different location if you want to setup for $manifest_machine"
+        echo >&2 "or clean up $workspace before continuing."
+        exit 1
+    fi
+}
+
+set_machine () {
+    workspace="$1"
+    manifest_name=$(basename "$2")
+    manifest_machine=$(echo "$manifest_name" | cut -d'-' -f3- | cut -d'.' -f1)
+    echo "$manifest_machine" > "$workspace/.machine"
+}
+
 prompt_choice () {
     choice_non_interactive=0
     while getopts n opt; do
@@ -164,11 +184,18 @@ if [ -z "$1" ]; then
             exit 1
         fi
     fi
+    if [ -e "$project/.machine" ]; then
+        verify_machine "$project" "$(cat "$project/.manifest" | head -n1)"
+    fi
     set -- $(cat "$project/.manifest")
     manifest="$1"
 else
+    if [ -e "$project/.machine" ]; then
+        verify_machine "$project" "$manifest"
+    fi
     echo "$manifest" >"$project/.manifest"
 fi
+set_machine "$project" "$manifest"
 
 if [ $no_extra_manifests -eq 1 ]; then
     set -- "$1"

--- a/scripts/release/setup-mel
+++ b/scripts/release/setup-mel
@@ -26,6 +26,6 @@ else
     "$meldir/scripts/setup-workspace" "$@" && \
     cd "$WORKSPACEDIR" && \
     echo >&2 "MEL setup complete in $WORKSPACEDIR" && \
-    echo >&2 "You can now use "$WORKSPACEDIR"/meta-mentor/setup-environment for setting up a build."
+    echo >&2 "You can now source "$WORKSPACEDIR"/meta-mentor/setup-environment for setting up a build."
 fi
 # vim: set ft=sh :

--- a/scripts/release/setup-workspace
+++ b/scripts/release/setup-workspace
@@ -116,8 +116,6 @@ eval set -- "$saved"
 
 if [ -e "$WORKSPACEDIR" ]; then
     existing_workspace=1
-    echo >&2 "A workspace already exists in $WORKSPACEDIR, please choose a different location"
-    exit 1
 else
     existing_workspace=0
 fi


### PR DESCRIPTION
The idea here is to tie a workspace to a particular BSP that is used to initially create the specific workspace. Although this is in contrast with how workspaces are usually used but our metadata that is checked out into a workspace is actually tied to a BSP already. If we don't follow this route (tying workspace to BSP) there can be a situation where a user might create build directories using this particular metadata and then runs setup-mel with a different machine/manifest on this workspace, in this scenario all the earlier created build directories would go out of sync and can cause known/unknown failures.