### PR TITLE
Add support for ROOT_PASSWORD, change behavior when empty for production-image

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -67,6 +67,11 @@ EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-openssh codebench-debug tools-pr
 # machine doesn't define them, the default types are tar.bz2 and ext3.
 #IMAGE_FSTYPES_append = " jffs2"
 
+# Uncomment and alter to set the root password. Set to 0 to explicitly allow
+# the empty root password even in production-image.
+#ROOT_PASSWORD = ""
+IMAGE_CLASSES_append = " image-root-password"
+
 # User features lets you manipulate the distro features. To add a distro
 # feature, simply add it to USER_FEATURES. To remove, prefix it with ~.
 #

--- a/meta-mentor-common/classes/image-root-password.bbclass
+++ b/meta-mentor-common/classes/image-root-password.bbclass
@@ -1,9 +1,17 @@
 # Enable use of the 'ROOT_PASSWORD' variable to set the root password for your
 # image or images. In addition to setting to a specific password, it also
 # handles special cases. If set to '0', empty root password is explicitly
-# allowed. If set to '*', root login is explicitly disabled.
+# allowed. If set to '*', root login is explicitly disabled. This also changes
+# the default behavior when ROOT_PASSWORD is empty -- if the image lacks
+# debug-tweaks and empty-root-password, the image qa check will fail, as the
+# user will have no way to login.
 
 ROOT_PASSWORD ?= ""
+IMAGE_INCOMPATIBLE_ZAPPED_MESSAGE = "ROOT_PASSWORD has not been set, and this \
+image has neither debug-tweaks nor empty-root-password set. This will result \
+in an image whose root login is disabled. Please set ROOT_PASSWORD to the root \
+password, to '*' to explicitly disable root login, or to '0' to explicitly \
+allow root login with an empty password."
 
 EMPTY_ROOT_PASSWORD = "${@'empty-root-password' if d.getVar('ROOT_PASSWORD', True) == '0' else ''}"
 IMAGE_FEATURES += "${EMPTY_ROOT_PASSWORD}"
@@ -15,3 +23,16 @@ inherit extrausers
 # variable checksums.
 ACTUAL_ROOT_PASSWORD = "${ROOT_PASSWORD}"
 EXTRA_USERS_PARAMS_prepend = "${@'usermod -P \'${ACTUAL_ROOT_PASSWORD}\' root;' if d.getVar('ACTUAL_ROOT_PASSWORD') not in ['', '0', '*'] else ''}"
+
+# Change the default behavior when the root password is empty. If the image
+# lacks empty-root-password and debug-tweaks, rather than defaulting to
+# disabling root login, error out. The user can explicitly opt-in to the old
+# behavior with this class inherited by setting ROOT_PASSWORD to '*'.
+IMAGE_QA_COMMANDS += "image_check_zapped_root_password"
+python image_check_zapped_root_password () {
+    root_password = d.getVar('ROOT_PASSWORD')
+    zapped_empty = bb.utils.contains_any('IMAGE_FEATURES', ['debug-tweaks', 'empty-root-password'], False, True, d)
+    if not root_password and zapped_empty:
+        message = d.getVar('IMAGE_INCOMPATIBLE_ZAPPED_MESSAGE')
+        raise oe.utils.ImageQAFailed(message, 'image_check_zapped_root_password')
+}

--- a/meta-mentor-common/classes/image-root-password.bbclass
+++ b/meta-mentor-common/classes/image-root-password.bbclass
@@ -1,0 +1,17 @@
+# Enable use of the 'ROOT_PASSWORD' variable to set the root password for your
+# image or images. In addition to setting to a specific password, it also
+# handles special cases. If set to '0', empty root password is explicitly
+# allowed. If set to '*', root login is explicitly disabled.
+
+ROOT_PASSWORD ?= ""
+
+EMPTY_ROOT_PASSWORD = "${@'empty-root-password' if d.getVar('ROOT_PASSWORD', True) == '0' else ''}"
+IMAGE_FEATURES += "${EMPTY_ROOT_PASSWORD}"
+
+inherit extrausers
+
+# This variable indirection allows for the possibility of programmatically
+# generating the root password, if so desired, without mucking up bitbake's
+# variable checksums.
+ACTUAL_ROOT_PASSWORD = "${ROOT_PASSWORD}"
+EXTRA_USERS_PARAMS_prepend = "${@'usermod -P \'${ACTUAL_ROOT_PASSWORD}\' root;' if d.getVar('ACTUAL_ROOT_PASSWORD') not in ['', '0', '*'] else ''}"


### PR DESCRIPTION
WIP, do not merge yet. I don't believe this is a good approach, defaulting to
an insecure random password for root in production-image is problematic. I'd
rather arrange for a warning to be emitted when production-image is built when
the user hasn't set ROOT_PASSWORD, indicating that they won't be able to login
as root by default.