### PR TITLE
mel: drop build-id

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -330,10 +330,6 @@ BBMASK += "/meta-intel/common/recipes-bsp/systemd-boot/"
 # reduce the memory footprint
 DEBUG_FLAGS_remove_pn-webkitgtk = "-g"
 
-# Align the external toolchain with the internal one. This is also needed for
-# Sourcery Analyzer with lttng-ust
-TARGET_LDFLAGS += "-Wl,--build-id=sha1"
-
 # Explicitly remove the proprietary stuff
 MACHINE_HWCODECS = ""
 


### PR DESCRIPTION
This was only needed when using an external toolchain which didn't include the build id by default. This is not the case with a Yocto-built toolchain, so we no longer need it.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
