### PR TITLE
[dunfell] mel-debugging / mel-bsp / inclusion of layers for upstream BSPs

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -50,7 +50,7 @@ MACHINE ??= "qemux86"
 # details.
 
 IMAGE_FEATURES_DEVELOPMENT ?= "debug-tweaks"
-IMAGE_FEATURES_DEVELOPMENT += "${@bb.utils.contains('MACHINE_FEATURES', 'mel-bsp', 'codebench-debug ssh-server-openssh tools-profile', '', d)}"
+IMAGE_FEATURES_DEVELOPMENT_append_feature-mel-bsp = " codebench-debug ssh-server-openssh tools-profile"
 EXTRA_IMAGE_FEATURES = "${IMAGE_FEATURES_DEVELOPMENT} multilib-runtime"
 
 # Image features for production-image

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -60,10 +60,6 @@ IMAGE_FEATURES_DISABLED_PRODUCTION ?= "${IMAGE_FEATURES_DEVELOPMENT} ssh-server-
 # Install tzdata with systemd when building read only images
 CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', 'tzdata' if d.getVar('VIRTUAL-RUNTIME_init_manager') == 'systemd' else '', '', d)}"
 
-# Uncomment the following to enable BSP specific patches and configurations for
-# kernel debugging
-#MACHINE_FEATURES_append = " mel-debugging"
-
 # Uncomment to enable runtime testing with ptest
 #USER_FEATURES += "ptest"
 #EXTRA_IMAGE_FEATURES += "ptest-pkgs"

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -274,7 +274,15 @@ setup_builddir () {
             fi
         fi
     fi
-    OPTIONALLAYERS="$OPTIONALLAYERS mentor-bsp-$MACHINE"
+
+    # Pick up qemu layers from meta-mentor-bsp as we do
+    # not create separate machines for them
+    case ${MACHINE} in
+        qemu*)
+            OPTIONALLAYERS="$OPTIONALLAYERS mentor-bsp-$MACHINE"
+            ;;
+    esac
+
 
     if [ $force_overwrite -eq 1 ]; then
         rm -f $BUILDDIR/conf/local.conf $BUILDDIR/conf/bblayers.conf


### PR DESCRIPTION
- move mel-debugging machine feature from meta-mentor to meta-mentor-bsp
- conditionalize inclusion of machine layer on qemu as other upstream BSPs should be handled differently
- utilize the feature-mel-bsp