### PR TITLE
libmodbus: add initial ptest

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus/local-tcp-test
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus/local-tcp-test
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+scriptdir="$(dirname "$0")"
+
+client_log=$scriptdir/unit-test-client.log
+server_log=$scriptdir/unit-test-server.log
+
+rm -f $client_log $server_log
+
+$scriptdir/unit-test-server > $server_log 2>&1 &
+
+sleep 1
+
+$scriptdir/unit-test-client > $client_log 2>&1
+rc=$?
+
+killall unit-test-server >/dev/null 2>&1
+
+if ! grep -q "ALL TESTS PASS WITH SUCCESS." $client_log; then
+    rc=1
+fi
+exit $rc

--- a/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus/run-ptest
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus/run-ptest
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for test in @PTEST_PATH@/tests/*-test; do
+    if "$test"; then
+        echo "PASS: ${test##*/}"
+    else
+        echo "FAIL: ${test##*/}"
+    fi
+done

--- a/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus_%.bbappend
+++ b/meta-mentor-staging/openembedded-layer/recipes-extended/libmodbus/libmodbus_%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/libmodbus:"
+SRC_URI += "\
+    file://run-ptest \
+    file://local-tcp-test \
+"
+
+inherit ptest
+
+do_install_ptest() {
+        install -d ${D}${PTEST_PATH}/tests/
+        install -m 0755 ${WORKDIR}/*-test ${B}/tests/.libs/* ${D}${PTEST_PATH}/tests/
+        sed -i -e 's#@PTEST_PATH@#${PTEST_PATH}#g' ${D}${PTEST_PATH}/run-ptest
+}


### PR DESCRIPTION
The current version uses our own script, but ideally we should likely patch the existing scripts to address any issues, patch the makefile to add an install-ptest rule, and ship the script and Makefile. This will do for the moment.

JIRA: MELMR-280

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
