### PR TITLE
mel-image.inc: Add haveged as entropy source.

### DIFF
--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -10,4 +10,4 @@ LICENSE = "MIT"
 inherit core-image image-sanity-incompatible
 
 IMAGE_FEATURES .= "${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
-IMAGE_INSTALL += " util-linux connman"
+IMAGE_INSTALL += " util-linux connman ${@bb.utils.contains("INCOMPATIBLE_LICENSE", "GPLv3", "", "haveged", d)}"


### PR DESCRIPTION
If GPLv3 license is allowed to be used, haveged is added as an entropy
source so that if user does not use random input sources like keyboard
and mouse, MEL image still has a random number's source.

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>