### PR TITLE
staging/layer.conf: hack around LAYERSERIES_COMPAT for qt5-layer

### DIFF
--- a/meta-mentor-staging/conf/layer.conf
+++ b/meta-mentor-staging/conf/layer.conf
@@ -25,3 +25,4 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"
 # Terrible hack, but shut up the warning, we know it functions
 LAYERSERIES_COMPAT_efibootguard ??= "sumo"
 LAYERSERIES_COMPAT_xilinx ??= "sumo"
+LAYERSERIES_COMPAT_qt5-layer ??= "sumo"


### PR DESCRIPTION
Adding to the tradition set in 3c373331, fix QA warning
WARNING: Layer qt5-layer should set LAYERSERIES_COMPAT_qt5-layer in its conf/layer.conf file to list the core layer names it is compatible with.

Signed-off-by: Awais Belal <awais_belal@mentor.com>