### PR TITLE
mel: default TCMODE to external-sourcery, not rebuild-libc

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -73,7 +73,7 @@ META_MENTOR_DIR = "${LAYERDIR_mel}/.."
 PATH_prepend = "${META_MENTOR_DIR}/scripts:"
 
 # Default to the external toolchain if available
-TCMODE ?= "${@bb.utils.contains('BBFILE_COLLECTIONS', 'sourcery', 'external-sourcery-rebuild-libc', bb.utils.contains('BBFILE_COLLECTIONS', 'external-toolchain', 'external', 'default', d), d)}"
+TCMODE ?= "${@bb.utils.contains('BBFILE_COLLECTIONS', 'sourcery', 'external-sourcery', bb.utils.contains('BBFILE_COLLECTIONS', 'external-toolchain', 'external', 'default', d), d)}"
 
 # We want media to auto-mount
 DISTRO_EXTRA_RRECOMMENDS += "udev-extraconf"


### PR DESCRIPTION
There's no need to rebuild it by default given the new toolchain.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
