### PR TITLE
setup-rh: Fix MEL build issue on RHEL 8 due to missing rpcgen.

### DIFF
--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -9,7 +9,7 @@
 packages="python38 \
           patch diffstat git bzip2 tar \
           gzip gawk chrpath wget cpio perl file which \
-          make gcc gcc-c++ rsync"
+          make gcc gcc-c++ rsync rpcgen"
 
 set -e
 


### PR DESCRIPTION
* On RHEL 8 rpcgen was needed on the host for few imx BSPs. Added in
  setup script so that it can be installed on host.
* SB-15706

Signed-off-by: ahsann <noor_ahsan@mentor.com>