### PR TITLE
update_font_cache: fix warnings

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -271,6 +271,9 @@ INHERIT += "resize-rootfs-gplv3"
 
 # Pull files/toolchain-shar-relocate.sh from BBPATH
 INHERIT += "${@'toolchain_shar_relocate_bbpath' if 'mentor-staging' in d.getVar('BBFILE_COLLECTIONS').split() else ''}"
+
+# Adjust fontcache/pixbufcache classes for oe-core d10fd6ae3f
+INHERIT += "${@'cachefixes' if 'mentor-staging' in '${BBFILE_COLLECTIONS}'.split() else ''}"
 ## }}}1
 ## Preferences & Package Selection {{{1
 PREFERRED_VERSION_linux-yocto ?= "4.12%"

--- a/meta-mentor-staging/classes/cachefixes.bbclass
+++ b/meta-mentor-staging/classes/cachefixes.bbclass
@@ -1,0 +1,9 @@
+python add_binprefix () {
+    for cclass in ['fontcache', 'pixbufcache']:
+        if bb.data.inherits_class(cclass, d):
+            common = d.getVar(cclass + '_common', False)
+            common = common.replace('mlprefix=${MLPREFIX}', 'mlprefix=${MLPREFIX} binprefix=${MLPREFIX}')
+            d.setVar(cclass + '_common', common)
+}
+add_binprefix[eventmask] = "bb.event.RecipeParsed"
+addhandler add_binprefix

--- a/meta-mentor-staging/postinst-intercepts/update_font_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_font_cache
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D/${libdir}:$D/${base_libdir} \
+					-E ${fontconfigcacheenv} $D${bindir}/fc-cache --sysroot=$D --system-only ${fontconfigcacheparams}
+chown -R root:root $D${fontconfigcachedir}

--- a/meta-mentor-staging/postinst-intercepts/update_font_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_font_cache
@@ -2,6 +2,5 @@
 
 set -e
 
-PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D/${libdir}:$D/${base_libdir} \
-					-E ${fontconfigcacheenv} $D${bindir}/fc-cache --sysroot=$D --system-only ${fontconfigcacheparams}
+PSEUDO_UNLOAD=1 ${binprefix}qemuwrapper -L $D -E ${fontconfigcacheenv} $D${bindir}/fc-cache --sysroot=$D --system-only ${fontconfigcacheparams}
 chown -R root:root $D${fontconfigcachedir}

--- a/meta-mentor-staging/postinst-intercepts/update_font_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_font_cache
@@ -2,5 +2,5 @@
 
 set -e
 
-PSEUDO_UNLOAD=1 ${binprefix}qemuwrapper -L $D -E ${fontconfigcacheenv} $D${bindir}/fc-cache --sysroot=$D --system-only ${fontconfigcacheparams}
+PSEUDO_UNLOAD=1 ${binprefix}qemuwrapper -L $D -E ${fontconfigcacheenv} $D${libexecdir}/${binprefix}fc-cache --sysroot=$D --system-only ${fontconfigcacheparams}
 chown -R root:root $D${fontconfigcachedir}

--- a/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
@@ -2,8 +2,7 @@
 
 set -e
 
-PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D${libdir}:$D${base_libdir} \
-	$D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
+PSEUDO_UNLOAD=1 ${binprefix}qemuwrapper -L $D $D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
 
 [ ! -e $D${libdir}/gio/modules/giomodule.cache ] ||
 	chown root:root $D${libdir}/gio/modules/giomodule.cache

--- a/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_gio_module_cache
@@ -3,10 +3,7 @@
 set -e
 
 PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D${libdir}:$D${base_libdir} \
-        $D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
+	$D${libexecdir}/${binprefix}gio-querymodules $D${libdir}/gio/modules/
 
-# If no modules are installed, no cache file will be written
-if [ -e $D${libdir}/gio/modules/giomodule.cache ]; then
-    chown root:root $D${libdir}/gio/modules/giomodule.cache
-fi
-
+[ ! -e $D${libdir}/gio/modules/giomodule.cache ] ||
+	chown root:root $D${libdir}/gio/modules/giomodule.cache

--- a/meta-mentor-staging/postinst-intercepts/update_pixbuf_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_pixbuf_cache
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+export GDK_PIXBUF_MODULEDIR=$D${libdir}/gdk-pixbuf-2.0/2.10.0/loaders
+export GDK_PIXBUF_FATAL_LOADER=1
+
+PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D/${libdir}:$D/${base_libdir}\
+    $D${libdir}/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders \
+    >$GDK_PIXBUF_MODULEDIR/../loaders.cache && \
+    sed -i -e "s:$D::g" $GDK_PIXBUF_MODULEDIR/../loaders.cache

--- a/meta-mentor-staging/postinst-intercepts/update_pixbuf_cache
+++ b/meta-mentor-staging/postinst-intercepts/update_pixbuf_cache
@@ -5,7 +5,6 @@ set -e
 export GDK_PIXBUF_MODULEDIR=$D${libdir}/gdk-pixbuf-2.0/2.10.0/loaders
 export GDK_PIXBUF_FATAL_LOADER=1
 
-PSEUDO_UNLOAD=1 qemuwrapper -L $D -E LD_LIBRARY_PATH=$D/${libdir}:$D/${base_libdir}\
-    $D${libdir}/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders \
+PSEUDO_UNLOAD=1 ${binprefix}qemuwrapper -L $D $D${libdir}/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders \
     >$GDK_PIXBUF_MODULEDIR/../loaders.cache && \
     sed -i -e "s:$D::g" $GDK_PIXBUF_MODULEDIR/../loaders.cache

--- a/meta-mentor-staging/postinst-intercepts/x86-64/update_font_cache
+++ b/meta-mentor-staging/postinst-intercepts/x86-64/update_font_cache
@@ -1,5 +1,0 @@
-#!/bin/sh
-# qemu user emulation for x86_64 sees a hang/freeze when trying to run
-# fc-cache, when using the sourcery toolchain, but it runs fine in system
-# emulation, so exit 1 and let it run on first boot instead
-exit 1

--- a/meta-mentor-staging/recipes-devtools/qemu/qemuwrapper-cross_%.bbappend
+++ b/meta-mentor-staging/recipes-devtools/qemu/qemuwrapper-cross_%.bbappend
@@ -1,0 +1,14 @@
+do_install_append () {
+	rm -f ${D}${bindir_crossscripts}/qemuwrapper
+ 
+	qemu_options='${QEMU_OPTIONS} -E LD_LIBRARY_PATH=$D${libdir}:$D${base_libdir}'
+
+	cat >> ${D}${bindir_crossscripts}/${MLPREFIX}qemuwrapper << EOF
+#!/bin/sh
+set -x
+
+$qemu_binary $qemu_options "\$@"
+EOF
+
+	chmod +x ${D}${bindir_crossscripts}/${MLPREFIX}qemuwrapper
+}

--- a/meta-mentor-staging/recipes-graphics/fontconfig/fontconfig_%.bbappend
+++ b/meta-mentor-staging/recipes-graphics/fontconfig/fontconfig_%.bbappend
@@ -1,0 +1,7 @@
+do_install_append_class-target() {
+    # duplicate fc-cache for postinstall script
+    mkdir -p ${D}${libexecdir}
+    ln ${D}${bindir}/fc-cache ${D}${libexecdir}/${MLPREFIX}fc-cache
+}
+
+FILES_fontconfig-utils += "${libexecdir}/*"


### PR DESCRIPTION
This series applies a couple patches from oe-core which fixes the
update_font_cache failures seen on x86-64 and elsewhere relating to multilibs,
adjusted to work in meta-mentor-staging without overriding the classes in
question. We no longer see warnings for this postinst intercept with this
applied.

JIRA: SB-12123