### PR TITLE
boost: Set PARALLEL_MAKE to -j 4.

### DIFF
--- a/meta-mel/recipes-support/boost/boost_%.bbappend
+++ b/meta-mel/recipes-support/boost/boost_%.bbappend
@@ -1,0 +1,1 @@
+PARALLEL_MAKE_mel = "-j 4"


### PR DESCRIPTION
* boost takes lots of system resources. Somethimes it give memory error.
  Setting PARALLEL_MAKE to 4 so that it does not cosume all of the
  system resources.

Signed-off-by: ahsann <noor_ahsan@mentor.com>