### PR TITLE
staging/layer.conf: add terrible layerseries compat hack

### DIFF
--- a/meta-mentor-staging/conf/layer.conf
+++ b/meta-mentor-staging/conf/layer.conf
@@ -21,3 +21,7 @@ LICENSE_PATH += "${LAYERDIR}/licenses"
 # We don't want systemd and everything depending on systemd to rebuild when
 # the metadata stored in os-release changes. TODO: push this to oe-core
 SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"
+
+# Terrible hack, but shut up the warning, we know it functions
+LAYERSERIES_COMPAT_efibootguard ??= "sumo"
+LAYERSERIES_COMPAT_xilinx ??= "sumo"


### PR DESCRIPTION
Shutting up warnings from layers that lacked the variable.

JIRA: SB-12065