### PR TITLE
mel.conf: update supported distros for elm

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -91,10 +91,10 @@ PACKAGE_CLASSES ?= "package_ipk"
 SANITY_TESTED_DISTROS = "\
     ubuntu-18.04 \n\
     ubuntu-16.04 \n\
-    ubuntu-14.04 \n\
-    centos-7.* \n \
-    centoslinux-7.* \n \
-    redhatenterprise*-7.* \n \
+    centos-7* \n \
+    centoslinux-7* \n \
+    rhel*-7* \n \
+    redhatenterprise*-7* \n \
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)


### PR DESCRIPTION
- Removed ubuntu-14.04
- Also match centos-7, not just centos-7.*
- Also match rhel, not just redhatenterprise