### PR TITLE
udev-extraconf: fix systemd automount issue

### DIFF
--- a/meta-mentor-staging/recipes-core/udev/udev-extraconf/0003-udev-extraconf-mount.sh-only-mount-devices-on-hotplu.patch
+++ b/meta-mentor-staging/recipes-core/udev/udev-extraconf/0003-udev-extraconf-mount.sh-only-mount-devices-on-hotplu.patch
@@ -22,14 +22,28 @@ variable during the remove action.
 
 Signed-off-by: Awais Belal <awais_belal@mentor.com>
 ---
- mount.sh | 27 ++++++++++++++++++++-------
- 1 file changed, 20 insertions(+), 7 deletions(-)
+ mount.sh | 33 ++++++++++++++++++++-------
+ 1 file changed, 26 insertions(+), 7 deletions(-)
 
 Index: 1.1-r0/mount.sh
 ===================================================================
 --- 1.1-r0.orig/mount.sh
 +++ 1.1-r0/mount.sh
-@@ -97,6 +97,13 @@ automount() {
+@@ -46,6 +46,13 @@ automount_systemd() {
+         return
+     fi
+ 
++	# Only go for auto-mounting when the device has been cleaned up in remove
++	# or has not been identified yet
++	if [ -e "/tmp/.automount-$name" ]; then
++		logger "mount.sh/automount" "[$MOUNT_PREFIX/$name] is already cached"
++		return
++	fi
++
+     # Skip the partition which are already in /etc/fstab
+     grep "^[[:space:]]*$DEVNAME" /etc/fstab && return
+     for n in LABEL PARTLABEL UUID PARTUUID; do
+@@ -105,6 +112,13 @@ automount() {
  		name="${LABEL}-${name}"
  	fi
  
@@ -43,7 +57,7 @@ Index: 1.1-r0/mount.sh
  	! test -d "$MOUNT_PREFIX/$name" && mkdir -p "$MOUNT_PREFIX/$name"
  	# Silent util-linux's version of mounting auto
  	if [ "x`readlink $MOUNT`" = "x/bin/mount.util-linux" ] ;
-@@ -155,12 +162,18 @@ if [ "$ACTION" = "add" ] && [ -n "$DEVNA
+@@ -165,12 +179,18 @@ if [ "$ACTION" = "add" ] && [ -n "$DEVNA
  fi
  
  if [ "$ACTION" = "remove" ] || [ "$ACTION" = "change" ] && [ -x "$UMOUNT" ] && [ -n "$DEVNAME" ]; then


### PR DESCRIPTION
This fixes auto-mounting issue where a manually
unmounted disk would get auto-mounted simply by running
tools such as fdisk from the util-linux package which
generate a BLKRRPART ioctl in order to support any of
their features.

JIRA Ticket: SB-15741

Signed-off-by: ekalemen <eugeny_kalemenev@mentor.com>