### PR TITLE
tripwire: fix sed for changing EDITOR

### DIFF
--- a/meta-mentor-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
+++ b/meta-mentor-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
@@ -4,7 +4,7 @@ RDEPENDS_${PN}_remove = "${RDEPENDS_REMOVE}"
 
 do_install_append () {
     # When submitting upstream, modify twcfg.txt in the layer instead
-    sed -i -e 's#^EDITOR=#EDITOR=/usr/bin/vi#' ${D}${sysconfdir}/${PN}/twcfg.txt
+    sed -i -e 's#^EDITOR[[:space:]]*=.*#EDITOR=/usr/bin/vi#' ${D}${sysconfdir}/${PN}/twcfg.txt
     if grep -q nano ${D}${sysconfdir}/${PN}/twcfg.txt; then
         bbfatal "EDITOR adjustment failed"
     fi


### PR DESCRIPTION
The twcfg.txt contains a number of spaces before the '=' sign
for each entry hence our current sed expression fails to update
the EDITOR entry as it intends to.
Fix the expression to check for any number of spaces before the
'=' sign for the entry.

Signed-off-by: Awais Belal <awais_belal@mentor.com>