### PR TITLE
glibc-locale: work around host-user-contaminated QA failure

### DIFF
--- a/meta-mentor-staging/recipes-core/glibc/glibc-locale_%.bbappend
+++ b/meta-mentor-staging/recipes-core/glibc/glibc-locale_%.bbappend
@@ -1,0 +1,10 @@
+# Work around long standing periodic host-user-contaminated QA failure by
+# explicitly correcting the ownership.
+#
+# See `glibc-locale: Rewrite do_install using install utility instead of cp`
+# on the oe-core mailing list for discussion. This should be dropped when
+# a real fix is implemented.
+
+do_prep_locale_tree_append () {
+    chown -R root:root $treedir
+}


### PR DESCRIPTION
Work around long standing periodic host-user-contaminated QA failure by
explicitly correcting the ownership.

See `glibc-locale: Rewrite do_install using install utility instead of cp`
on the oe-core mailing list for discussion. This should be dropped when
a real fix is implemented.

JIRA: SB-12560