### PR TITLE
Revert "setup-ubuntu: install realpath"

### DIFF
--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -27,9 +27,6 @@ PKGS="$PKGS bmap-tools"
 # This is needed for Windows ADE
 PKGS="$PKGS zip"
 
-# Host Security Tool's cmdline requires this for update image generation
-PKGS="$PKGS realpath"
-
 echo "Installing packages required to build Mentor Embedded Linux"
 apt-get update
 apt-get -y install $PKGS


### PR DESCRIPTION
This reverts commit 0b063172d1b4036226f156c22580c64802904d4b.

The HST script requiring this dependency has been changed to work
without this.

https://stash.alm.mentorg.com/projects/CB/repos/cb_iot/pull-requests/40/overview