### PR TITLE
mel.conf: remove vmlinux from KERNEL_IMAGETYPES to reduce image size

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -329,9 +329,6 @@ FEATURE_PACKAGES_samba-server    ?= "samba swat"
 # Include nss-myhostname for sysvinit, so the hostname resolves. systemd
 # includes myhostname itself.
 DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
-
-# Include vmlinux in DEPLOY_DIR_IMAGE for debugging purposes
-KERNEL_IMAGETYPES_append = " vmlinux"
 ## }}}1
 ## Workarounds & Overrides {{{1
 # qemu (g-ir-scanner-qemuwrapper) keeps segfaulting in vte, bypass the issue for now


### PR DESCRIPTION
This essentially reverts 56cb67a401135d7f9c70511053c2284435f5f4d7 as
the intent of KERNEL_IMAGETYPES has changed. i.e. adding vmlinux to
KERNEL_IMAGETYPES ends up in tmp/deploy/images/${MACHINE} but also
ends up in the rootfs of the image being built where it is not needed
for any MEL requirements, and as a side-effect, it results in
increasing the size of the image by a considerable amount:

root@snowyowl:~# du -h /boot/vmlinux-4.14.71-yocto-standard
598.5M  /boot/vmlinux-4.14.71-yocto-standard

This happens because oe-core/meta/classes/kernel.bbclass takes all
the KERNEL_IMAGETYPES and creates PACKAGES and sets the kernel-image
package to RDEPENDS on kernel-image-<KERNEL_IMAGETYPES> pkgs:

root@snowyowl:~# opkg info kernel-image-4.14.71-yocto-standard
Package: kernel-image-4.14.71-yocto-standard
Version: 4.14.71+git0+c35dd5cbbd_78a16a4d8c-r4.1.7
Depends: kernel-image-bzimage-4.14.71-yocto-standard,
         kernel-image-vmlinux-4.14.71-yocto-standard
Provides: kernel-image
Status: install ok installed
Architecture: snowyowl
Installed-Time: 1542878281

root@snowyowl:~# opkg list-installed | grep -o "kernel-image.* "
kernel-image-4.14.71-yocto-standard -
kernel-image-bzimage-4.14.71-yocto-standard -
kernel-image-vmlinux-4.14.71-yocto-standard -

The vmlinux binary still gets generated in the kernel build dir even
if it is not in KERNEL_IMAGETYPES because all other image types such
as: vmlinux.bin, vmlinuz, zImage & bzImage etc are created from the
vmlinux binary itself. Therefore, in case vmlinux is needed for
kernel debugging purpose, it is still available in the kernel build
dir just as it is documented in the mel_user guide.

Ref: https://unix.stackexchange.com/questions/5518/what-is-the-difference-between-the-following-kernel-makefile-terms-vmlinux-vml

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>