### PR TITLE
mel: remove unnecessary INHERIT of cb-mbs-options

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -253,9 +253,6 @@ INHERIT += "mentor-updates-check"
 # Check PDK license
 INHERIT += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-private', 'pdk-license', '', d)}"
 
-# Write cb-mbs-options for CodeBench
-INHERIT += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-private', 'cb-mbs-options', '', d)}"
-
 EXTERNAL_SETUP_SCRIPT_VARS += "REAL_MULTIMACH_TARGET_SYS"
 CB_MBS_OPTIONS[general.yocto.sdk.value] = "${EXTERNAL_REAL_MULTIMACH_TARGET_SYS}"
 


### PR DESCRIPTION
This is already inherited where it's used.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
