### PR TITLE
mel.conf: Update supported host list for Fir release.

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -96,11 +96,12 @@ PACKAGE_CLASSES ?= "package_ipk"
 # MEL's supported hosts
 SANITY_TESTED_DISTROS = "\
     ubuntu-18.04 \n\
-    ubuntu-16.04 \n\
+    ubuntu-20.04 \n\
     centos-7* \n \
     centoslinux-7* \n \
-    rhel*-7* \n \
-    redhatenterprise*-7* \n \
+    debian-10* \n \
+    rhel*-8* \n \
+    redhatenterprise*-8* \n \
 "
 
 # Sane default append for the kernel cmdline (not used by all BSPs)


### PR DESCRIPTION
* Remove ubuntu 16 and rhel 7. Add ubuntu 20, debina 10, rhel 8
  and redhatenterprise 8.
* SB-15559

Signed-off-by: ahsann <noor_ahsan@mentor.com>