### PR TITLE
openssh:  fix CVE-2021-28041 by updating the package

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/openssh/files/add-test-support-for-busybox.patch
+++ b/meta-mentor-staging/recipes-connectivity/openssh/files/add-test-support-for-busybox.patch
@@ -1,0 +1,47 @@
+Adjust test cases to work with busybox.
+
+- Replace dd parameter "obs" with "bs".
+- Replace "head -<num>" with "head -n <num>".
+
+Signed-off-by: Maxin B. John <maxin.john@enea.com>
+Upstream-Status: Pending
+
+Index: openssh-7.6p1/regress/cipher-speed.sh
+===================================================================
+--- openssh-7.6p1.orig/regress/cipher-speed.sh
++++ openssh-7.6p1/regress/cipher-speed.sh
+@@ -17,7 +17,7 @@ for c in `${SSH} -Q cipher`; do n=0; for
+ 		printf "%-60s" "$c/$m:"
+ 		( ${SSH} -o 'compression no' \
+ 			-F $OBJ/ssh_proxy -m $m -c $c somehost \
+-			exec sh -c \'"dd of=/dev/null obs=32k"\' \
++			exec sh -c \'"dd of=/dev/null bs=32k"\' \
+ 		< ${DATA} ) 2>&1 | getbytes
+ 
+ 		if [ $? -ne 0 ]; then
+Index: openssh-7.6p1/regress/transfer.sh
+===================================================================
+--- openssh-7.6p1.orig/regress/transfer.sh
++++ openssh-7.6p1/regress/transfer.sh
+@@ -13,7 +13,7 @@ cmp ${DATA} ${COPY}		|| fail "corrupted
+ for s in 10 100 1k 32k 64k 128k 256k; do
+ 	trace "dd-size ${s}"
+ 	rm -f ${COPY}
+-	dd if=$DATA obs=${s} 2> /dev/null | \
++	dd if=$DATA bs=${s} 2> /dev/null | \
+ 		${SSH} -q -F $OBJ/ssh_proxy somehost "cat > ${COPY}"
+ 	if [ $? -ne 0 ]; then
+ 		fail "ssh cat $DATA failed"
+Index: openssh-7.6p1/regress/key-options.sh
+===================================================================
+--- openssh-7.6p1.orig/regress/key-options.sh
++++ openssh-7.6p1/regress/key-options.sh
+@@ -47,7 +47,7 @@ for f in 127.0.0.1 '127.0.0.0\/8'; do
+ 	fi
+ 
+ 	sed 's/.*/from="'"$f"'" &/' $origkeys >$authkeys
+-	from=`head -1 $authkeys | cut -f1 -d ' '`
++	from=`head -n 1 $authkeys | cut -f1 -d ' '`
+ 	verbose "key option $from"
+ 	r=`${SSH} -q -F $OBJ/ssh_proxy somehost 'echo true'`
+ 	if [ "$r" = "true" ]; then

--- a/meta-mentor-staging/recipes-connectivity/openssh/files/fix-potential-signed-overflow-in-pointer-arithmatic.patch
+++ b/meta-mentor-staging/recipes-connectivity/openssh/files/fix-potential-signed-overflow-in-pointer-arithmatic.patch
@@ -1,0 +1,111 @@
+From 3328e98bcbf2930cd7eea3e6c92ad5dcbdf4794f Mon Sep 17 00:00:00 2001
+From: Yuanjie Huang <yuanjie.huang@windriver.com>
+Date: Wed, 24 Aug 2016 03:15:43 +0000
+Subject: [PATCH] Fix potential signed overflow in pointer arithmatic
+
+Pointer arithmatic results in implementation defined signed integer
+type, so that 's - src' in strlcpy and others may trigger signed overflow.
+In case of compilation by gcc or clang with -ftrapv option, the overflow
+would lead to program abort.
+
+Upstream-Status: Submitted [http://bugzilla.mindrot.org/show_bug.cgi?id=2608]
+
+Signed-off-by: Yuanjie Huang <yuanjie.huang@windriver.com>
+
+Complete the fix
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ openbsd-compat/strlcat.c | 10 +++++++---
+ openbsd-compat/strlcpy.c |  8 ++++++--
+ openbsd-compat/strnlen.c |  8 ++++++--
+ 3 files changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/openbsd-compat/strlcat.c b/openbsd-compat/strlcat.c
+index bcc1b61..124e1e3 100644
+--- a/openbsd-compat/strlcat.c
++++ b/openbsd-compat/strlcat.c
+@@ -23,6 +23,7 @@
+ 
+ #include <sys/types.h>
+ #include <string.h>
++#include <stdint.h>
+ 
+ /*
+  * Appends src to string dst of size siz (unlike strncat, siz is the
+@@ -42,7 +43,7 @@ strlcat(char *dst, const char *src, size_t siz)
+ 	/* Find the end of dst and adjust bytes left but don't go past end */
+ 	while (n-- != 0 && *d != '\0')
+ 		d++;
+-	dlen = d - dst;
++	dlen = (uintptr_t)d - (uintptr_t)dst;
+ 	n = siz - dlen;
+ 
+ 	if (n == 0)
+@@ -55,8 +56,11 @@ strlcat(char *dst, const char *src, size_t siz)
+ 		s++;
+ 	}
+ 	*d = '\0';
+-
+-	return(dlen + (s - src));	/* count does not include NUL */
++        /*
++	 * Cast pointers to unsigned type before calculation, to avoid signed
++	 * overflow when the string ends where the MSB has changed.
++	 */
++	return (dlen + ((uintptr_t)s - (uintptr_t)src));	/* count does not include NUL */
+ }
+ 
+ #endif /* !HAVE_STRLCAT */
+diff --git a/openbsd-compat/strlcpy.c b/openbsd-compat/strlcpy.c
+index b4b1b60..b06f374 100644
+--- a/openbsd-compat/strlcpy.c
++++ b/openbsd-compat/strlcpy.c
+@@ -23,6 +23,7 @@
+ 
+ #include <sys/types.h>
+ #include <string.h>
++#include <stdint.h>
+ 
+ /*
+  * Copy src to string dst of size siz.  At most siz-1 characters
+@@ -51,8 +52,11 @@ strlcpy(char *dst, const char *src, size_t siz)
+ 		while (*s++)
+ 			;
+ 	}
+-
+-	return(s - src - 1);	/* count does not include NUL */
++        /*
++	 * Cast pointers to unsigned type before calculation, to avoid signed
++	 * overflow when the string ends where the MSB has changed.
++	 */
++	return ((uintptr_t)s - (uintptr_t)src - 1);	/* count does not include NUL */
+ }
+ 
+ #endif /* !HAVE_STRLCPY */
+diff --git a/openbsd-compat/strnlen.c b/openbsd-compat/strnlen.c
+index 7ad3573..7040f1f 100644
+--- a/openbsd-compat/strnlen.c
++++ b/openbsd-compat/strnlen.c
+@@ -23,6 +23,7 @@
+ #include <sys/types.h>
+ 
+ #include <string.h>
++#include <stdint.h>
+ 
+ size_t
+ strnlen(const char *str, size_t maxlen)
+@@ -31,7 +32,10 @@ strnlen(const char *str, size_t maxlen)
+ 
+ 	for (cp = str; maxlen != 0 && *cp != '\0'; cp++, maxlen--)
+ 		;
+-
+-	return (size_t)(cp - str);
++        /*
++	 * Cast pointers to unsigned type before calculation, to avoid signed
++	 * overflow when the string ends where the MSB has changed.
++	 */
++	return (size_t)((uintptr_t)cp - (uintptr_t)str);
+ }
+ #endif
+-- 
+2.17.1
+

--- a/meta-mentor-staging/recipes-connectivity/openssh/openssh_8.5p1.bb
+++ b/meta-mentor-staging/recipes-connectivity/openssh/openssh_8.5p1.bb
@@ -1,0 +1,181 @@
+SUMMARY = "A suite of security-related network utilities based on \
+the SSH protocol including the ssh client and sshd server"
+DESCRIPTION = "Secure rlogin/rsh/rcp/telnet replacement (OpenSSH) \
+Ssh (Secure Shell) is a program for logging into a remote machine \
+and for executing commands on a remote machine."
+HOMEPAGE = "http://www.openssh.com/"
+SECTION = "console/network"
+LICENSE = "BSD-2-Clause & BSD-3-Clause & BSD-4-Clause & BSD & ISC & MIT"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=d9d2753bdef9f19466dc7bc959114b11"
+
+DEPENDS = "zlib openssl virtual/crypt"
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
+
+FILESEXTRAPATHS_prepend := "${LAYERDIR_core}/recipes-connectivity/${PN}/${PN}:"
+
+SRC_URI = "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${PV}.tar.gz \
+           file://sshd_config \
+           file://ssh_config \
+           file://init \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '${PAM_SRC_URI}', '', d)} \
+           file://sshd.socket \
+           file://sshd@.service \
+           file://sshdgenkeys.service \
+           file://volatiles.99_sshd \
+           file://run-ptest \
+           file://fix-potential-signed-overflow-in-pointer-arithmatic.patch \
+           file://sshd_check_keys \
+           file://add-test-support-for-busybox.patch \
+           "
+SRC_URI[sha256sum] = "f52f3f41d429aa9918e38cf200af225ccdd8e66f052da572870c89737646ec25"
+
+# This CVE is specific to OpenSSH server, as used in Fedora and Red Hat Enterprise Linux 7
+# and when running in a Kerberos environment. As such it is not relevant to OpenEmbedded
+CVE_CHECK_WHITELIST += "CVE-2014-9278"
+
+PAM_SRC_URI = "file://sshd"
+
+inherit manpages useradd update-rc.d update-alternatives systemd
+
+USERADD_PACKAGES = "${PN}-sshd"
+USERADD_PARAM_${PN}-sshd = "--system --no-create-home --home-dir /var/run/sshd --shell /bin/false --user-group sshd"
+INITSCRIPT_PACKAGES = "${PN}-sshd"
+INITSCRIPT_NAME_${PN}-sshd = "sshd"
+INITSCRIPT_PARAMS_${PN}-sshd = "defaults 9"
+
+SYSTEMD_PACKAGES = "${PN}-sshd"
+SYSTEMD_SERVICE_${PN}-sshd = "sshd.socket"
+
+inherit autotools-brokensep ptest
+
+PACKAGECONFIG ??= "rng-tools"
+PACKAGECONFIG[kerberos] = "--with-kerberos5,--without-kerberos5,krb5"
+PACKAGECONFIG[ldns] = "--with-ldns,--without-ldns,ldns"
+PACKAGECONFIG[libedit] = "--with-libedit,--without-libedit,libedit"
+PACKAGECONFIG[manpages] = "--with-mantype=man,--with-mantype=cat"
+
+# Add RRECOMMENDS to rng-tools for sshd package
+PACKAGECONFIG[rng-tools] = ""
+
+EXTRA_AUTORECONF += "--exclude=aclocal"
+
+# login path is hardcoded in sshd
+EXTRA_OECONF = "'LOGIN_PROGRAM=${base_bindir}/login' \
+                ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '--with-pam', '--without-pam', d)} \
+                --without-zlib-version-check \
+                --with-privsep-path=${localstatedir}/run/sshd \
+                --sysconfdir=${sysconfdir}/ssh \
+                --with-xauth=${bindir}/xauth \
+                --disable-strip \
+                "
+
+# musl doesn't implement wtmp/utmp and logwtmp
+EXTRA_OECONF_append_libc-musl = " --disable-wtmp --disable-lastlog"
+
+# Since we do not depend on libbsd, we do not want configure to use it
+# just because it finds libutil.h.  But, specifying --disable-libutil
+# causes compile errors, so...
+CACHED_CONFIGUREVARS += "ac_cv_header_bsd_libutil_h=no ac_cv_header_libutil_h=no"
+
+# passwd path is hardcoded in sshd
+CACHED_CONFIGUREVARS += "ac_cv_path_PATH_PASSWD_PROG=${bindir}/passwd"
+
+# We don't want to depend on libblockfile
+CACHED_CONFIGUREVARS += "ac_cv_header_maillock_h=no"
+
+do_configure_prepend () {
+	export LD="${CC}"
+	install -m 0644 ${WORKDIR}/sshd_config ${B}/
+	install -m 0644 ${WORKDIR}/ssh_config ${B}/
+}
+
+do_compile_ptest() {
+        # skip regress/unittests/ binaries: this will silently skip
+        # unittests in run-ptests which is good because they are so slow.
+        oe_runmake regress/modpipe regress/setuid-allowed regress/netcat \
+                   regress/check-perm regress/mkdtemp
+}
+
+do_install_append () {
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'pam', d)}" ]; then
+		install -D -m 0644 ${WORKDIR}/sshd ${D}${sysconfdir}/pam.d/sshd
+		sed -i -e 's:#UsePAM no:UsePAM yes:' ${D}${sysconfdir}/ssh/sshd_config
+	fi
+
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}" ]; then
+		sed -i -e 's:#X11Forwarding no:X11Forwarding yes:' ${D}${sysconfdir}/ssh/sshd_config
+	fi
+
+	install -d ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/sshd
+	rm -f ${D}${bindir}/slogin ${D}${datadir}/Ssh.bin
+	rmdir ${D}${localstatedir}/run/sshd ${D}${localstatedir}/run ${D}${localstatedir}
+	install -d ${D}/${sysconfdir}/default/volatiles
+	install -m 644 ${WORKDIR}/volatiles.99_sshd ${D}/${sysconfdir}/default/volatiles/99_sshd
+	install -m 0755 ${S}/contrib/ssh-copy-id ${D}${bindir}
+
+	# Create config files for read-only rootfs
+	install -d ${D}${sysconfdir}/ssh
+	install -m 644 ${D}${sysconfdir}/ssh/sshd_config ${D}${sysconfdir}/ssh/sshd_config_readonly
+	sed -i '/HostKey/d' ${D}${sysconfdir}/ssh/sshd_config_readonly
+	echo "HostKey /var/run/ssh/ssh_host_rsa_key" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
+	echo "HostKey /var/run/ssh/ssh_host_ecdsa_key" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
+	echo "HostKey /var/run/ssh/ssh_host_ed25519_key" >> ${D}${sysconfdir}/ssh/sshd_config_readonly
+
+	install -d ${D}${systemd_unitdir}/system
+	install -c -m 0644 ${WORKDIR}/sshd.socket ${D}${systemd_unitdir}/system
+	install -c -m 0644 ${WORKDIR}/sshd@.service ${D}${systemd_unitdir}/system
+	install -c -m 0644 ${WORKDIR}/sshdgenkeys.service ${D}${systemd_unitdir}/system
+	sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+		-e 's,@SBINDIR@,${sbindir},g' \
+		-e 's,@BINDIR@,${bindir},g' \
+		-e 's,@LIBEXECDIR@,${libexecdir}/${BPN},g' \
+		${D}${systemd_unitdir}/system/sshd.socket ${D}${systemd_unitdir}/system/*.service
+
+	sed -i -e 's,@LIBEXECDIR@,${libexecdir}/${BPN},g' \
+		${D}${sysconfdir}/init.d/sshd
+
+	install -D -m 0755 ${WORKDIR}/sshd_check_keys ${D}${libexecdir}/${BPN}/sshd_check_keys
+}
+
+do_install_ptest () {
+	sed -i -e "s|^SFTPSERVER=.*|SFTPSERVER=${libexecdir}/sftp-server|" regress/test-exec.sh
+	cp -r regress ${D}${PTEST_PATH}
+}
+
+ALLOW_EMPTY_${PN} = "1"
+
+PACKAGES =+ "${PN}-keygen ${PN}-scp ${PN}-ssh ${PN}-sshd ${PN}-sftp ${PN}-misc ${PN}-sftp-server"
+FILES_${PN}-scp = "${bindir}/scp.${BPN}"
+FILES_${PN}-ssh = "${bindir}/ssh.${BPN} ${sysconfdir}/ssh/ssh_config"
+FILES_${PN}-sshd = "${sbindir}/sshd ${sysconfdir}/init.d/sshd ${systemd_unitdir}/system"
+FILES_${PN}-sshd += "${sysconfdir}/ssh/moduli ${sysconfdir}/ssh/sshd_config ${sysconfdir}/ssh/sshd_config_readonly ${sysconfdir}/default/volatiles/99_sshd ${sysconfdir}/pam.d/sshd"
+FILES_${PN}-sshd += "${libexecdir}/${BPN}/sshd_check_keys"
+FILES_${PN}-sftp = "${bindir}/sftp"
+FILES_${PN}-sftp-server = "${libexecdir}/sftp-server"
+FILES_${PN}-misc = "${bindir}/ssh* ${libexecdir}/ssh*"
+FILES_${PN}-keygen = "${bindir}/ssh-keygen"
+
+RDEPENDS_${PN} += "${PN}-scp ${PN}-ssh ${PN}-sshd ${PN}-keygen"
+RDEPENDS_${PN}-sshd += "${PN}-keygen ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam-plugin-keyinit pam-plugin-loginuid', '', d)}"
+RRECOMMENDS_${PN}-sshd_append_class-target = "\
+    ${@bb.utils.filter('PACKAGECONFIG', 'rng-tools', d)} \
+"
+
+# gdb would make attach-ptrace test pass rather than skip but not worth the build dependencies
+RDEPENDS_${PN}-ptest += "${PN}-sftp ${PN}-misc ${PN}-sftp-server make sed sudo coreutils"
+
+RPROVIDES_${PN}-ssh = "ssh"
+RPROVIDES_${PN}-sshd = "sshd"
+
+RCONFLICTS_${PN} = "dropbear"
+RCONFLICTS_${PN}-sshd = "dropbear"
+
+CONFFILES_${PN}-sshd = "${sysconfdir}/ssh/sshd_config"
+CONFFILES_${PN}-ssh = "${sysconfdir}/ssh/ssh_config"
+
+ALTERNATIVE_PRIORITY = "90"
+ALTERNATIVE_${PN}-scp = "scp"
+ALTERNATIVE_${PN}-ssh = "ssh"
+
+BBCLASSEXTEND += "nativesdk"

--- a/meta-mentor-staging/recipes-connectivity/openssh/openssh_8.5p1.bb
+++ b/meta-mentor-staging/recipes-connectivity/openssh/openssh_8.5p1.bb
@@ -13,7 +13,7 @@ DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
 
 FILESEXTRAPATHS_prepend := "${LAYERDIR_core}/recipes-connectivity/${PN}/${PN}:"
 
-SRC_URI = "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${PV}.tar.gz \
+SRC_URI = "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.5p1.tar.gz \
            file://sshd_config \
            file://ssh_config \
            file://init \


### PR DESCRIPTION
This CVE has an impact before version 8.5 so updating
to 8.5p1 version fixes this issue.

Signed-off-by: Karim, Hafiz Abdul <HafizAbdul_Karim@mentor.com>