### PR TITLE
Move from CODEBENCH_PATH to TOOLCHAINS_PATH

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -168,7 +168,7 @@ mkdir -p "$project"
 cd "$project"
 echo "$installdir" >"$project/.installpath"
 
-for install_subdir in ../../codebench ../../codebench-lite ../../tools; do
+for install_subdir in ../../codebench ../../tools; do
     if [ -d "$installdir/$install_subdir" ]; then
         ln -sf "$installdir/$install_subdir" .
     fi

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -168,7 +168,7 @@ mkdir -p "$project"
 cd "$project"
 echo "$installdir" >"$project/.installpath"
 
-for install_subdir in ../../codebench ../../tools; do
+for install_subdir in ../../toolchains ../../tools; do
     if [ -d "$installdir/$install_subdir" ]; then
         ln -sf "$installdir/$install_subdir" .
     fi

--- a/scripts/release/setup-workspace
+++ b/scripts/release/setup-workspace
@@ -105,6 +105,3 @@ if [ $? -ne 0 ]; then
     fi
     exit 1
 fi
-if [ -e "$scriptdir/../.mel-lite" ]; then
-    touch "$WORKSPACEDIR/.mel-lite"
-fi

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -312,20 +312,15 @@ setup_builddir () {
         echo "You had no local.conf file. This configuration file has therefore been"
         echo "created for you with some default values."
 
-        if [ -h "$MELDIR/codebench" ]; then
-            codebench_path="$(cd "$MELDIR" && cd "$(readlink codebench)" && pwd -P)" || codebench_path="$MELDIR/../../codebench"
-            sedexpr="\${MELDIR}/codebench"
+        if [ -h "$MELDIR/toolchains" ]; then
+            toolchains_path="$MELDIR/toolchains"
+            sedexpr='${MELDIR}/toolchains'
         else
-            codebench_path="$MELDIR/../../codebench"
-            sedexpr="\${MELDIR}/../../codebench"
+            toolchains_path="$MELDIR/../../toolchains"
+            sedexpr='${MELDIR}/../../toolchains'
         fi
-
-        if [ -d "$codebench_path" ]; then
-            if [ -d "$codebench_path/../toolchains" ]; then
-                sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,CODEBENCH_PATH ?= \"$sedexpr\"," "$BUILDDIR/conf/local.conf"
-            else
-                sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,EXTERNAL_TOOLCHAIN ?= \"$sedexpr\"," "$BUILDDIR/conf/local.conf"
-            fi
+        if [ -d "$toolchains_path" ]; then
+            sed -i -e "s,^#\?EXTERNAL_TOOLCHAIN.*,TOOLCHAINS_PATH ?= \"$toolchains_path\"," "$BUILDDIR/conf/local.conf"
         fi
     else
         if [ -n "$MACHINE" ]; then

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -8,9 +8,7 @@
 
 DISTRO="${DISTRO:-mel}"
 CORELAYERS="${CORELAYERS:-core mel-support mentor-staging}"
-if [ "${DISTRO}" != "mel-lite" ]; then
-    OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private}"
-fi
+OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private}"
 EXTRAMELLAYERS="${EXTRAMELLAYERS-openembedded-layer filesystems-layer networking-layer multimedia-layer sourcery gplv2}"
 layer_priority_overrides="openembedded-layer=1"
 
@@ -314,17 +312,12 @@ setup_builddir () {
         echo "You had no local.conf file. This configuration file has therefore been"
         echo "created for you with some default values."
 
-        codebench_type="codebench"
-        if [ "$DISTRO" = "mel-lite" ]; then
-            codebench_type="codebench-lite"
-        fi
-
-        if [ -h "$MELDIR/$codebench_type" ]; then
-            codebench_path="$(cd "$MELDIR" && cd "$(readlink $codebench_type)" && pwd -P)" || codebench_path="$MELDIR/../../$codebench_type"
-            sedexpr="\${MELDIR}/$codebench_type"
+        if [ -h "$MELDIR/codebench" ]; then
+            codebench_path="$(cd "$MELDIR" && cd "$(readlink codebench)" && pwd -P)" || codebench_path="$MELDIR/../../codebench"
+            sedexpr="\${MELDIR}/codebench"
         else
-            codebench_path="$MELDIR/../../$codebench_type"
-            sedexpr="\${MELDIR}/../../$codebench_type"
+            codebench_path="$MELDIR/../../codebench"
+            sedexpr="\${MELDIR}/../../codebench"
         fi
 
         if [ -d "$codebench_path" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -42,26 +42,16 @@ else
             fi
         done
 
-        if [ -z "${DISTRO}" ]; then
-            if [ -e "$layerdir/../.mel-lite" ]; then
-                export DISTRO="mel-lite"
-            fi
-        fi
-
-        if [ "${DISTRO}" = "mel-lite" ]; then
-            OPTIONALLAYERS="${OPTIONALLAYERS-}"
-        else
-            OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private}"
-        fi
+        OPTIONALLAYERS="${OPTIONALLAYERS-mentor-private}"
         # Customer directory layers handling (e.g. <customername>-custom)
         for layercheck in . $layerdir/..; do
             if [ -e "$layercheck/customer.conf" ]; then
                 while read -r _customer; do
                     for layercheck2 in . $layerdir/..; do
                         if [ -d "$layercheck2/$_customer-custom" ]; then
-                            if [ -e "$layercheck2/$_customer-custom/custom.conf" ] ; then
-                                CUSTOMERLAYERS=`cat $layercheck2/$_customer-custom/custom.conf | sed -e '/^[ 	]*#/d'`
-                                CUSTOMERLAYERS=`echo $CUSTOMERLAYERS | sed -e 's/\n//g'`
+                            if [ -e "$layercheck2/$_customer-custom/custom.conf" ]; then
+                                CUSTOMERLAYERS=$(cat $layercheck2/$_customer-custom/custom.conf | sed -e '/^[ 	]*#/d')
+                                CUSTOMERLAYERS=$(echo $CUSTOMERLAYERS | sed -e 's/\n//g')
                                 OPTIONALLAYERS="$OPTIONALLAYERS $CUSTOMERLAYERS"
                             fi
                             break
@@ -73,16 +63,16 @@ else
         done
 
         # Hotfix layers handling
-        if [ -e "$layerdir/../hotfixes/hotfix.conf" ] ; then
-            HOTFIXES=`cat $layerdir/../hotfixes/hotfix.conf | sed -e '/^[ 	]*#/d'`
-            HOTFIXES=`echo $HOTFIXES | sed -e 's/\n//g'`
+        if [ -e "$layerdir/../hotfixes/hotfix.conf" ]; then
+            HOTFIXES=$(cat $layerdir/../hotfixes/hotfix.conf | sed -e '/^[ 	]*#/d')
+            HOTFIXES=$(echo $HOTFIXES | sed -e 's/\n//g')
             OPTIONALLAYERS="$OPTIONALLAYERS $HOTFIXES"
         fi
 
         # Extra layers handling
-        if [ -e "$layerdir/../xlayers.conf" ] ; then
-            EXTRALAYERS=`cat $layerdir/../xlayers.conf | sed -e '/^[ 	]*#/d'`
-            EXTRALAYERS=`echo $EXTRALAYERS | sed -e 's/\n//g'`
+        if [ -e "$layerdir/../xlayers.conf" ]; then
+            EXTRALAYERS=$(cat $layerdir/../xlayers.conf | sed -e '/^[ 	]*#/d')
+            EXTRALAYERS=$(echo $EXTRALAYERS | sed -e 's/\n//g')
             OPTIONALLAYERS="$OPTIONALLAYERS $EXTRALAYERS"
         fi
 
@@ -94,21 +84,21 @@ else
     if [ $mel_setup_ret -eq 0 ] && [ -n "$BUILDDIR" ] && [ -e "$BUILDDIR" ]; then
         . $BUILDDIR/setup-environment
 
-        configured_layers () {
-            tac $BUILDDIR/conf/bblayers.conf | \
-                sed -n -e '/^"/,/^BBLAYERS = /{ /^BBLAYERS =/d; /^"/d; p;}' | \
-                awk {'print $1'} | sed -e "s#\${TOPDIR}/#$BUILDDIR/#"
+        configured_layers() {
+            tac $BUILDDIR/conf/bblayers.conf \
+                | sed -n -e '/^"/,/^BBLAYERS = /{ /^BBLAYERS =/d; /^"/d; p;}' \
+                | awk {'print $1'} | sed -e "s#\${TOPDIR}/#$BUILDDIR/#"
         }
 
-        load_lconf_snippet () {
+        load_lconf_snippet() {
             if [ ! -e "$1/$2" ]; then
                 return
             fi
             (
-            lheadername="${1#${layerdir%/*}/}/$2"
-            printf '\n## Begin %s\n\n' "$lheadername"
-            cat "$1/$2"
-            printf '\n## End %s\n' "$lheadername"
+                lheadername="${1#${layerdir%/*}/}/$2"
+                printf '\n## Begin %s\n\n' "$lheadername"
+                cat "$1/$2"
+                printf '\n## End %s\n' "$lheadername"
             ) >>conf/local.conf
         }
 


### PR DESCRIPTION
We're moving to a 'toolchains' link and TOOLCHAINS_PATH rather
than 'codebench' and CODEBENCH_PATH.

JIRA: SB-15621