### PR TITLE
setup-mel-builddir: make the -l argument cumulative

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -46,7 +46,9 @@ Options:
                If any path in this list contains wildcards, the list must be quoted
                to avoid wildcard substitution by the shell
   -l LAYERS    Space-separated list of layer names for additional layers you
-               want to be included in the configuration
+               want to be included in the configuration. This argument is
+               cumulative. Both '-l "meta-foo meta-bar"' and
+               '-l meta-foo -l meta-bar' are valid and include both layers.
   -t           Create toaster configuration file in the build directory with layers
                configured
   -f           Force overwrite of existing configuration files in the build
@@ -190,7 +192,7 @@ process_arguments () {
                 extrasearchpaths="$OPTARG"
                 ;;
             l)
-                extralayers="$OPTARG"
+                extralayers="$extralayers $OPTARG"
                 ;;
             t)
                 toasterconfig=1


### PR DESCRIPTION
This is a behavioral change that could be noticed by customers, but it's fairly unlikely that anyone is relying on the current behavior, as as noted by the opener of the issue, the existing behavior is a potential source of confusion, so let's go ahead and include it in the asyncs.