### PR TITLE
udev-extraconf: force systemd-udevd to use shared MountFlags

### DIFF
--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf/systemd-udevd.service
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf/systemd-udevd.service
@@ -1,0 +1,3 @@
+.include @systemd_unitdir@/system/systemd-udevd.service
+[Service]
+MountFlags=shared

--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf_%.bbappend
@@ -1,8 +1,16 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI +=  "file://mount_modified.sh"
+SRC_URI +=  "file://mount_modified.sh \
+             ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://systemd-udevd.service', '', d)}"
 
 RDEPENDS_${PN} += "util-linux-blkid"
 
+FILES_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${sysconfdir}/systemd/system/systemd-udevd.service', '', d)}"
+
 do_install_append() {
 	install -m 0755 ${WORKDIR}/mount_modified.sh ${D}${sysconfdir}/udev/scripts/mount.sh
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+		install -d ${D}${sysconfdir}/systemd/system
+		install ${WORKDIR}/systemd-udevd.service ${D}${sysconfdir}/systemd/system/systemd-udevd.service
+		sed -i 's|@systemd_unitdir@|${systemd_unitdir}|g' ${D}${sysconfdir}/systemd/system/systemd-udevd.service
+	fi
 }


### PR DESCRIPTION
Automounting does not work cleanly in case systemd as well as
udev rules are being used simultaneously and in most cases
race conditions and unknown behavior can come up.
In case we're running on top of systemd we need to make sure
that systemd-udevd knows that udev is in play as well and
mounting should be done using shared flags. Also as we're
using mount from sources other than systemd-mount in our
current scripts this is the most manageable fix to automounting
problems.

JIRA: SB-12028.

Signed-off-by: Awais Belal <awais_belal@mentor.com>