### PR TITLE
staging/rootfs.py: align run-postinsts handling with upstream

### DIFF
--- a/meta-mentor-staging/lib/oe/rootfs.py
+++ b/meta-mentor-staging/lib/oe/rootfs.py
@@ -247,17 +247,11 @@ class Rootfs(object, metaclass=ABCMeta):
 
 
     def _uninstall_unneeded(self):
-        # Remove unneeded init script symlinks
+        # Remove the run-postinsts package if no delayed postinsts are found
         delayed_postinsts = self._get_delayed_postinsts()
         if delayed_postinsts is None:
-            if os.path.exists(self.d.expand("${IMAGE_ROOTFS}${sysconfdir}/init.d/run-postinsts")):
-                self._exec_shell_cmd(["update-rc.d", "-f", "-r",
-                                      self.d.getVar('IMAGE_ROOTFS'),
-                                      "run-postinsts", "remove"])
-            if os.path.exists(self.d.expand("${IMAGE_ROOTFS}${systemd_unitdir}/system/run-postinsts.service")):
-                self._exec_shell_cmd(["systemctl",
-                                        "--root", self.d.getVar('IMAGE_ROOTFS'),
-                                        "mask", "run-postinsts.service"])
+            if os.path.exists(self.d.expand("${IMAGE_ROOTFS}${sysconfdir}/init.d/run-postinsts")) or os.path.exists(self.d.expand("${IMAGE_ROOTFS}${systemd_unitdir}/system/run-postinsts.service")):
+                self.pm.remove(["run-postinsts"])
 
         image_rorfs = bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs",
                                         True, False, self.d)


### PR DESCRIPTION
This aligns the approach that got accepted upstream so it would
make sense to pick that up right now.

Ref: https://git.openembedded.org/openembedded-core/commit/meta/lib/oe?id=627fb3181edd71502fbdf96549c41b2dea027250

Signed-off-by: Awais Belal <awais_belal@mentor.com>