### PR TITLE
Exclude vmlinux from production-image

### DIFF
--- a/meta-mel-support/recipes-core/images/production-image.bb
+++ b/meta-mel-support/recipes-core/images/production-image.bb
@@ -12,3 +12,7 @@ IMAGE_FEATURES_DISABLED_PRODUCTION ?= "debug-tweaks codebench-debug tools-profil
 IMAGE_FEATURES_remove = "${IMAGE_FEATURES_DISABLED_PRODUCTION}"
 
 require recipes-core/images/mel-image.inc
+
+# Exclude the extra vmlinux from production, as this is used for debugging
+EXTRA_VMLINUX = "${@'1' if 'vmlinux' in set(d.getVar('KERNEL_IMAGETYPES').split()) and len(set(d.getVar('KERNEL_IMAGETYPES').split())) > 1 else ''}"
+BAD_RECOMMENDATIONS += "${@'kernel-image-vmlinux' if d.getVar('EXTRA_VMLINUX') == '1' else ''}"

--- a/meta-mel/classes/kernel_rdeps.bbclass
+++ b/meta-mel/classes/kernel_rdeps.bbclass
@@ -1,0 +1,9 @@
+python () {
+    name = d.getVar('KERNEL_PACKAGE_NAME')
+    for pkg in [name + '-base', name + '-image']:
+        rdeps = d.getVar('RDEPENDS_%s' % pkg, False)
+        if rdeps and rdeps.strip():
+            bb.debug(1, 'Converted rdeps to rrecs for %s: %s' % (pkg, rdeps))
+            d.setVar('RDEPENDS_%s' % pkg, '')
+            d.appendVar('RRECOMMENDS_%s' % pkg, ' ' + rdeps)
+}

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -250,6 +250,10 @@ BUILDHISTORY_COMMIT ?= "1"
 # Copy the image license manifest into DEPLOY_DIR_IMAGE
 INHERIT += "deploy-license-manifest"
 
+# Convert kernel-base & kernel-image rdeps to rrecs, to allow us or the user
+# to exclude image packages with BAD_RECOMMENDATIONS
+KERNEL_CLASSES_append = " kernel_rdeps"
+
 # Support USER_FEATURES
 INHERIT += "user_features"
 


### PR DESCRIPTION
We'll need to discuss whether this is appropriate for sumo for patch releases and asyncs or if it should go directly to master. There's also the question of whether to default to exclusion for all images and explicitly include it in development-image, or this approach, which leaves it included in images by default and excludes it explicitly in production-image.