### PR TITLE
glibc-locale: explicitly disable host-user-contaminated

### DIFF
--- a/meta-mentor-staging/recipes-core/glibc/glibc-locale_%.bbappend
+++ b/meta-mentor-staging/recipes-core/glibc/glibc-locale_%.bbappend
@@ -8,3 +8,9 @@
 do_prep_locale_tree_append () {
     chown -R root:root $treedir
 }
+
+# Explicitly disable host-user-contaminated to further work around the
+# pseudo bug. With pseudo acting up, even if the ownership is correct,
+# it may well think it is not, so just sidestep the issue until upstream
+# fixes the root cause.
+ERROR_QA_remove = "host-user-contaminated"


### PR DESCRIPTION
Explicitly disable host-user-contaminated to further work around the
pseudo bug. With pseudo acting up, even if the ownership is correct, it
may well think it is not, so just sidestep the issue until upstream
fixes the root cause.

JIRA: SB-13459