### PR TITLE
Encrypted-fs support updates.

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -44,9 +44,6 @@ MACHINE ??= "qemux86"
 #
 #  "virtualization"  - add docker support. Including meta-virtualization and dependencies
 #                      to bblayers is COMPULSORY for having no errors.
-#
-#  "encrypted-fs"     - add encrypted file system support. Some manual steps are needed
-#                       after flashing the image.
 # There are other options that can be used here, see
 # meta/classes/image.bbclass and meta/classes/core-image.bbclass for more
 # details.
@@ -296,14 +293,17 @@ BB_DISKMON_DIRS = "\
 # Use this to add extra packages to the split-debug filesystem
 #EXTRA_DEBUG_PACKAGES = "ltrace strace"
 
-# Uncomment following two lines to enable INITRAMFS. This adds dmcrypt-initramfs-image in 
-# INITRAMFS_IMAGE if encrypted-fs image feature is enabled otherwise add core-image-minimal-initramfs.
-#INITRAMFS_IMAGE = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', 'core-image-minimal-initramfs', d)}"
+# Uncomment to enable encrypted-fs User Feature:
+#USER_FEATURES_append = " encrypted-fs"
+EXTRA_IMAGE_FEATURES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', 'encrypted-fs', '', d)}"
+# Uncomment it to enable INITRAMFS:
+#INITRAMFS_IMAGE = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', 'core-image-minimal-initramfs', d)}"
+# Uncomment it to bundle initramfs image with kernel image:
 #INITRAMFS_IMAGE_BUNDLE = "1"
 # removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
-MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
+MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
 # Add initramfs image to the boot partition.
-IMAGE_BOOT_FILES_append = "${@bb.utils.contains('EXTRA_IMAGE_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
+IMAGE_BOOT_FILES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -300,10 +300,6 @@ EXTRA_IMAGE_FEATURES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted
 #INITRAMFS_IMAGE = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', 'dmcrypt-initramfs-image', 'core-image-minimal-initramfs', d)}"
 # Uncomment it to bundle initramfs image with kernel image:
 #INITRAMFS_IMAGE_BUNDLE = "1"
-# removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
-MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
-# Add initramfs image to the boot partition.
-IMAGE_BOOT_FILES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '${dm-initramfs}', '', d)}"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -489,5 +489,13 @@ PREFERRED_VERSION_bmap-tools-native = "2.5"
 
 # Security / SELinux configuration.
 include conf/distro/include/mel-security.conf
+
+# Set name of initramfs image specific to machine name and kernel name being used in that machine:
+DM_INITRAMFS = "${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE}-dm-init"
+# removing 96boards-tools package so that rootfs does not occupy entire available space over the boot media.
+MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '96boards-tools', '', d)}"
+# Add initramfs image to the boot partition.
+IMAGE_BOOT_FILES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '${DM_INITRAMFS}', '', d)}"
+
 ## }}}1
 # vim: set fdm=marker fdl=0 :

--- a/meta-mentor-common/classes/kernel-config-encryptfs.bbclass
+++ b/meta-mentor-common/classes/kernel-config-encryptfs.bbclass
@@ -1,2 +1,9 @@
 FILESEXTRAPATHS_append = ":${@os.path.dirname(bb.utils.which(BBPATH, 'files/encryptfs.cfg') or '')}"
-SRC_URI_append = " file://encryptfs.cfg "
+
+ENCRYPTFS_CFG = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', 'file://encryptfs.cfg', '', d)}"
+SRC_URI_append = " ${ENCRYPTFS_CFG}"
+
+python () {
+    if not oe.utils.inherits(d, 'kernel-yocto', 'cml1-config'):
+        bb.fatal("kernel-config-encryptfs.bbclass.bbclass requires kernel config fragments support. Please use kernel-yocto.bbclass or cml1-config.bbclass.")
+}


### PR DESCRIPTION
**encryptfs.bbclass: conditionally add fragment** 
kernel-config-encryptfs.bbclass adds kerenl configs required by
encrypted file system support. And this class is inherited in
kernel recipe class. This class adds the kernel configs in all
cases, even if encrypted-fs is not enabled as a feature.

This commit adds this kernel fragment to SRC_URI only if the
encrypted-fs is enabled in the USER_FEATURE variable.
Otherwise doesn't add it.

**local.conf: set encrypted-fs as a user feature**
encrypted-fs was previously being used as an EXTRA_IMAGE_FEATURE.
But machine related kernel configurations cannot be made on the
basis of an image feature. Since in most of the imx bsps, we
encountered hardware crypto failure, kernel configurations needed
to be set on the basis of encrypted-fs. And that's why it is
to be set as USER FEATURE instead of IMAGE FEATURE.

This commit updates the checks that were previously being made
on the basis of IMAGE FEATURE and lets the user to add encrypted-fs
as USER_FEATURE just by uncommenting a line.

**mel.conf: move encryptedfs configuration to distro**
Encrypted File System support needs to remove 96boardstools and
add kernel image to boot partition.  Both of these actions were
previously being performed on the basis of a check condition
applied to EXTRA_IMAGE_FEATURE. And due to intervention of the
IMAGE_FEATURE variable, these statements were placed in local.conf

But now, as we switched encrypted-fs to USER_FEATURE, and there
is no user intervention intended with these statements, we can now
move them to mel.conf.

Additionally, DM_INITRAMFS variable was previously being set by
each bsp in their machine file. The variale stored name of the
bundled image of initramfs+kernel so that it could be placed in
boot partition via IMAGE_BOOT_FILES variable. But same action can
be performed by yocto provided variables, as the name of bundled
file keeps same pattern. This change is also added to mel.conf
along the being shifted configuration lines for encrypted-fs.

Jira Issue: http://jira.alm.mentorg.com:8080/browse/SB-12527

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>