### PR TITLE
setup-mel-builddir: do not depend on mentor-bsp for every machine

### DIFF
--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -274,7 +274,7 @@ setup_builddir () {
             fi
         fi
     fi
-    OPTIONALLAYERS="$OPTIONALLAYERS mentor-bsp mentor-bsp-$MACHINE"
+    OPTIONALLAYERS="$OPTIONALLAYERS mentor-bsp-$MACHINE"
 
     if [ $force_overwrite -eq 1 ]; then
         rm -f $BUILDDIR/conf/local.conf $BUILDDIR/conf/bblayers.conf


### PR DESCRIPTION
We have a requirement where upstream Yocto BSPs should be able to
build with MEL out of the box. Sourcing setup-environment at this
point for an upstream machine adds the MEL common BSP layer to
bblayers automatically which is not correct as that particular
machine is not a MEL BSP. However, we do need this for qemu BSPs
as we use the same upstream machine name but create a layer for
our modifications.

Signed-off-by: Awais Belal <awais_belal@mentor.com>