### PR TITLE
util-linux: disable redundant packages leaving only mkfs as required

### DIFF
--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -10,4 +10,4 @@ LICENSE = "MIT"
 inherit core-image image-sanity-incompatible
 
 IMAGE_FEATURES .= "${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
-IMAGE_INSTALL += " util-linux connman ${@bb.utils.contains("INCOMPATIBLE_LICENSE", "GPLv3", "", "haveged", d)}"
+IMAGE_INSTALL += " util-linux-mkfs connman ${@bb.utils.contains("INCOMPATIBLE_LICENSE", "GPLv3", "", "haveged", d)}"


### PR DESCRIPTION
util-linux was enabled recently:
5b0efbdc6710cef767334eedea55b99dfc798f15
which provides more than 15 sub-packages, most of which are already
provided by busybox which are being used by default in oe-core.
Since we only need mkfs, this commit enables only that instead of all 
the util-linux-* packages, which are not only redundant, but also may 
cause conflicts and errors such as following:

fdisk from util-linux, when run like e.g.:

$ fdisk /dev/sda

at its start causes the kernel to generate remove+change+add events for 
all the existing partitions of /dev/sda. This triggers the udev
automount.rules to start the mount.sh for all the partitions, hence
remounts all the existing partitions before we could create new ones.

Hence this disables util-linux-fdisk as well, still leaving us with
the busybox-fdisk which works perfectly fine. busybox-fdisk is also the 
default fdisk in oe-core. This auto-remount issue started when we
enabled all the packages of util-linux including util-linux-fdisk.

JIRA: INTAMDDET-2606

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>