### PR TITLE
mel-image.inc: Add util-linux to ensure vital functionality

### DIFF
--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -10,4 +10,4 @@ LICENSE = "MIT"
 inherit core-image image-sanity-incompatible
 
 IMAGE_FEATURES .= "${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
-IMAGE_INSTALL += " quota connman"
+IMAGE_INSTALL += " util-linux connman"


### PR DESCRIPTION
util-linux provides mkfs which is necessary. And removed quota as we are not
supporting quota fs.

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>