### PR TITLE
busybox: enable reboot support

### DIFF
--- a/meta-mentor-staging/recipes-core/busybox/busybox/reboot.cfg
+++ b/meta-mentor-staging/recipes-core/busybox/busybox/reboot.cfg
@@ -1,0 +1,1 @@
+CONFIG_REBOOT=y

--- a/meta-mentor-staging/recipes-core/busybox/busybox_1.27.%.bbappend
+++ b/meta-mentor-staging/recipes-core/busybox/busybox_1.27.%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI_append_mel = " file://reboot.cfg"


### PR DESCRIPTION
996247ba7dfffbeb444f793f7e105fcfb5ffa939 in upstream oe-core
moved the power flags (POWEROFF, HALT, REBOOT) to a fragment
init.cfg which is only included when busybox is selected as
the init_manager. This assumption is incorrect in scenarios
where installation mechanism is provided through live images
and almost all the initramfs scripts use the reboot command at
the end of installation. Without this change we see
reboot: not found

Signed-off-by: Awais Belal <awais_belal@mentor.com>