### PR TITLE
 setup-*: add rsync

### DIFF
--- a/scripts/setup-debian
+++ b/scripts/setup-debian
@@ -31,6 +31,7 @@ set -- \
     patch \
     python3 \
     python3-distutils \
+    rsync \
     wget \
     ssh
 

--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -9,7 +9,7 @@
 packages="python38 \
           patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
-          make gcc gcc-c++"
+          make gcc gcc-c++ rsync"
 
 set -e
 

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -16,7 +16,7 @@ if [ $(id -u) -ne 0 ]; then
     fi
 fi
 
-PKGS="$PKGS ubuntu-minimal ubuntu-standard make gcc g++ patch diffstat texinfo texi2html cvs subversion bzip2 tar gzip gawk chrpath libncurses5-dev git-core lsb-release python python3 xvfb x11-utils"
+PKGS="$PKGS ubuntu-minimal ubuntu-standard make gcc g++ patch diffstat texinfo texi2html cvs subversion bzip2 tar gzip gawk chrpath libncurses5-dev git-core lsb-release python python3 xvfb x11-utils rsync"
 
 # These are needed for the qemu-native build
 PKGS="$PKGS libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev"


### PR DESCRIPTION
This is used by the `make headers` target in the kernel builds for linux-libc-headers. For non-imx, we use the external recipe and don't call this target, but on imx we build linux-imx-headers and can run into a build failure on hosts lacking rsync.

JIRA: SB-15635