### PR TITLE
sourcery-version-check.inc: ignore the minor version

### DIFF
--- a/meta-mel/conf/distro/include/sourcery-version-check.inc
+++ b/meta-mel/conf/distro/include/sourcery-version-check.inc
@@ -6,21 +6,19 @@ python sourcery_version_check () {
     if not sourcery_version or sourcery_version == 'UNKNOWN':
         return
 
-    def version(str):
-        if str is None:
+    def version(s):
+        if s is None:
             return []
-
-        elements = str.split('-')
-        if len(elements) > 1:
-            elements.pop()
-        return elements
+        ver = s.split('-', 1)[0].split('.')
+        if len(ver) > 2:
+            ver = ver[:2]
+        return ver
 
     # Check for a specified required toolchain version for releases
-    toolchain_required_version = version(d.getVar('SOURCERY_VERSION_REQUIRED', True))
+    toolchain_required_version = d.getVar('SOURCERY_VERSION_REQUIRED')
     if toolchain_required_version:
-        sourcery_version = version(sourcery_version)
-        if sourcery_version != toolchain_required_version:
-            bb.fatal('Found toolchain version `%s`, expected `%s`. Please install the supported toolchain.' % ('-'.join(sourcery_version), '-'.join(toolchain_required_version)))
+        if version(sourcery_version) != version(toolchain_required_version):
+            bb.fatal('Found toolchain version `%s`, expected `%s`. Please install the supported toolchain.' % (sourcery_version, toolchain_required_version))
 }
 # We run this at build start to ensure that bitbake -e still works
 sourcery_version_check[eventmask] = "bb.event.BuildStarted"


### PR DESCRIPTION
We don't need to abort the build if we have 12.0.4 but it wants 12.0.0.

JIRA: SB-16597