### PR TITLE
imx-vpu: correct install paths

### DIFF
--- a/meta-mentor-staging/fsl-bsp-release/recipes-bsp/imx-vpu/imx-vpu_%.bbappend
+++ b/meta-mentor-staging/fsl-bsp-release/recipes-bsp/imx-vpu/imx-vpu_%.bbappend
@@ -1,0 +1,11 @@
+do_install_append () {
+    if [ "${libdir}" != "/usr/lib" ]; then
+        install -d "$(dirname "${D}${libdir}")"
+        mv "${D}/usr/lib" "${D}${libdir}"
+    fi
+    if [ "${includedir}" != "/usr/include" ]; then
+        install -d "$(dirname "${D}${includedir}")"
+        mv "${D}/usr/include" "${D}${includedir}"
+    fi
+    rmdir --ignore-fail-on-non-empty "${D}/usr"
+}


### PR DESCRIPTION
Multimedia+graphics+qt5-mel builds fail with an external toolchain due to this recipe always installing to '/usr/lib'.