### PR TITLE
layer.conf: drop LICENSE_PATH

### DIFF
--- a/meta-mel-support/conf/layer.conf
+++ b/meta-mel-support/conf/layer.conf
@@ -13,7 +13,5 @@ BBFILE_PATTERN_mel-support = "^${LAYERDIR_RE}/"
 LAYERDEPENDS_mel-support = "core mentor-common"
 LAYERSERIES_COMPAT_mel-support = "thud warrior zeus"
 
-LICENSE_PATH += "${LAYERDIR}/licenses"
-
 PREFERRED_PROVIDER_virtual/nativesdk-update-alternatives ??= "nativesdk-opkg-utils"
 PREFERRED_PROVIDER_chkconfig-alternatives ??= "chkconfig-alternatives"

--- a/meta-mentor-staging/conf/layer.conf
+++ b/meta-mentor-staging/conf/layer.conf
@@ -16,8 +16,6 @@ BBFILE_PATTERN_mentor-staging = "^${LAYERDIR_RE}/"
 LAYERDEPENDS_mentor-staging = "core mentor-common"
 LAYERSERIES_COMPAT_mentor-staging = "thud warrior zeus"
 
-LICENSE_PATH += "${LAYERDIR}/licenses"
-
 # We don't want systemd and everything depending on systemd to rebuild when
 # the metadata stored in os-release changes. TODO: push this to oe-core
 SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"


### PR DESCRIPTION
We aren't currently providing any additional common license files, so
don't need to adjust this. Adding paths without having the licenses
directory is now fatal.