### PR TITLE
mel-checkout: link uninative downloads to toplevel

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -283,8 +283,10 @@ done | (
         if [ -e "$downloads" ]; then
             cat "$downloads" | while read -r path checksum; do
                 destdir="$(dirname "$path")"
-                if [ -n "$destdir" ]; then
+                if [ "$destdir" != "." ]; then
                     mkdir -p "downloads/$destdir"
+                    ln -sf "$path" downloads/
+                    ln -sf "${path}.done" downloads/
                 fi
                 ln -sf "$installdir/downloads/$checksum" "downloads/$path"
                 touch "downloads/${path}.done"


### PR DESCRIPTION
This allows `${MELDIR}/downloads` to be used either directly as DL_DIR
or as mirror, whereas the uninative tarballs were only found for the
former previously.

JIRA: SB-11940