### PR TITLE
kernel-config-debugging.bbclass: class to add kernel debugging kconfigs

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -54,6 +54,10 @@ MACHINE ??= "qemux86"
 IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks codebench-debug ssh-server-openssh tools-profile"
 EXTRA_IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT}"
 
+# Uncomment the following to enable BSP specific patches and configurations for
+# kernel debugging
+#MACHINE_FEATURES_append = " mel-debugging"
+
 # Uncomment to enable runtime testing with ptest
 #USER_FEATURES += "ptest"
 #EXTRA_IMAGE_FEATURES += "ptest-pkgs"

--- a/meta-mel/files/debugging.cfg
+++ b/meta-mel/files/debugging.cfg
@@ -1,0 +1,13 @@
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_KERNEL=y
+
+# Dynamic printk() support
+CONFIG_DYNAMIC_DEBUG=y
+
+# KGDB over console
+CONFIG_KGDB=y
+CONFIG_KGDB_SERIAL_CONSOLE=y
+
+# Generally required/wanted for kernel debugging
+# CONFIG_CPU_IDLE is not set
+# CONFIG_DEBUG_SET_MODULE_RONX is not set

--- a/meta-mentor-common/classes/kernel-config-debugging.bbclass
+++ b/meta-mentor-common/classes/kernel-config-debugging.bbclass
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_append = ":${@os.path.dirname(bb.utils.which(BBPATH, 'files/debugging.cfg') or '')}"
+SRC_URI_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'mel-debugging', 'file://debugging.cfg', '', d)}"
+
+python () {
+    if not oe.utils.inherits(d, 'kernel-yocto', 'cml1-config'):
+        bb.fatal("kernel-config-debugging.bbclass requires kernel config fragments support. Please use kernel-yocto.bbclass or cml1-config.bbclass.")
+}


### PR DESCRIPTION
Right now the following are added, which can be easily expanded if
needed:

* KGDBOC
* Kernel debugging and debug info
* CPU_IDLE and DEBUG_SET_MODULE_RONX have been unset

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>