### PR TITLE
icedtea7-native,openjdk-8: fix newer gcc failures/warnings

### DIFF
--- a/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native/0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch
+++ b/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native/0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch
@@ -1,0 +1,89 @@
+From 4163c0a0eb88263a3d3e593942cd9cf402909977 Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Mon, 5 Nov 2018 22:23:43 +0500
+Subject: [PATCH] PR3597: Potential bogus -Wformat-overflow warning with
+ -Wformat enabled
+
+2018-05-29  Andrew John Hughes  <gnu_andrew@member.fsf.org>
+
+	PR3597: Potential bogus -Wformat-overflow warning
+	with -Wformat enabled
+	* Makefile.am:
+	(ICEDTEA_PATCHES): Add patch.
+	* NEWS: Updated.
+	* patches/pr3597.patch:
+	Disable -Wformat-overflow on the
+	the build_pipe_classes function with GCC >= 7 as it
+	produces apparent false positives.
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ Makefile.am          |  4 ++++
+ patches/pr3597.patch | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 47 insertions(+)
+ create mode 100644 patches/pr3597.patch
+
+diff --git a/Makefile.am b/Makefile.am
+index 5f0c90d..c1950b5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -277,6 +277,10 @@ else
+ ICEDTEA_PATCHES += patches/nss-not-enabled-config.patch
+ endif
+ 
++# Apply additional HotSpot patches against same patch base
++ICEDTEA_PATCHES += \
++	patches/pr3597.patch
++
+ ICEDTEA_PATCHES += $(DISTRIBUTION_PATCHES)
+ 
+ # Bootstrapping patches
+diff --git a/patches/pr3597.patch b/patches/pr3597.patch
+new file mode 100644
+index 0000000..5e3b4ef
+--- /dev/null
++++ b/patches/pr3597.patch
+@@ -0,0 +1,43 @@
++diff --git openjdk.orig/hotspot/src/share/vm/adlc/adlc.hpp openjdk/hotspot/src/share/vm/adlc/adlc.hpp
++--- openjdk.orig/hotspot/src/share/vm/adlc/adlc.hpp
+++++ openjdk/hotspot/src/share/vm/adlc/adlc.hpp
++@@ -85,6 +85,19 @@
++ #undef max
++ #define max(a, b)   (((a)>(b)) ? (a) : (b))
++ 
+++#if !defined(__clang_major__) && (__GNUC__ >= 7)
+++#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
+++#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
+++#define PRAGMA_FORMAT_OVERFLOW_IGNORED _Pragma("GCC diagnostic ignored \"-Wformat-overflow\"")
+++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL PRAGMA_FORMAT_OVERFLOW_IGNORED
+++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_INTERNAL PRAGMA_FORMAT_OVERFLOW_IGNORED
+++#else
+++#define PRAGMA_DIAG_PUSH
+++#define PRAGMA_DIAG_POP
+++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL
+++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_INTERNAL
+++#endif
+++
++ // ADLC components
++ #include "arena.hpp"
++ #include "opto/adlcVMDeps.hpp"
++diff --git openjdk.orig/hotspot/src/share/vm/adlc/output_c.cpp openjdk/hotspot/src/share/vm/adlc/output_c.cpp
++--- openjdk.orig/hotspot/src/share/vm/adlc/output_c.cpp
+++++ openjdk/hotspot/src/share/vm/adlc/output_c.cpp
++@@ -560,6 +560,8 @@
++   return (ndx);
++ }
++ 
+++PRAGMA_DIAG_PUSH
+++PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL
++ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
++   const char *classname;
++   const char *resourcename;
++@@ -1016,6 +1018,7 @@
++   fprintf(fp_cpp, "}\n");
++   fprintf(fp_cpp, "#endif\n");
++ }
+++PRAGMA_DIAG_POP
++ 
++ // ---------------------------------------------------------------------------
++ //------------------------------Utilities to build Instruction Classes--------

--- a/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native/0002-8184309-PR3596-Build-warnings-from-GCC-7.1-on-Fedora.patch
+++ b/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native/0002-8184309-PR3596-Build-warnings-from-GCC-7.1-on-Fedora.patch
@@ -1,0 +1,55 @@
+From 18cc03a4713ff7c69a909950f9e3aca5de7db38e Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Tue, 6 Nov 2018 02:18:35 +0500
+Subject: [PATCH] 8184309, PR3596: Build warnings from GCC 7.1 on Fedora 26
+
+Another patch from upstream icedtea.
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ Makefile.am                  |  3 ++-
+ patches/8184309-pr3596.patch | 21 +++++++++++++++++++++
+ 2 files changed, 23 insertions(+), 1 deletion(-)
+ create mode 100644 patches/8184309-pr3596.patch
+
+Index: icedtea-2.1.3/Makefile.am
+===================================================================
+--- icedtea-2.1.3.orig/Makefile.am
++++ icedtea-2.1.3/Makefile.am
+@@ -279,7 +279,8 @@ endif
+ 
+ # Apply additional HotSpot patches against same patch base
+ ICEDTEA_PATCHES += \
+-	patches/pr3597.patch
++	patches/pr3597.patch \
++	patches/8184309-pr3596.patch
+ 
+ ICEDTEA_PATCHES += $(DISTRIBUTION_PATCHES)
+ 
+Index: icedtea-2.1.3/patches/8184309-pr3596.patch
+===================================================================
+--- /dev/null
++++ icedtea-2.1.3/patches/8184309-pr3596.patch
+@@ -0,0 +1,22 @@
++# HG changeset patch
++# User ysuenaga
++# Date 1527498573 -3600
++#      Mon May 28 10:09:33 2018 +0100
++# Node ID ef176cb429c49d1c330d9575938f66b04e3fb730
++# Parent  6915dc9ae18cce5625d3a3fc74b37da70a5b4215
++8184309, PR3596: Build warnings from GCC 7.1 on Fedora 26
++Reviewed-by: kbarrett, vlivanov
++
++Index: openjdk/hotspot/src/share/vm/code/dependencies.cpp
++===================================================================
++--- openjdk.orig/hotspot/src/share/vm/code/dependencies.cpp
+++++ openjdk/hotspot/src/share/vm/code/dependencies.cpp
++@@ -488,7 +488,7 @@ void Dependencies::write_dependency_to(x
++     if (j == 1) {
++       xtty->object("x", args[j]);
++     } else {
++-      char xn[10]; sprintf(xn, "x%d", j);
+++      char xn[12]; sprintf(xn, "x%d", j);
++       xtty->object(xn, args[j]);
++     }
++   }

--- a/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native_%.bbappend
+++ b/meta-mentor-staging/meta-java/recipes-core/icedtea/icedtea7-native_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+    file://0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch \
+    file://0002-8184309-PR3596-Build-warnings-from-GCC-7.1-on-Fedora.patch \
+"

--- a/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8-native_%.bbappend
+++ b/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8-native_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch"
+

--- a/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8/0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch
+++ b/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8/0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch
@@ -1,0 +1,71 @@
+From 7efbc09cf4fb6aa9c081974d378d503c8bb0745e Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Mon, 5 Nov 2018 21:01:47 +0500
+Subject: [PATCH] PR3597: Potential bogus -Wformat-overflow warning with
+ -Wformat enabled
+
+2018-05-29 Andrew John Hughes <gnu_andrew@member.fsf.org>
+
+PR3597: Potential bogus -Wformat-overflow warning
+with -Wformat enabled
+* Makefile.am:
+* (ICEDTEA_PATCHES): Add patch.
+* * NEWS: Updated.
+* * patches/pr3597.patch:
+* Disable -Wformat-overflow on the
+* the build_pipe_classes function with GCC >= 7 as it
+* produces apparent false positives.
+
+Patch pulled from the icedtea project.
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ hotspot/src/share/vm/adlc/adlc.hpp     | 13 +++++++++++++
+ hotspot/src/share/vm/adlc/output_c.cpp |  3 +++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/hotspot/src/share/vm/adlc/adlc.hpp b/hotspot/src/share/vm/adlc/adlc.hpp
+index 8d48ed60..48a226ae 100644
+--- a/hotspot/src/share/vm/adlc/adlc.hpp
++++ b/hotspot/src/share/vm/adlc/adlc.hpp
+@@ -85,6 +85,19 @@ typedef unsigned int uintptr_t;
+ #undef max
+ #define max(a, b)   (((a)>(b)) ? (a) : (b))
+ 
++#if !defined(__clang_major__) && (__GNUC__ >= 7)
++#define PRAGMA_DIAG_PUSH             _Pragma("GCC diagnostic push")
++#define PRAGMA_DIAG_POP              _Pragma("GCC diagnostic pop")
++#define PRAGMA_FORMAT_OVERFLOW_IGNORED _Pragma("GCC diagnostic ignored \"-Wformat-overflow\"")
++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL PRAGMA_FORMAT_OVERFLOW_IGNORED
++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_INTERNAL PRAGMA_FORMAT_OVERFLOW_IGNORED
++#else
++#define PRAGMA_DIAG_PUSH
++#define PRAGMA_DIAG_POP
++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL
++#define PRAGMA_FORMAT_OVERFLOW_IGNORED_INTERNAL
++#endif
++
+ // ADLC components
+ #include "arena.hpp"
+ #include "opto/adlcVMDeps.hpp"
+diff --git a/hotspot/src/share/vm/adlc/output_c.cpp b/hotspot/src/share/vm/adlc/output_c.cpp
+index f53dbd58..7a59ec59 100644
+--- a/hotspot/src/share/vm/adlc/output_c.cpp
++++ b/hotspot/src/share/vm/adlc/output_c.cpp
+@@ -560,6 +560,8 @@ static int pipeline_res_mask_initializer(
+   return (ndx);
+ }
+ 
++PRAGMA_DIAG_PUSH
++PRAGMA_FORMAT_OVERFLOW_IGNORED_EXTERNAL
+ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
+   const char *classname;
+   const char *resourcename;
+@@ -1016,6 +1018,7 @@ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
+   fprintf(fp_cpp, "}\n");
+   fprintf(fp_cpp, "#endif\n");
+ }
++PRAGMA_DIAG_POP
+ 
+ // ---------------------------------------------------------------------------
+ //------------------------------Utilities to build Instruction Classes--------

--- a/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
+++ b/meta-mentor-staging/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-PR3597-Potential-bogus-Wformat-overflow-warning-with.patch"
+


### PR DESCRIPTION
Apply patches from upstream icedtea.

JIRA: SB-12077