### PR TITLE
Ima

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -468,8 +468,8 @@ include conf/distro/include/qt5-versions.inc
 # Install bmap-tools version 2.5 inorder to support both Ubuntu 14.04 and 16.04 respectively.
 PREFERRED_VERSION_bmap-tools-native = "2.5"
 
-# Security / SELinux configuration.
-include conf/distro/include/mel-security-selinux.conf
+# Security configuration.
+include conf/distro/include/mel-security.conf
 
 # Set name of initramfs image specific to machine name and kernel name being used in that machine:
 DM_INITRAMFS = "${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin;${KERNEL_IMAGETYPE}-dm-init"

--- a/meta-mel/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-mel/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -1,4 +1,4 @@
-PACKAGE_INSTALL_mel = "initramfs-boot iperf2 iptables busybox udev base-passwd dosfstools ${ROOTFS_BOOTSTRAP_INSTALL} ${FEATURE_INSTALL}"
+PACKAGE_INSTALL_mel = "iperf2 iptables busybox udev base-passwd dosfstools ${ROOTFS_BOOTSTRAP_INSTALL} ${FEATURE_INSTALL}"
 IMAGE_FEATURES_mel = "codebench-debug ssh-server-openssh"
 
 COMPATIBLE_HOST_mel = "(arm|aarch64|i.86|x86_64).*-linux"


### PR DESCRIPTION
Instead of including individual configurations from meta-mentor-security use the common configuration <mel-security.conf> in meta-mentor-security and include in mel.conf once.

core-image-minimal-initramfs add a module <initramfs-boot> which pass the control to console when kernel loads the first module of initramfs, it is not required in standard workflow and only needed when hypervisor team uses MEL. To avoid user input it is removed from meta-mentor and will need to be added to the paravirtualization layer if needed by HV team anymore.