### PR TITLE
staging: haveged: backport patch for systemd dependency issues

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-extended/haveged/haveged/0001-fix-ordering-cycle-with-private-tmp.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/haveged/haveged/0001-fix-ordering-cycle-with-private-tmp.patch
@@ -1,0 +1,27 @@
+From 2098470a38e16173c23d176fe87c64754c2000e5 Mon Sep 17 00:00:00 2001
+From: Christian Hesse <mail@eworm.de>
+Date: Tue, 9 Jun 2020 21:48:36 +0200
+Subject: [PATCH] fix ordering cycle with private tmp
+
+Upstream-Status: Backport
+---
+ init.d/service.fedora | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/init.d/service.fedora b/init.d/service.fedora
+index b8f32ea..8de8828 100644
+--- a/init.d/service.fedora
++++ b/init.d/service.fedora
+@@ -12,7 +12,8 @@ SuccessExitStatus=137 143
+ 
+ SecureBits=noroot-locked
+ CapabilityBoundingSet=CAP_SYS_ADMIN
+-PrivateTmp=true
++# We can *not* set PrivateTmp=true as it can cause an ordering cycle.
++PrivateTmp=false
+ PrivateDevices=true
+ PrivateNetwork=true
+ ProtectSystem=full
+-- 
+2.17.1
+

--- a/meta-mentor-staging/openembedded-layer/recipes-extended/haveged/haveged_1.9.9.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/haveged/haveged_1.9.9.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI_append_mel = " file://0001-fix-ordering-cycle-with-private-tmp.patch"


### PR DESCRIPTION
The haveged systemd service file creates a dependency chain in a
way that at times breaks journald services and hence we don't get
anything from the journal logs after boot.
The backport copes with this issue by fixing the service file. This
is a backport of
https://github.com/jirka-h/haveged/commit/2098470a38e16173c23d176fe87c64754c2000e5

Signed-off-by: Awais Belal <awais_belal@mentor.com>