### PR TITLE
local.conf.sample: Reversing commit 9b616.

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -59,9 +59,6 @@ EXTRA_IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT} multilib-runtime"
 IMAGE_FEATURES_PRODUCTION ?= ""
 IMAGE_FEATURES_DISABLED_PRODUCTION ?= "${IMAGE_FEATURES_DEVELOPMENT} ssh-server-dropbear"
 
-# Install binutils with the tools-profile feature, as our tracing scripts need ld
-CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains('IMAGE_FEATURES', 'tools-profile', 'binutils', '', d)}"
-
 # Install tzdata with systemd when building read only images
 CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', 'tzdata' if d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd' else '', '', d)}"
 


### PR DESCRIPTION
* 9b616 was added for SB-11691. Now SA rework their script.
  See SA-4899 and SA-4905. Now binutils package is not
  needed. So reversing the commit.

Signed-off-by: ahsann <noor_ahsan@mentor.com>