### PR TITLE
fluidsynth: fix typo in PACKAGECONFIG[pulseaudio]

### DIFF
--- a/meta-mentor-staging/multimedia-layer/recipes-multimedia/fluidsynth/fluidsynth_1.1.10.bbappend
+++ b/meta-mentor-staging/multimedia-layer/recipes-multimedia/fluidsynth/fluidsynth_1.1.10.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG[pulseaudio] = "-Denable-pulseaudio=ON,-Denable-pulseaudio=OFF,pulseaudio"


### PR DESCRIPTION
there is an additional '-' slipped into when checking pulseaudio
typo: --Denable-pulseaudio=OFF
fix: -Denable-pulseaudio=OFF

JIRA-ID: SB-15256

Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>