### PR TITLE
local.conf.sample: Fix initramfs image file creation in deploy folder.

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -289,9 +289,10 @@ BB_DISKMON_DIRS = "\
 # Use this to add extra packages to the split-debug filesystem
 #EXTRA_DEBUG_PACKAGES = "ltrace strace"
 
-# enabling dmcrypt-initramfs-image if the encrypted-fs image feature is added to EXTRA_IMAGE_FEATURES variable.
-INITRAMFS_IMAGE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', '', d)}"
-INITRAMFS_IMAGE_BUNDLE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '1', '', d)}"
+# Uncomment following two lines to enable INITRAMFS. This adds dmcrypt-initramfs-image in 
+# INITRAMFS_IMAGE if encrypted-fs image feature is enabled otherwise add core-image-minimal-initramfs.
+#INITRAMFS_IMAGE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', 'core-image-minimal-initramfs', d)}"
+#INITRAMFS_IMAGE_BUNDLE = "1"
 # removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
 MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
 # Add initramfs image to the boot partition.


### PR DESCRIPTION
* In local.conf INITRAMFS_IMAGE and INITRAMFS_IMAGE_BUNDLE variables were being
  set for encrypted-fs. For generating normal INITRAMFS the location of the vars
  were mattering alot. If those were added after the lines where INITRAMFS_IMAGE
  and INITRAMFS_IMAGE_BUNDLE were being set for encrypted-fs then it worked fine.
  But we those were added earlier then encrypted-fs vars were overwriting it. So
  commented out line which were added for encrypted-fs. Add core-image-minimal-initramfs
  in those lines. Now in order to generate encrypted-fs or normal initramfs one
  has to uncomment following lines

  #INITRAMFS_IMAGE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', 'core-image-minimal-initramfs', d)}"
  #INITRAMFS_IMAGE_BUNDLE = "1"
* SB-12074

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>