### PR TITLE
qtbase: fix abi tag note alignment for some targets

### DIFF
--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase/Fix-note-alignment.patch
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase/Fix-note-alignment.patch
@@ -1,0 +1,32 @@
+From 4d8f490c91767806c267cb50fb3f97e8ecc7e533 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Sun, 17 May 2020 11:57:58 +0200
+Subject: [PATCH] Fix note alignment
+
+It is architecture defined whether .align means .palign or .balign.  Use
+.balign to make that explicit.
+
+Change-Id: I8c7e3760b37edfb207b7088319a338a1f583255b
+Reviewed-by: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+Upstream-Status: Backport [47a4e6a9497b068a0400ba3f01629c62608e1ec3]
+---
+ src/corelib/global/minimum-linux.S | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/corelib/global/minimum-linux.S b/src/corelib/global/minimum-linux.S
+index dfc3cec1be..e324379efc 100644
+--- a/src/corelib/global/minimum-linux.S
++++ b/src/corelib/global/minimum-linux.S
+@@ -62,7 +62,7 @@
+ 
+     .section    ".note.GNU-stack", "", progbits
+     .section    ".note.ABI-tag", "a", note
+-    .align      4       /* we have 32-bit data */
++    .balign     4       /* we have 32-bit data */
+ 
+ /*  * For the format of the note section's contents, see Elf32_Nhdr / Elf64_Nhdr */
+     .long       .Lnameend-.Lname        /* n_namesz */
+-- 
+2.28.0
+

--- a/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/meta-mentor-staging/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/qtbase:"
+SRC_URI += "file://Fix-note-alignment.patch"


### PR DESCRIPTION
This cherry-picks the fix from upstream qtbase git to fix a warning seen by `readelf -n` due to an alignment issue with the note.

JIRA: SB-16601

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
