### PR TITLE
mel: drop the pointless GLIBC_GENERATE_LOCALES override

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -139,8 +139,7 @@ do_image_complete[recrdeptask] += "do_populate_lic"
 # space will be needed and fails badly as the fs size grows.
 IMAGE_ROOTFS_EXTRA_SPACE = "40960"
 
-# Sane default locales for images
-GLIBC_GENERATE_LOCALES ?= "en_US en_US.UTF-8"
+# Default locale for images
 IMAGE_LINGUAS ?= "en-us"
 
 # Ensure the emitted locale packages are in that section, so they can be


### PR DESCRIPTION
The user may well want to have the option to use or install any or
multiple locales, and not generating fr-fr and de-de breaks the ability
to run the bash ptests.

JIRA: SB-11898

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>
Signed-off-by: Christopher Larson <chris_larson@mentor.com>