### PR TITLE
mel-initramfs-image: remove selinux labelling for initramfs

### DIFF
--- a/meta-mel/recipes-core/images/mel-initramfs-image.bb
+++ b/meta-mel/recipes-core/images/mel-initramfs-image.bb
@@ -18,4 +18,7 @@ IMAGE_QA_COMMANDS_remove = "image_check_zapped_root_password"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
 
+# We don't need selinux labels in initramfs
+IMAGE_PREPROCESS_COMMAND_remove = "selinux_set_labels ;"
+
 COMPATIBLE_HOST_mel = "(arm|aarch64|i.86|x86_64).*-linux"


### PR DESCRIPTION
selinux context labeling is only required for rootfs, "selinux_set_labels" call can be removed from IMAGE_PREPROCESSOR_COMMAND from the mel-initramfs-image recipe.

JIRA: https://jira.alm.mentorg.com/browse/SB-14198

Signed-off-by: sajjad238 <sajjad_ahmed@mentor.com>