### PR TITLE
mel-checkout: move qemu manifests to the end when prompting

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -118,7 +118,7 @@ prompt_choice () {
 
 prompt_manifest () {
     find "$1" -maxdepth 1 -type f -name \*.manifest | \
-        sed 's,^.*/,,' | sort -rn | \
+        sed 's,^.*/,,' | sed '/qemu/!s/^/1 /; /qemu/s/^/0 /;' | sort -rn | sed 's/^[01] //' | \
         ( set +u; prompt_choice $prompt_non_interactive "$2" 1; ) | sed "s,^,$1/,"
 }
 


### PR DESCRIPTION
qemu is less likely to be the user's selection than their BSP, so prefer
the latter via the typical decorate-sort-undecorate.

JIRA: SB-12559