### PR TITLE
archive-release: include conf-notes.txt

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -403,6 +403,7 @@ do_archive_images () {
         echo "--transform=s,$PWD/,${CONF_INSTALL_PATH}/," >>include
         echo "$PWD/local.conf.sample" >>include
         echo "$PWD/bblayers.conf.sample" >>include
+        echo "$PWD/conf-notes.txt" >>include
     fi
 
     if [ -e "${DEPLOY_DIR_IMAGE}/${RELEASE_IMAGE}-${MACHINE}.qemuboot.conf" ]; then


### PR DESCRIPTION
Absence of conf-notes.txt, causes installer based setup-environment
scripts to have incomplete logs.

JIRA Issue: http://jira.alm.mentorg.com:8080/browse/SB-12522

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>