### PR TITLE
mel.conf: include mel-security-selinux.conf

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -473,7 +473,7 @@ include conf/distro/include/qt5-versions.inc
 PREFERRED_VERSION_bmap-tools-native = "2.5"
 
 # Security / SELinux configuration.
-include conf/distro/include/mel-security.conf
+include conf/distro/include/mel-security-selinux.conf
 
 # Set name of initramfs image specific to machine name and kernel name being used in that machine:
 DM_INITRAMFS = "${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE}-dm-init"


### PR DESCRIPTION
mel.conf: include mel-security-selinux.conf

* remove selinux and smack common config file mel-security.conf and add selinux config file mel-security-selinux.conf

related PR in mel-meta-mentor-security: https://github.com/MentorEmbedded/mel-meta-mentor-security/pull/100
Signed-off-by: Haseeb Ashraf <Haseeb_Ashraf@mentor.com>