### PR TITLE
Remove vulkan from mel default distro features list

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -190,7 +190,7 @@ require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"
 ## Distro Features & Recipe Configuration {{{1
-MEL_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch vulkan"
+MEL_DEFAULT_DISTRO_FEATURES = "largefile opengl multiarch"
 
 # This violates typical MACHINE/DISTRO boundaries, but is part of MEL's
 # supported features. If the vendor supports x11 and not wayland for its


### PR DESCRIPTION
Remove Vulkan from the default MEL default distro feature list.
This change also helps to compile qt5 packages.