### PR TITLE
MEL Lite use glibc 2.28

### DIFF
--- a/meta-mel/conf/distro/mel-lite.conf
+++ b/meta-mel/conf/distro/mel-lite.conf
@@ -7,3 +7,5 @@ DISTROOVERRIDES = "${DISTRO}:mel"
 SANITY_TESTED_DISTROS = "\
     Ubuntu-16.04 \n\
 "
+
+GLIBCVERSION ?= "2.28%"

--- a/meta-mel/sourcery/recipes-sourcery/glibc-sourcery/glibc-sourcery.bbappend
+++ b/meta-mel/sourcery/recipes-sourcery/glibc-sourcery/glibc-sourcery.bbappend
@@ -1,0 +1,6 @@
+LIC_FILES_CHKSUM_remove_mel-lite = "file://LICENSES;md5=e9a558e243b36d3209f380deb394b213"
+SRCREV_mel-lite ?= "5a74abda201907cafbdabd1debf98890313ff71e"
+SRC_URI_mel-lite = "git://sourceware.org/git/glibc.git;branch=release/2.28/master;name=glibc \
+          file://0010-eglibc-run-libm-err-tab.pl-with-specific-dirs-in-S.patch \
+          file://etc/ld.so.conf \
+          file://generate-supported.mk"


### PR DESCRIPTION
The CB Lite tools for current release are based off of
glibc 2.28 so make adjustments accordingly.

Signed-off-by: Awais Belal <awais_belal@mentor.com>