### PR TITLE
mel-image.inc: fix IMAGE_FEATURES append

### DIFF
--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -9,5 +9,5 @@ LICENSE = "MIT"
 
 inherit core-image image-sanity-incompatible
 
-IMAGE_FEATURES_append_mel = "splash ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
+IMAGE_FEATURES_append_mel = " splash ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', ' tools-audio', '', d)}"
 IMAGE_INSTALL_append_mel = " util-linux-mkfs connman ${@bb.utils.contains("INCOMPATIBLE_LICENSE", "GPLv3", "", bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "haveged", "", d), d)}"


### PR DESCRIPTION
An append requires a space and otherwise would mess up
the whole variable.

Signed-off-by: Awais Belal <awais_belal@mentor.com>