### PR TITLE
mel.conf: Add ubuntu-18.04 to mel supported hosts.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -86,6 +86,7 @@ PACKAGE_CLASSES ?= "package_ipk"
 
 # MEL's supported hosts
 SANITY_TESTED_DISTROS = "\
+    ubuntu-18.04 \n\
     ubuntu-16.04 \n\
     ubuntu-14.04 \n\
     centos-7.* \n \


### PR DESCRIPTION
Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>