### PR TITLE
mel-initramfs-image: disable zapped root password qa check

### DIFF
--- a/meta-mel/recipes-core/images/mel-initramfs-image.bb
+++ b/meta-mel/recipes-core/images/mel-initramfs-image.bb
@@ -15,6 +15,9 @@ inherit core-image
 IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 
+# We don't care about root password for login on initramfs images
+IMAGE_QA_COMMANDS_remove = "image_check_zapped_root_password"
+
 BAD_RECOMMENDATIONS += "busybox-syslog"
 
 COMPATIBLE_HOST_mel = "(arm|aarch64|i.86|x86_64).*-linux"


### PR DESCRIPTION
This was intended to only be run for non-initramfs images, but
mel-swupdate.conf adjusts IMAGE_FSTYPES in a way that results in the
default removal no longer applying, so do so explicitly here.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
