### PR TITLE
psplash: fix failed starting Terminate Psplash Boot Screen

### DIFF
--- a/meta-mel/recipes-core/psplash/mel/psplash-quit.service
+++ b/meta-mel/recipes-core/psplash/mel/psplash-quit.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Terminate Psplash Boot Screen
 After=psplash-start.service
+ConditionPathExists=/run/psplash_fifo
 
 [Service]
 Environment=TMPDIR=/run


### PR DESCRIPTION
Removing type=oneshot and "default" way of starting the service.

JIRA: https://jira.alm.mentorg.com/browse/SB-16089

Signed-off-by: Arulpandiyan Vadivel <arulpandiyan_vadivel@mentor.com>