### PR TITLE
python3-scapy: add a required runtime dependency on fcntl

### DIFF
--- a/meta-mentor-staging/security/recipes-security/scapy/python3-scapy_%.bbappend
+++ b/meta-mentor-staging/security/recipes-security/scapy/python3-scapy_%.bbappend
@@ -1,0 +1,3 @@
+RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-fcntl \
+"


### PR DESCRIPTION
This fixes a runtime issue where scapy complains
ModuleNotFoundError: No module named 'fcntl'

Signed-off-by: Awais Belal <awais_belal@mentor.com>