### PR TITLE
local.conf.sample: switch back to use of MELDIR/downloads directly

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -95,13 +95,13 @@ USER_FEATURES += "~nfc"
 #SOURCE_MIRROR_URL = "file:///cache/downloads"
 #SOURCE_MIRROR_URL = "http://myserver/sources"
 
-# Our download directory / cache
-DL_DIR ?= "${TOPDIR}/downloads"
+# Our download directory / cache for the workspace
+DL_DIR ?= "${MELDIR}/downloads"
 
-# Continue to pull downloads from the MEL install
+# Continue to pull downloads from the build dir if available
 PREMIRRORS_prepend = "\
     .*://.*/.* file://${MELDIR}/${MACHINE}/downloads/ \n \
-    .*://.*/.* file://${MELDIR}/downloads/ \n \
+    .*://.*/.* file://${TOPDIR}/downloads/ \n \
 "
 
 # BitBake has the capability to accelerate builds based on previously built


### PR DESCRIPTION
Using it as a mirror rather than DL_DIR was done to support a read-only
meldir, but now that we use the new delivery method with workspaces,
that's no longer a concern -- the user created the workspace, so the
workspace downloads is writable, and using it ensures we share downloads
between all the build directories in a given workspace.