### PR TITLE
packagegroup-core-tools-profile: Remove systemtap.

### DIFF
--- a/meta-mel/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
+++ b/meta-mel/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
@@ -1,3 +1,6 @@
 inherit incompatible-recipe-check
 
 PROFILE_TOOLS_X_remove = "${@'sysprof' if is_incompatible(d, ['sysprof'], 'GPL-3.0') else ''}"
+
+# MEL Flex does not support systemtap. Systemtap brings boost which takes lots of resources. So we do not need it.
+SYSTEMTAP_mel = ""


### PR DESCRIPTION
* MEL FLEX does not need systemtap. It brings boost which takes
  lots of resources while building. So Remove systemtap from build.

Signed-off-by: ahsann <noor_ahsan@mentor.com>