### PR TITLE
setup-mel-builddir: set BBLAYERS using loose assignment

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -125,7 +125,7 @@ configure_for_machine () {
     sed -i -e"s/^#*MACHINE *?*=.*/MACHINE ??= \"$MACHINE\"/" $BUILDDIR/conf/local.conf
     sed -n -i -e "s|##COREBASE##|$OEROOT|g" -e '/^BBLAYERS /{ :start; /\\$/{n; b start}; d; }; p' -e "/BBFILE_PRIORITY/d" $BUILDDIR/conf/bblayers.conf
 
-    echo 'BBLAYERS = "\' >> $BUILDDIR/conf/bblayers.conf
+    echo 'BBLAYERS ?= "\' >> $BUILDDIR/conf/bblayers.conf
     layersfile=$(mktemp setup-mel-builddir.XXXXXX)
 
     # Convert layer paths to layer names for bb-determine-layers


### PR DESCRIPTION
In cases such as toaster the setting for BBLAYERS is
done through cmdline params and then during the parse
phase bblayers.conf is picked up which overrides the
setting that was passed if we use a simple set (=)
here.
Fix this by using loose assignment so cmdline params
work as expected.

JIRA: SB-12082.

Signed-off-by: Awais Belal <awais_belal@mentor.com>