### PR TITLE
bblayers.mel_utils: fix dump-downloads

### DIFF
--- a/meta-mel/lib/bblayers/mel_utils.py
+++ b/meta-mel/lib/bblayers/mel_utils.py
@@ -85,7 +85,7 @@ class MELUtilsPlugin(LayerPlugin):
         urldata = fetcher.ud
 
         items_by_layer = defaultdict(set)
-        items_files = data.varhistory.get_variable_items_files('SRC_URI', data)
+        items_files = data.varhistory.get_variable_items_files('SRC_URI')
         for item, filename in items_files.items():
             ud = urldata[item]
             decoded = bb.fetch.decodeurl(item)


### PR DESCRIPTION
This was incorrectly passing an additional argument to get_variable_items_files
which could not be send across the connection to the server, resulting in a pickle
failure traceback.

JIRA: SB-15436

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
