### PR TITLE
udev-extraconf/mount.sh: ignore lvm in automount

### DIFF
--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf/0001-udev-extraconf-mount.sh-ignore-lvm-in-automount.patch
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf/0001-udev-extraconf-mount.sh-ignore-lvm-in-automount.patch
@@ -1,0 +1,35 @@
+From c81149d0faef688270b7f4b49bef7bd71016b242 Mon Sep 17 00:00:00 2001
+From: Ansar Rasool <ansar_rasool@mentor.com>
+Date: Tue, 10 Nov 2020 12:50:14 +0500
+Subject: [PATCH 1/1] udev-extraconf/mount.sh: ignore lvm in automount
+
+Signed-off-by: Ansar Rasool <ansar_rasool@mentor.com>
+---
+ mount.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/mount.sh b/mount.sh
+index ef4e1ad..513a716 100644
+--- a/mount.sh
++++ b/mount.sh
+@@ -67,6 +67,8 @@ automount_systemd() {
+         ;;
+     swap)
+         return ;;
++    lvm*|LVM*)
++        return ;;
+     # TODO
+     *)
+         ;;
+@@ -127,6 +129,8 @@ automount() {
+ 		;;
+ 	swap)
+ 		return ;;
++	lvm*|LVM*)
++                return ;;
+ 	# TODO
+ 	*)
+ 		;;
+-- 
+2.17.1
+

--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf_%.bbappend
@@ -3,7 +3,8 @@ SRC_URI +=  "file://0001-udev-extraconf-mount.sh-add-LABELs-to-mountpoints.patch
              ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://systemd-udevd.service', '', d)} \
              file://0001-udev-extraconf-mount.sh-define-mount-prefix-using-a-.patch \
              file://0002-udev-extraconf-mount.sh-save-mount-name-in-our-tmp-f.patch \
-             file://0003-udev-extraconf-mount.sh-only-mount-devices-on-hotplu.patch"
+             file://0003-udev-extraconf-mount.sh-only-mount-devices-on-hotplu.patch \
+             file://0001-udev-extraconf-mount.sh-ignore-lvm-in-automount.patch"
 
 RDEPENDS_${PN} += "util-linux-blkid"
 


### PR DESCRIPTION
Failure message is shown in boot logs when trying to
mount lvm on emmc while booting from sdcard. This
simply skips lvm while automounting to avoid failure
message in boot logs.

Fixes: https://jira.alm.mentorg.com/browse/SB-15734
Signed-off-by: Ansar Rasool <ansar_rasool@mentor.com>