### PR TITLE
mel.conf: disable sanity check from meta-virtualization

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -389,6 +389,11 @@ UPSTREAM_URL_openembedded-core = "https://github.com/openembedded/openembedded-c
 
 FORKED_REPOS ?= "bitbake openembedded-core"
 PUBLIC_REPOS ?= "meta-mentor meta-sourcery meta-tracing ${FORKED_REPOS}"
+
+# Disable sanity check from meta-virtualization, we support the layer
+# a bit differently.
+SKIP_META_VIRT_SANITY_CHECK = "1"
+
 ## }}}1
 ## Includes {{{1
 # Ensure that we implement shared state reuse handling for non-target recipes


### PR DESCRIPTION
Fixes
WARNING: You have included the meta-virtualization layer, but 'virtualization' has not been enabled in your DISTRO_FEATURES. Some bbappend files may not take effect. See the meta-virtualization README for details on enabling virtualization support.

Our support for the layer is implemented a bit differently
as we only pick a handful of packages from it.

Signed-off-by: Awais Belal <awais_belal@mentor.com>