### PR TITLE
mel.conf: Update PDK_LICENSE_VERSION_DATE to final RC date.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -8,7 +8,7 @@ SDK_VENDOR = "-melsdk"
 # Distro and release versioning
 DISTRO_VERSION = "11"
 ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
-PDK_LICENSE_VERSION_DATE = "20181130"
+PDK_LICENSE_VERSION_DATE = "20181206"
 
 # Version of the mel-scripts artifact, including setup-mel
 SCRIPTS_VERSION ?= "0"


### PR DESCRIPTION
* PDK_LICENSE_VERSION_DATE is updated to Dec 6th as final RC for elm release.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>