### PR TITLE
Add and use codename_is_corename.bbclass

### DIFF
--- a/meta-mel/classes/codename_is_corename.bbclass
+++ b/meta-mel/classes/codename_is_corename.bbclass
@@ -1,0 +1,9 @@
+python codename_is_corename() {
+    codename = d.getVar('DISTRO_CODENAME')
+    if codename:
+        corenames = d.getVar('LAYERSERIES_CORENAMES')
+        if corenames and codename not in corenames.split():
+            raise_sanity_error("This version of %s is incompatible with this version of openembedded-core (code name %s). Please use matching layer branches or update %s." % (d.getVar('DISTRO'), d.getVar('LAYERSERIES_CORENAMES'), d.getVar('DISTRO_NAME') or d.getVar('DISTRO')), d, network_error=False)
+}
+codename_is_corename[eventmask] = 'bb.event.SanityCheck'
+addhandler codename_is_corename

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -265,6 +265,9 @@ CB_MBS_OPTIONS[general.yocto.sdk.value] = "${EXTERNAL_REAL_MULTIMACH_TARGET_SYS}
 # Warn the user and disable rootfs resizing for non-GPLv3 builds
 INHERIT += "resize-rootfs-gplv3"
 
+# Ensure that our DISTRO_CODENAME aligns with LAYERSERIES_CORENAMES
+INHERIT += "codename_is_corename"
+
 # Use our toolchain relocation scripts
 INHERIT += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-staging', 'toolchain_ship_relocate_sdk', '', d)}"
 TOOLCHAIN_SHAR_REL_TMPL = "${LAYERDIR_mentor-staging}/files/toolchain-shar-relocate.sh"


### PR DESCRIPTION
This class implements a sanity check which only makes sense when this DISTRO always defines its DISTRO_CODENAME to match up with the Yocto release codename. If DISTRO_CODENAME is not listed in LAYERSERIES_CORENAMES, we abort.

Example output:
```
This version of mel is incompatible with this version of openembedded-core (code name gatesgarth). Please use matching layer branches or update Mentor Embedded Linux Flex OS.
```

JIRA: SB-15572