### PR TITLE
local.conf: replace += with append_ operator

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -303,7 +303,7 @@ BB_DISKMON_DIRS = "\
 # removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
 MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
 # Add initramfs image to the boot partition.
-IMAGE_BOOT_FILES += "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
+IMAGE_BOOT_FILES_append = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if


### PR DESCRIPTION
IMAGE_BOOT_FILES is being assigned in machine file and being appended
in local.conf.
Bitbake parses local.conf earlier and parses machine file later.
Also, += operator appends the corresponding variable instantly during
the parse.
And _append operator appends the variable after parsing all the recipes
completely.
In case we place += operator in local.conf and same variable is being
assigned (using = operator) in other recipe, we will get our local.conf
append overwritten due to later assignment. This overwrite is simply
avoided by using _append instead of += operator.

Jira Issue: http://jira.alm.mentorg.com/browse/SB-12629

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>