### PR TITLE
python3: use patchinfo to write python3-patches.txt for release-downloads

### DIFF
--- a/meta-mel-support/recipes-devtools/python/python3-unidiff/run-ptest
+++ b/meta-mel-support/recipes-devtools/python/python3-unidiff/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pytest -o log_cli=true -o log_cli_level=INFO | sed -e 's/\[...%\]//g'| sed -e 's/PASSED/PASS/g'| sed -e 's/FAILED/FAIL/g'|sed -e 's/SKIPPED/SKIP/g'| awk '{if ($NF=="PASS" || $NF=="FAIL" || $NF=="SKIP" || $NF=="XFAIL" || $NF=="XPASS"){printf "%s: %s\n", $NF, $0}else{print}}'| awk '{if ($NF=="PASS" || $NF=="FAIL" || $NF=="SKIP" || $NF=="XFAIL" || $NF=="XPASS") {$NF="";print $0}else{print}}'

--- a/meta-mel-support/recipes-devtools/python/python3-unidiff_%.bbappend
+++ b/meta-mel-support/recipes-devtools/python/python3-unidiff_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "native"

--- a/meta-mel-support/recipes-devtools/python/python3-unidiff_0.6.0.bb
+++ b/meta-mel-support/recipes-devtools/python/python3-unidiff_0.6.0.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Unified diff parsing/metadata extraction library"
+HOMEPAGE = "http://github.com/matiasb/python-unidiff"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4c434b08ef42fea235bb019b5e5a97b3"
+
+SRC_URI[md5sum] = "ae9524079753df7b1239f0378ed326b7"
+SRC_URI[sha256sum] = "90c5214e9a357ff4b2fee19d91e77706638e3e00592a732d9405ea4e93da981f"
+
+inherit pypi setuptools3 ptest
+
+SRC_URI += " \
+        file://run-ptest \
+"
+
+RDEPENDS_${PN}-ptest += " \
+       ${PYTHON_PN}-pytest \
+"
+
+do_install_ptest() {
+      install -d ${D}${PTEST_PATH}/tests
+        cp -rf ${S}/tests/* ${D}${PTEST_PATH}/tests/
+}
+
+RDEPENDS_${PN} += " \
+    ${PYTHON_PN}-codecs \
+    ${PYTHON_PN}-io \
+"

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -277,6 +277,9 @@ TOOLCHAIN_EXT_REL_TMPL = "${LAYERDIR_mentor-staging}/files/toolchain-shar-extrac
 RELOCATE_SDK_SH ?= "${LAYERDIR_mentor-staging}/files/relocate_sdk.sh"
 ## }}}1
 ## Preferences & Package Selection {{{1
+# Prefer this version for patchinfo for python3
+PREFERRED_VERSION_python3-unidiff-native = "0.6.0"
+
 # Default to the Xorg X server if the BSP doesn't specify
 XSERVER ??= "\
     xserver-xorg \

--- a/meta-mel/recipes-devtools/python/python3_%.bbappend
+++ b/meta-mel/recipes-devtools/python/python3_%.bbappend
@@ -1,0 +1,51 @@
+# Needed by patchinfo
+PATCHINFO_PYTHONPATH = "${COMPONENTS_DIR}/${BUILD_ARCH}/python3-unidiff-native/${libdir}/python${PYTHON_MAJMIN}/site-packages"
+DEPENDS_UNIDIFF = ""
+DEPENDS_UNIDIFF_mel_class-target = "python3-unidiff-native:do_populate_sysroot"
+do_archive_release_downloads[depends] += "${DEPENDS_UNIDIFF}"
+
+# Write patch names and modified files to python3-patches.txt
+python do_archive_release_downloads_append_mel_class-target () {
+    import csv
+    import json
+    from collections import defaultdict
+    from pathlib import Path
+
+    sources_dir = Path(sources_dir)
+    layerdir = d.getVar('LAYERDIR_mel')
+    script = Path(layerdir).parent / 'scripts' / 'patchinfo'
+    if not script.exists():
+        bb.fatal('Expected {} script does not exist'.format(str(script)))
+    
+    python = d.getVar('PYTHON')
+    env = os.environ.copy()
+    env['PYTHONPATH'] = d.getVar('PATCHINFO_PYTHONPATH')
+
+    patchinfos = []
+    patches = [bb.fetch.decodeurl(u)[2] for u in src_patches(d)]
+    for patch in patches:
+        try:
+            info, _ = bb.process.run([python, str(script), patch], cwd=sources_dir, env=env)
+        except bb.process.ExecutionError as exc:
+            bb.warn("Failed to get patchinfo for %s: %s" % (patch, exc))
+            continue
+        else:
+            try:
+                patchinfo = json.loads(info)
+            except json.decoder.JSONDecodeError as exc:
+                bb.warn("Failed to decode json from patchinfo for %s" % patch)
+                continue
+            else:
+                if 'Filename' in patchinfo and 'Files' in patchinfo:
+                    patchinfos.append(patchinfo)
+                else:
+                    bb.warn("Unexpected json contents for patchinfo for %s" % patch)
+    
+    with open(sources_dir / 'python3-patches.txt', 'w') as f:
+        for patchinfo in patchinfos:
+            bb.warn(repr(patchinfo))
+            patch, files = patchinfo['Filename'], patchinfo['Files']
+            f.write(patch + ':\n')
+            for fn in files:
+                f.write('  ' + fn + '\n')
+}

--- a/scripts/patchinfo
+++ b/scripts/patchinfo
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import itertools
+import json
+import re
+import subprocess
+import sys
+import traceback
+from email.parser import Parser
+from email.policy import default
+from pathlib import Path
+
+import unidiff
+
+patchnum = re.compile(r'^[0-9]*-')
+prefix = re.compile(r'(\[.*\] *)*')
+fieldline = re.compile(r'^(?P<field>[a-zA-Z]+(-[a-zA-Z]+)*): (?P<value>.*)$')
+multifields = ['CVE', 'Signed-off-by']
+modified_file_prefixes = ['a', 'b']
+
+
+class PatchError(Exception):
+    pass
+
+
+class PatchParseError(PatchError):
+    def __init__(self, filename, message=None):
+        super().__init__(message)
+        self.filename = filename
+
+    def __str__(self):
+        message = f'Failed to parse {self.filename}'
+        while self.__cause__:
+            message = message + ": " + str(self.__cause__)
+            self = self.__cause__
+        return message
+
+
+def parse(patchfile):
+    try:
+        return unidiff.PatchSet(patchfile, metadata_only=True)
+    except (UnicodeDecodeError, unidiff.errors.UnidiffParseError) as exc:
+        raise PatchParseError(patchfile.name) from exc
+
+
+def addinfo(info, key, value):
+    if key in multifields:
+        if key in info:
+            info[key].append(value)
+        else:
+            info[key] = [value]
+    else:
+        info[key] = value
+        
+def patchinfo(patchfile):
+    """Print patch information."""
+
+    errors = []
+    patchpath = Path(patchfile.name)
+    patchinfo = {'Filename': patchpath.name}
+    patched_files = []
+    subject = patchnum.sub('', patchpath.stem, 1)
+    subject = subject.replace(
+        '-', ' ').replace('_', ' ')
+    subject = subject[0].upper() + subject[1:]
+
+    try:
+        patch = parse(patchfile)
+    except PatchError as exc:
+        errors.append(traceback.TracebackException.from_exception(exc))
+
+        try:
+            diffstat_l = subprocess.check_output(['diffstat', '-l', patchpath])
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            patched_files = diffstat_l.decode('utf-8').splitlines()
+    else:
+        if patch:
+            patch_info = patch[0].patch_info
+            if not patch_info[0].startswith('diff '):
+                filtered = list(itertools.takewhile(lambda l: l.strip()
+                                                    != '---' and not l.startswith('diff '), patch_info))
+                info = ''.join(filtered[1:])
+                if info:
+                    headers = Parser(policy=default).parsestr(info)
+                    for key, value in headers.items():
+                        addinfo(patchinfo, key, value)
+
+                    if headers['subject']:
+                        subject = headers['subject']
+
+                    matches = [fieldline.match(l.rstrip()) for l in filtered[1:]]
+                    extrafields = dict((m.group('field'), m.group('value')) for m in matches if m)
+                    for key, value in extrafields.items():
+                        if key not in headers:
+                            addinfo(patchinfo, key, value)
+
+            for patchedfile in patch:
+                fn = Path(patchedfile.target_file)
+                first = fn.parts[0]
+                if first in modified_file_prefixes:
+                    fn = fn.relative_to(first)
+
+                patched_files.append(str(fn))
+
+    if subject:
+        subject = prefix.sub('', subject, 1)
+        addinfo(patchinfo, 'Summary', subject)
+
+    if patched_files:
+        addinfo(patchinfo, 'Files', sorted(patched_files))
+
+    return patchinfo, errors
+
+
+def main(argv=sys.argv):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Print information about the specified patches')
+    parser.add_argument('patchfiles', metavar='PATCHFILE', nargs='*',
+                        help='Patch filename')
+
+    args = parser.parse_args()
+
+    ret = 0
+    for filename in args.patchfiles:
+        with open(filename) as patchfile:
+            info, errors = patchinfo(patchfile)
+            if errors:
+                for error in errors:
+                    sys.stderr.write(str(error) + '\n')
+                    ret = 1
+
+        print(json.dumps(info, indent=4))
+
+    return ret
+
+
+if __name__ == '__main__':
+    sys.exit(main() or 0)


### PR DESCRIPTION
This aligns with the behavior of meta-codebench-toolchain for python3 clearing, as suggested by @jeremy-robinson. In this case patchinfo is used, solely because the other script from the other layer is more specific to their requirements rather than general purpose.