### PR TITLE
systemd-boot: use an array for efi-ld to allow ld args

### DIFF
--- a/meta-mentor-staging/recipes-core/systemd/systemd-boot/0001-Use-an-array-for-efi-ld-to-allow-for-ld-arguments.patch
+++ b/meta-mentor-staging/recipes-core/systemd/systemd-boot/0001-Use-an-array-for-efi-ld-to-allow-for-ld-arguments.patch
@@ -1,0 +1,48 @@
+From 586638384dd980628e1d51a29fd9324eab661834 Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Mon, 5 Oct 2020 22:06:12 +0500
+Subject: [PATCH] Use an array for efi-ld to allow for ld arguments
+
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ meson_options.txt        | 2 +-
+ src/boot/efi/meson.build | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index 44ff23f641..8dad5926db 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -305,7 +305,7 @@ option('gnu-efi', type : 'combo', choices : ['auto', 'true', 'false'],
+        description : 'gnu-efi support for sd-boot')
+ option('efi-cc', type : 'array',
+        description : 'the compiler to use for EFI modules')
+-option('efi-ld', type : 'string',
++option('efi-ld', type : 'array',
+        description : 'the linker to use for EFI modules')
+ option('efi-libdir', type : 'string',
+        description : 'path to the EFI lib directory')
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index c1fe04597b..b42b202ad3 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -45,8 +45,8 @@ if conf.get('ENABLE_EFI') == 1 and get_option('gnu-efi') != 'false'
+                 efi_cc = cc.cmd_array()
+         endif
+         efi_ld = get_option('efi-ld')
+-        if efi_ld == ''
+-                efi_ld = find_program('ld', required: true)
++        if efi_ld.length() == 0
++                efi_ld = [find_program('ld', required: true)]
+         endif
+         efi_incdir = get_option('efi-includedir')
+ 
+@@ -211,7 +211,7 @@ if have_gnu_efi
+                         tuple[0],
+                         input : tuple[2],
+                         output : tuple[0],
+-                        command : [efi_ld, '-o', '@OUTPUT@'] +
++                        command : efi_ld + ['-o', '@OUTPUT@'] +
+                                   efi_ldflags + tuple[2] +
+                                   ['-lefi', '-lgnuefi', libgcc_file_name])
+ 

--- a/meta-mentor-staging/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-mentor-staging/recipes-core/systemd/systemd-boot_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Use-an-array-for-efi-ld-to-allow-for-ld-arguments.patch"
+
+LDFLAGS_remove := "${@ " ".join(d.getVar('LD').split()[1:])} "
+EXTRA_OEMESON += '"-Defi-ld=${@meson_array("LD", d)}"'


### PR DESCRIPTION
The previous method to implement this in the recipe passed only the first LD argument as efi-ld, then added the remainder of the TUNE_LDARGS to LDFLAGS, but this breaks builds, as TUNE_LDARGS is to be passed to *ld*, not *gcc*, but LDFLAGS are flags used when linking with gcc. Fix this by using an array for efi-ld as is done for efi-cc.

JIRA: SB-15603

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
