### PR TITLE
toaster_configuration: conform to new mechanism of BBLAYERS

### DIFF
--- a/scripts/toaster_configuration
+++ b/scripts/toaster_configuration
@@ -18,7 +18,7 @@ OE_CORE_NAME="openembedded-core"
 BBLAYERS=
 configured_layers () {
    tac "$BUILDDIR/conf/bblayers.conf" | \
-   sed -n -e '/^"/,/^BBLAYERS = /{ /^BBLAYERS =/d; /^"/d; p;}' | \
+   sed -n -e '/^"/,/^BBLAYERS ?= /{ /^BBLAYERS ?=/d; /^"/d; p;}' | \
    awk {'print $1'}
 }
 


### PR DESCRIPTION
BBLAYERS is now set using a weak assignment rather than a
strict one. See 6ac988dcad81b6bfa38e15446618184258d23eba
in meta-mentor. Without this the BBLAYERS variable isn't
parsed and picked up correctly.

JIRA: SB-12165.

Signed-off-by: Awais Belal <awais_belal@mentor.com>