### PR TITLE
Sanitize included image types for installation

### DIFF
--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -395,8 +395,8 @@ do_archive_images () {
         fi
         sed -e "s/##ROOTFS##/${RELEASE_IMAGE}.$ext/; s/##KERNEL##/$kernel/" ${WORKDIR}/runqemu.in >runqemu
         chmod +x runqemu
-        echo ./runqemu >>include
-        echo "--transform=s,./runqemu$,${BINARY_INSTALL_PATH}/runqemu," >>include
+        echo "--transform=s,runqemu,${BINARY_INSTALL_PATH}/runqemu," >>include
+        echo runqemu >>include
     fi
     if echo "${RELEASE_ARTIFACTS}" | grep -qw templates; then
         prepare_templates

--- a/meta-mel-support/recipes-core/meta/archive-release.bb
+++ b/meta-mel-support/recipes-core/meta/archive-release.bb
@@ -364,15 +364,12 @@ do_archive_images () {
         grep -Ev '^${DEPLOY_DIR_IMAGE}/${DEPLOY_IMAGES_EXCLUDE_PATTERN}' >>include
 
     # Lock down any autorevs
-    buildhistory-collect-srcrevs -p "${BUILDHISTORY_DIR}" >"${WORKDIR}/autorevs.conf"
-    if [ -s "${WORKDIR}/autorevs.conf" ]; then
-        echo "--transform=s,${WORKDIR}/autorevs.conf,${CONF_INSTALL_PATH}/autorevs.conf," >>include
-        echo "${WORKDIR}/autorevs.conf" >>include
-    fi
-
     if [ -e "${BUILDHISTORY_DIR}" ]; then
-        echo "--transform=s,${BUILDHISTORY_DIR},${BINARY_INSTALL_PATH}/buildhistory," >>include
-        echo ${BUILDHISTORY_DIR} >>include
+        buildhistory-collect-srcrevs -p "${BUILDHISTORY_DIR}" >"${WORKDIR}/autorevs.conf"
+        if [ -s "${WORKDIR}/autorevs.conf" ]; then
+            echo "--transform=s,${WORKDIR}/autorevs.conf,${CONF_INSTALL_PATH}/autorevs.conf," >>include
+            echo "${WORKDIR}/autorevs.conf" >>include
+        fi
     fi
 
     release_tar --files-from=include -cf ${MACHINE}-${ARCHIVE_RELEASE_VERSION}.tar

--- a/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
+++ b/meta-mel-support/recipes-core/meta/archive-release/runqemu.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 scriptdir="$(cd "$(dirname "$0")" && pwd)"
-meldir="$(dirname "$(dirname "$scriptdir")")"
+meldir="$(cd "$scriptdir/../../.." && pwd)"
 
 if ! which bitbake >/dev/null 2>&1; then
     if [ -e "$meldir/manifests" ] && ! [ -e "$meldir/meta-mentor" ]; then
@@ -12,9 +12,9 @@ if ! which bitbake >/dev/null 2>&1; then
     exit 1
 fi
 
-if ( eval $(bitbake -e | grep -E '^(export PATH|STAGING_BINDIR_NATIVE)='); ! which tunctl >/dev/null 2>&1 ); then
+if ( eval $(bitbake -e | grep -E '^COMPONENTS_DIR='); ! [ -e "$COMPONENTS_DIR/x86_64/qemu-helper-native/usr/bin/tunctl" ] ); then
     echo >&2 "Unable to find tunctl binary, building qemu-helper-native.."
     bitbake qemu-helper-native:do_addto_recipe_sysroot
 fi
 
-exec "$meldir/oe-core/scripts/runqemu" "$(basename "${scriptdir%/*}")" "$scriptdir/"*.qemuboot.conf "$@"
+exec "$meldir/oe-core/scripts/runqemu" "$(basename "${scriptdir%/*/*}")" "$scriptdir/"*.qemuboot.conf "$@"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -131,6 +131,7 @@ LOGO_pn-plymouth = "${PLYMOUTH_LOGO}"
 UBI_VOLNAME = "rootfs"
 
 IMAGE_FSTYPES ?= "ext4"
+ARCHIVE_RELEASE_IMAGE_FSTYPES_EXCLUDE ?= "tar.bz2"
 
 # If a wic image type is enabled, also enable wic.bmap
 require conf/distro/include/wic-bmap.inc

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -128,9 +128,9 @@ DISTRO_EXTRA_RRECOMMENDS += "${@'plymouth-mel' if '${SPLASH}' == 'plymouth' else
 PLYMOUTH_LOGO ?= "${datadir}/plymouth/themes/mel/mel.png"
 LOGO_pn-plymouth = "${PLYMOUTH_LOGO}"
 
-# Default to these image types
-IMAGE_FSTYPES ?= "tar.bz2 ext3"
 UBI_VOLNAME = "rootfs"
+
+IMAGE_FSTYPES ?= "ext4"
 
 # If a wic image type is enabled, also enable wic.bmap
 require conf/distro/include/wic-bmap.inc


### PR DESCRIPTION
JIRA: SB-15569

This avoids shipping tar.bz2 where we can, prefers ext4 to ext3, fixes runqemu so it works at all (doesn't really belong in this pull request, but it's related), avoids shipping buildhistory, and moves to an explicit list of files to include from DEPLOY_DIR_IMAGE, and if a wic image type is enabled, those are the only types we ship.