### PR TITLE
tripwire: deploy installation script to an appropriate location

### DIFF
--- a/meta-mentor-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
+++ b/meta-mentor-staging/security/recipes-ids/tripwire/tripwire_%.bbappend
@@ -8,4 +8,13 @@ do_install_append () {
     if grep -q nano ${D}${sysconfdir}/${PN}/twcfg.txt; then
         bbfatal "EDITOR adjustment failed"
     fi
+
+    # The main recipe installs the installation script to
+    # /etc which isn't meant for such stuff (executables)
+    # move it to a more appropriate location
+    if [ -e "${D}${sysconfdir}/tripwire/twinstall.sh" ]; then
+        rm -f "${D}${sysconfdir}/tripwire/twinstall.sh"
+    fi
+    install -d "${D}${bindir}"
+    install -m 0755 "${WORKDIR}/twinstall.sh" "${D}${bindir}/"
 }


### PR DESCRIPTION
The main recipe deploys the installation script to /etc which
isn't meant for executables and doesn't work well when a read-only
or no-exec strategy is in place for /etc which can be the case
in many systems. This renders the installation script invalid
to be used with such strategy.
We now deploy the script to bindir which is always an executable
location by any specification so it can be executed.

Signed-off-by: Awais Belal <awais_belal@mentor.com>