### PR TITLE
mel.conf: Added gst-plugins-bad to multimedia packages

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -313,7 +313,7 @@ FEATURE_PACKAGES_graphics += "${@bb.utils.contains('DISTRO_FEATURES', 'x11', '${
 FEATURE_PACKAGES_codebench-debug ?= "gdbserver strace openssh-sftp-server"
 FEATURE_PACKAGES_tools-audio     ?= "packagegroup-tools-audio"
 FEATURE_PACKAGES_tools-benchmark ?= "packagegroup-tools-benchmark"
-FEATURE_PACKAGES_multimedia      ?= "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good"
+FEATURE_PACKAGES_multimedia      ?= "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer-plugins-bad"
 FEATURE_PACKAGES_virtualization  ?= "docker python3-docker-compose"
 FEATURE_PACKAGES_encrypted-fs    ?= "cryptsetup e2fsprogs-mke2fs gptfdisk lvm2 lvm2-udevrules util-linux util-linux-blkid"
 


### PR DESCRIPTION
Adds video sink for gstreamer, running over wayland system.

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>