### PR TITLE
Fix mel-lite and codebench-lite handling in setup scripts

### DIFF
--- a/scripts/release/setup-workspace
+++ b/scripts/release/setup-workspace
@@ -105,3 +105,6 @@ if [ $? -ne 0 ]; then
     fi
     exit 1
 fi
+if [ -e "$scriptdir/../.mel-lite" ]; then
+    touch "$WORKSPACEDIR/.mel-lite"
+fi

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -314,12 +314,17 @@ setup_builddir () {
         echo "You had no local.conf file. This configuration file has therefore been"
         echo "created for you with some default values."
 
-        if [ -h "$MELDIR/codebench" ]; then
-            codebench_path="$(cd "$MELDIR" && cd "$(readlink codebench)" && pwd -P)" || codebench_path="$MELDIR/../../codebench"
-            sedexpr="\${MELDIR}/codebench"
+        codebench_type="codebench"
+        if [ "$DISTRO" = "mel-lite" ]; then
+            codebench_type="codebench-lite"
+        fi
+
+        if [ -h "$MELDIR/$codebench_type" ]; then
+            codebench_path="$(cd "$MELDIR" && cd "$(readlink $codebench_type)" && pwd -P)" || codebench_path="$MELDIR/../../$codebench_type"
+            sedexpr="\${MELDIR}/$codebench_type"
         else
-            codebench_path="$MELDIR/../../codebench"
-            sedexpr="\${MELDIR}/../../codebench"
+            codebench_path="$MELDIR/../../$codebench_type"
+            sedexpr="\${MELDIR}/../../$codebench_type"
         fi
 
         if [ -d "$codebench_path" ]; then
@@ -398,9 +403,6 @@ layerdir="${scriptsdir%/*}"
 setup_builddir "$@" || exit $?
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$DISTRO\'/" $BUILDDIR/conf/local.conf
-    if [ -d "$MELDIR/../../codebench-lite" ]; then
-        sed -i -e 's,^#\?EXTERNAL_TOOLCHAIN.*,EXTERNAL_TOOLCHAIN ?= "${MELDIR}/../../codebench-lite",' "$BUILDDIR/conf/local.conf"
-    fi
 fi
 
 if [ $toasterconfig -eq 1 ]; then

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -395,10 +395,6 @@ scriptsdir="$(cd $(dirname $0) && pwd)"
 scriptsdir="$(abspath $scriptsdir)"
 layerdir="${scriptsdir%/*}"
 
-if [ -e $layerdir/../.mel-lite ]; then
-    DISTRO="mel-lite"
-fi
-
 setup_builddir "$@" || exit $?
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$DISTRO\'/" $BUILDDIR/conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -42,6 +42,12 @@ else
             fi
         done
 
+        if [ -z "${DISTRO}" ]; then
+            if [ -e "$layerdir/../.mel-lite" ]; then
+                export DISTRO="mel-lite"
+            fi
+        fi
+
         if [ "${DISTRO}" = "mel-lite" ]; then
             OPTIONALLAYERS="${OPTIONALLAYERS-tracing-layer}"
         else


### PR DESCRIPTION
The workspace setup script needs to pass on information regarding mel-lite variant to the workspace itself so once the scripts from the workspace are executed they can detect the presence of the distro. Furthermore, the setup scripts inside the workspace are fixed to handle the mel-lite and codebench-lite cases.