### PR TITLE
mel.conf: do not fetch anti-virus db at compile time in clamav

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -234,6 +234,8 @@ PACKAGECONFIG_REMOVE_pn-mesa-demos = "glx"
 # We don't use dracut to build initramfs
 PACKAGECONFIG_REMOVE_pn-plymouth = "initrd"
 
+# Do not fetch the anti-virus db at compile-time
+INSTALL_CLAMAV_CVD ?= ""
 ## }}}1
 ## Inherits {{{1
 # We want information about package and image contents


### PR DESCRIPTION
JIRA: SB-16462

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
