### PR TITLE
python-native: fix one do_populate_sysroot warning

### DIFF
--- a/meta-mentor-staging/recipes-devtools/python/python-native/0001-python-native-fix-one-do_populate_sysroot-warning.patch
+++ b/meta-mentor-staging/recipes-devtools/python/python-native/0001-python-native-fix-one-do_populate_sysroot-warning.patch
@@ -1,0 +1,39 @@
+From 12292444e1b3662b994bc223d92b8338fb0895ff Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Thu, 25 Oct 2018 07:32:14 +0000
+Subject: [PATCH] python-native: fix one do_populate_sysroot warning
+
+Fix below warning:
+WARNING: Skipping RPATH /usr/lib64 as is a standard search path for
+work/x86_64-linux/python-native/2.7.15-r1.1/recipe-sysroot-native/
+usr/lib/python2.7/lib-dynload/_bsddb.so
+
+setup.py will check db.h under include_dirs, for native build,
+/usr/lib64 will be insert to postion 0 of include_dirs, so
+it's priority is higher then our sysroot, cause db.h sysroot
+is ignored, and rpath set to /usr/lib64. and this cause warning
+when do_populate_sysroot. use append to fix it.
+
+Upstream-Status: Inappropriate [oe-specific]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 7bf13ed..6c0f29b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -40,7 +40,7 @@ def add_dir_to_list(dirlist, dir):
+     1) 'dir' is not already in 'dirlist'
+     2) 'dir' actually exists, and is a directory."""
+     if dir is not None and os.path.isdir(dir) and dir not in dirlist:
+-        dirlist.insert(0, dir)
++        dirlist.append(dir)
+
+ def macosx_sdk_root():
+     """
+-- 
+2.18.0
+

--- a/meta-mentor-staging/recipes-devtools/python/python-native_2.7.14.bbappend
+++ b/meta-mentor-staging/recipes-devtools/python/python-native_2.7.14.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://0001-python-native-fix-one-do_populate_sysroot-warning.patch"


### PR DESCRIPTION
Fix below warning:
WARNING: Skipping RPATH /usr/lib64 as is a standard search path for
work/x86_64-linux/python-native/2.7.15-r1.1/recipe-sysroot-native/
usr/lib/python2.7/lib-dynload/_bsddb.so

setup.py will check db.h under include_dirs, for native build,
/usr/lib64 will be insert to postion 0 of include_dirs, so
it's priority is higher then our sysroot, cause db.h sysroot
is ignored, and rpath set to /usr/lib64. and this cause warning
when do_populate_sysroot. use append to fix it.

Signed-off-by: Changqing Li <changqing.li@windriver.com>
Signed-off-by: Christopher Larson <chris_larson@mentor.com>