### PR TITLE
[dunfell] libsdl2: disable shared memory for native builds

### DIFF
--- a/meta-mentor-staging/recipes-graphics/libsdl2/libsdl2_2.%.bbappend
+++ b/meta-mentor-staging/recipes-graphics/libsdl2/libsdl2_2.%.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append_class-native = " -DNO_SHARED_MEMORY"


### PR DESCRIPTION
libsdl2 currently does not handle the failures that
occur due to shared memory in case of remote hosts
where it should ideally switch to socket based writing
when a failure is seen with shared memory.
Consider a scenario where a qemu build is done with
graphics support on a build machine and then accessed
remotely using ssh. If the remote host's X presents
MIT-SHM as an extension, launching qemu fails with

runqemu - ERROR - Failed to run qemu: X Error:  BadValue
   Request Major code 130 (MIT-SHM)
   Request Minor code 3 ()

This is most often seen when the remote machine doing
ssh is a Ubuntu 20.04. The libsdl2 native are mainly
used for qemu at this time so it is a major usecase.
A report of such a failure was also presented at
https://lists.yoctoproject.org/g/poky/topic/78854857

Fixes: https://jira.alm.mentorg.com/browse/SB-16569
Signed-off-by: Awais Belal <awais_belal@mentor.com>