### PR TITLE
mel-lite.conf: fix SANITY_TESTED_DISTROS for elm release

### DIFF
--- a/meta-mel/conf/distro/mel-lite.conf
+++ b/meta-mel/conf/distro/mel-lite.conf
@@ -5,7 +5,7 @@ DISTRO_NAME += "Lite"
 DISTROOVERRIDES = "${DISTRO}:mel"
 
 SANITY_TESTED_DISTROS = "\
-    Ubuntu-16.04 \n\
+    ubuntu-18.04 \n\
 "
 
 GLIBCVERSION ?= "2.28%"


### PR DESCRIPTION
We're only supporting Ubuntu 18.04 for the MEL Lite ELM
release.

JIRA: INTAMDDET-2611.

Signed-off-by: Awais Belal <awais_belal@mentor.com>