### PR TITLE
mel-initramfs-image: add initramfs-module-udev to packages

### DIFF
--- a/meta-mel/recipes-core/images/mel-initramfs-image.bb
+++ b/meta-mel/recipes-core/images/mel-initramfs-image.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "MEL Image initramfs"
 
-PACKAGE_INSTALL = "initramfs-framework-base ${VIRTUAL-RUNTIME_base-utils} udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "initramfs-framework-base ${VIRTUAL-RUNTIME_base-utils} initramfs-module-udev udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
 
 IMAGE_FEATURES = "${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', 'encrypted-fs', '', d)}"
 


### PR DESCRIPTION
Adds initramfs-module-udev to the PACKAGE_INSTALL for the start/stop udev
daemon script in the initramfs

Signed-off-by: ekalemen <eugeny_kalemenev@mentor.com>