### PR TITLE
initramfs-framework: move storage mounts to actual rootfs

### DIFF
--- a/meta-mentor-staging/recipes-core/initrdscripts/files/0001-initramfs-framework-finish-move-mounts-to-rootfs-bef.patch
+++ b/meta-mentor-staging/recipes-core/initrdscripts/files/0001-initramfs-framework-finish-move-mounts-to-rootfs-bef.patch
@@ -1,0 +1,51 @@
+From 59f5fd34edae4e1c4633b160ee6c6e51ec6a98e4 Mon Sep 17 00:00:00 2001
+From: Awais Belal <awais_belal@mentor.com>
+Date: Wed, 28 Nov 2018 13:02:08 +0500
+Subject: [PATCH] initramfs-framework/finish: move mounts to rootfs before
+ switching
+
+If basic device mounts are not moved onto the rootfs before
+switching, the device is not properly accessible for operations
+such as mkfs and for such devices once the system is fully booted
+we see
+
+root@v1000:~# mkfs.ext4 /dev/sdb1
+mke2fs 1.43.8 (1-Jan-2018)
+/dev/sdb1 contains a ext4 file system
+	last mounted on Wed Nov 28 07:33:54 2018
+Proceed anyway? (y,N) y
+/dev/sdb1 is apparently in use by the system; will not make a filesystem here!
+
+This fragment is picked up from initramfs-live-boot. See
+8293f564685d0f587ab63a107285625dc4f98f1c and
+6f8f984ba363f764e83290b972ec31a90aad1603
+for more details.
+
+Signed-off-by: Awais Belal <awais_belal@mentor.com>
+---
+ finish | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/finish b/finish
+index 717383e..9722d02 100755
+--- a/finish
++++ b/finish
+@@ -14,6 +14,15 @@ finish_run() {
+ 
+ 		info "Switching root to '$ROOTFS_DIR'..."
+ 
++		debug "Moving basic mounts onto rootfs"
++		for dir in `awk '/\/dev.* \/run\/media/{print $2}' /proc/mounts`; do
++			# Parse any OCT or HEX encoded chars such as spaces
++			# in the mount points to actual ASCII chars
++			dir=`printf $dir`
++			mkdir -p "${ROOTFS_DIR}/media/${dir##*/}"
++			mount -n --move "$dir" "${ROOTFS_DIR}/media/${dir##*/}"
++		done
++
+ 		debug "Moving /dev, /proc and /sys onto rootfs..."
+ 		mount --move /dev $ROOTFS_DIR/dev
+ 		mount --move /proc $ROOTFS_DIR/proc
+-- 
+2.11.1
+

--- a/meta-mentor-staging/recipes-core/initrdscripts/initramfs-framework_1.0.bbappend
+++ b/meta-mentor-staging/recipes-core/initrdscripts/initramfs-framework_1.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-initramfs-framework-finish-move-mounts-to-rootfs-bef.patch"


### PR DESCRIPTION
Operations such as mkfs fail on devices that are not
switched to the actual rootfs before switch_root is
called. The kernel interprets these devices as still
being used even after unmounting and errors such as
below are seen when the target is fully booted

root@v1000:~# umount /dev/sdb1
root@v1000:~# mkfs.ext4 /dev/sdb1
mke2fs 1.43.8 (1-Jan-2018)
/dev/sdb1 contains a ext4 file system
	last mounted on Wed Nov 28 07:33:54 2018
Proceed anyway? (y,N) y
/dev/sdb1 is apparently in use by the system; will not make a filesystem here!

Signed-off-by: Awais Belal <awais_belal@mentor.com>