### PR TITLE
local.conf: replace MACHINE_BOOT_FILES variable

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -303,7 +303,7 @@ BB_DISKMON_DIRS = "\
 # removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
 MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
 # Add initramfs image to the boot partition.
-MACHINE_BOOT_FILES += "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
+IMAGE_BOOT_FILES += "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if


### PR DESCRIPTION
MACHINE_BOOT_FILES variable is used to add bsp specific images to
BOOT partition. This variable adds its contents to IMAGE_BOOT_FILES
at the end in case of ultrazed.
Instead of manually adding contents of MACHINE_BOOT_FILES into
IMAGE_BOOT_FILES, directly place desired image to IMAGE_BOOT_FILES.

Jira Issue: http://jira.alm.mentorg.com:8080/browse/SB-12576

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>