### PR TITLE
python3-docker-compose: add missing dependencies

### DIFF
--- a/meta-mentor-staging/virtualization-layer/recipes-containers/docker-compose/python3-docker-compose_1.16.1.bbappend
+++ b/meta-mentor-staging/virtualization-layer/recipes-containers/docker-compose/python3-docker-compose_1.16.1.bbappend
@@ -1,0 +1,4 @@
+
+RDEPENDS_${PN} += " python3-misc \
+                    python3-modules \
+                  "


### PR DESCRIPTION
docker-compose needs a number of python3 runtime dependencies. The
packages python3-misc and python3-modules provide those dependencies.
The bbappend is being applied to current version of python3-docker-
compose so that it is reviewed later on as well if these dependencies
are fixed by upstream in the later versions or not.

Signed-off-by: arshadaleem66 <arshad_aleem@mentor.com>