### PR TITLE
mel-checkout: create link for tools dir if available

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -168,7 +168,7 @@ mkdir -p "$project"
 cd "$project"
 echo "$installdir" >"$project/.installpath"
 
-for install_subdir in ../../codebench ../../codebench-lite; do
+for install_subdir in ../../codebench ../../codebench-lite ../../tools; do
     if [ -d "$installdir/$install_subdir" ]; then
         ln -sf "$installdir/$install_subdir" .
     fi


### PR DESCRIPTION
Just like codebench, we're now introducing a tools directory
which will contain different tools. So force a link creation
inside workspace such that it can be utilized from inside.

Ref: http://confluence.alm.mentorg.com:8090/display/MEIF/MEIF+Host+Tool+Restructuring

Signed-off-by: Awais Belal <awais_belal@mentor.com>