### PR TITLE
bblayers/dl: add command for dumping license information

### DIFF
--- a/meta-mel/lib/bblayers/mel_utils.py
+++ b/meta-mel/lib/bblayers/mel_utils.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('bitbake-layers')
 
 
 def plugin_init(plugins):
-    return DownloadsPlugin()
+    return MELUtilsPlugin()
 
 
 def iter_except(func, exception, first=None):
@@ -47,7 +47,7 @@ def iter_except(func, exception, first=None):
           pass
 
 
-class DownloadsPlugin(LayerPlugin):
+class MELUtilsPlugin(LayerPlugin):
     def _get_depgraph(self, targets, task='do_build'):
         depgraph = None
 


### PR DESCRIPTION
For OSS approvals we need to provide list of items that are
being built/distributed along with their version and license
information. This now adds a command 'dump-licenses' to
bitbake-layers to aid this requirement.

Signed-off-by: Awais Belal <awais_belal@mentor.com>