### PR TITLE
Revert "Added fix for build issues on upstream virtualization layer f…

### DIFF
--- a/meta-mentor-staging/virtualization-layer/recipes-containers/runc/runc-docker_git.bbappend
+++ b/meta-mentor-staging/virtualization-layer/recipes-containers/runc/runc-docker_git.bbappend
@@ -1,4 +1,0 @@
-
-# Specify the proper Host ARCH Flags for building
-CFLAGS  += "${HOST_CC_ARCH}"
-LDFLAGS += "${HOST_CC_ARCH}"


### PR DESCRIPTION
…or MEL avantech UNO BSP"

This reverts commit 209df50ae0e358872758e23c44edae0fa64dbfe2.

HOST_CC_ARCH is meant to be used with compiler flags, and not for LDFLAGS;
doing so messes up GO_EXTLDFLAGS which already uses this and thus causes
segmentation fault for arm machines including qemuarm. The idea is that
we remove this for now, and fix in an appropriate way for UNO BSP if we
encounter an issue with latest upstream