### PR TITLE
mel.conf: remove root-home volatile bind

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -226,17 +226,6 @@ PACKAGECONFIG_REMOVE_pn-mesa-demos = "glx"
 # We don't use dracut to build initramfs
 PACKAGECONFIG_REMOVE_pn-plymouth = "initrd"
 
-# Ensure we have the writable paths we need in a read-only rootfs
-
-# If the user-data feature is in the picture, it takes over ownership of
-# determining what to do with ROOT_HOME and bind mounts.
-
-ROOT_HOME_BIND = "\
-    /var/volatile/root-home ${ROOT_HOME}\n\
-"
-VOLATILE_BINDS_append = "\
-    ${@bb.utils.contains('COMBINED_FEATURES', 'user-data', '', d.getVar('ROOT_HOME_BIND', True), d)}\
-"
 ## }}}1
 ## Inherits {{{1
 # We want information about package and image contents


### PR DESCRIPTION
this entry is being added through volatile-binds
recipe in mentor-bsp layer

Jira: https://jira.alm.mentorg.com/browse/SB-14619