### PR TITLE
archive-release: Add setup-debian script to MEL_SCRIPTS_FILES.

### DIFF
--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS_append = ":${@':'.join('%s/../scripts/release:%s/../scripts' % (l, l) for l in '${BBPATH}'.split(':'))}"
-MEL_SCRIPTS_FILES = "mel-checkout version-sort setup-mel setup-workspace setup-ubuntu setup-rh"
+MEL_SCRIPTS_FILES = "mel-checkout version-sort setup-mel setup-workspace setup-ubuntu setup-rh setup-debian"
 SRC_URI += "${@' '.join(uninative_urls(d)) if 'mel_downloads' in '${RELEASE_ARTIFACTS}'.split() else ''}"
 SRC_URI += "${@' '.join('file://%s' % s for s in d.getVar('MEL_SCRIPTS_FILES').split())}"
 


### PR DESCRIPTION
* Flex installer were missing setup-debian script. Add it in
  MEL_SCRIPTS_FILES so that it can be bundled with installer.
* SB-15578

Signed-off-by: ahsann <noor_ahsan@mentor.com>