### PR TITLE
mel.conf: Reorder BSP_VERSION and PATCH_VERSION.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -7,7 +7,7 @@ SDK_VENDOR = "-melsdk"
 
 # Distro and release versioning
 DISTRO_VERSION = "11"
-ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${PATCH_VERSION}.${BSP_VERSION}"
+ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181001"
 
 # Default values for BSP and PATCH version, to be redefined in other layers


### PR DESCRIPTION
* In order to show the version in this order
  distro_version.bsp_version.patch_version just reorder the variables.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>