### PR TITLE
postgresql: Add 12.5 version to fix CVEs

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/0001-Add-support-for-RISC-V.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/0001-Add-support-for-RISC-V.patch
@@ -1,0 +1,41 @@
+From b06a228a5fd1589fc9bed654b3288b321fc21aa1 Mon Sep 17 00:00:00 2001
+From: "Richard W.M. Jones" <rjones@redhat.com>
+Date: Sun, 20 Nov 2016 15:04:52 +0000
+Subject: [PATCH] Add support for RISC-V.
+
+The architecture is sufficiently similar to aarch64 that simply
+extending the existing aarch64 macro works.
+---
+ src/include/storage/s_lock.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/include/storage/s_lock.h b/src/include/storage/s_lock.h
+index 3fe29ce..7cd578f 100644
+--- a/src/include/storage/s_lock.h
++++ b/src/include/storage/s_lock.h
+@@ -316,11 +316,12 @@ tas(volatile slock_t *lock)
+ 
+ /*
+  * On ARM and ARM64, we use __sync_lock_test_and_set(int *, int) if available.
++ * On RISC-V, the same.
+  *
+  * We use the int-width variant of the builtin because it works on more chips
+  * than other widths.
+  */
+-#if defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(__aarch64)
++#if defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(__aarch64) || defined(__riscv)
+ #ifdef HAVE_GCC__SYNC_INT32_TAS
+ #define HAS_TEST_AND_SET
+ 
+@@ -337,7 +338,7 @@ tas(volatile slock_t *lock)
+ #define S_UNLOCK(lock) __sync_lock_release(lock)
+ 
+ #endif	 /* HAVE_GCC__SYNC_INT32_TAS */
+-#endif	 /* __arm__ || __arm || __aarch64__ || __aarch64 */
++#endif	 /* __arm__ || __arm || __aarch64__ || __aarch64 || __riscv */
+ 
+ 
+ /* S/390 and S/390x Linux (32- and 64-bit zSeries) */
+-- 
+2.9.3
+

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/0001-Improve-reproducibility.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/0001-Improve-reproducibility.patch
@@ -1,0 +1,39 @@
+From 3c13315447fa175da6c9ebe59a039e611cdb5bd1 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 4 Jun 2019 13:45:30 +0800
+Subject: [PATCH] Improve reproducibility,
+
+Remove build patch from binaries which pg_config do
+not record var-CC, var-CFLAGS, and configure
+
+$ /usr/bin/pg_config --cc
+not recorded
+
+$ /usr/bin/pg_config --configure
+not recorded
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ src/common/Makefile | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/common/Makefile b/src/common/Makefile
+index 1fc2c66..5e6c457 100644
+--- a/src/common/Makefile
++++ b/src/common/Makefile
+@@ -27,10 +27,6 @@ include $(top_builddir)/src/Makefile.global
+ # don't include subdirectory-path-dependent -I and -L switches
+ STD_CPPFLAGS := $(filter-out -I$(top_srcdir)/src/include -I$(top_builddir)/src/include,$(CPPFLAGS))
+ STD_LDFLAGS := $(filter-out -L$(top_builddir)/src/common -L$(top_builddir)/src/port,$(LDFLAGS))
+-override CPPFLAGS += -DVAL_CONFIGURE="\"$(configure_args)\""
+-override CPPFLAGS += -DVAL_CC="\"$(CC)\""
+-override CPPFLAGS += -DVAL_CPPFLAGS="\"$(STD_CPPFLAGS)\""
+-override CPPFLAGS += -DVAL_CFLAGS="\"$(CFLAGS)\""
+ override CPPFLAGS += -DVAL_CFLAGS_SL="\"$(CFLAGS_SL)\""
+ override CPPFLAGS += -DVAL_LDFLAGS="\"$(STD_LDFLAGS)\""
+ override CPPFLAGS += -DVAL_LDFLAGS_EX="\"$(LDFLAGS_EX)\""
+-- 
+2.7.4
+

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/not-check-libperl.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/not-check-libperl.patch
@@ -1,0 +1,37 @@
+From 7e2af4de19be58bc9d551c41ce2750396d357f34 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 27 Nov 2018 13:25:15 +0800
+Subject: [PATCH] PATCH] not check libperl under cross compiling
+
+Upstream-Status: Inappropriate [configuration]
+
+libperl ldflags returned by PGAC_CHECK_PERL_EMBED_LDFLAGS are native,
+can not be used to check target library.
+
+postpresql has the dependency on perl, so not need to check libperl
+again, like in postgresql-9.2.4
+
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+
+update patch to version 11.1
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ configure.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.in b/configure.in
+index b98b9bb..8584677 100644
+--- a/configure.in
++++ b/configure.in
+@@ -2211,7 +2211,7 @@ Use --without-tcl to disable building PL/Tcl.])
+ fi
+ 
+ # check for <perl.h>
+-if test "$with_perl" = yes; then
++if test "$with_perl" = yes && test "$cross_compiling" = no; then
+   ac_save_CPPFLAGS=$CPPFLAGS
+   CPPFLAGS="$CPPFLAGS $perl_includespec"
+   AC_CHECK_HEADER(perl.h, [], [AC_MSG_ERROR([header file <perl.h> is required for Perl])],
+-- 
+2.7.4
+

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql-profile
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql-profile
@@ -1,0 +1,4 @@
+[ -f /etc/profile ] && source /etc/profile
+
+PGDATA=/var/lib/postgresql/data
+export PGDATA

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql-setup
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql-setup
@@ -1,0 +1,73 @@
+#!/bin/sh
+#
+# postgresql-setup      Initialization operation for PostgreSQL
+
+# For SELinux we need to use 'runuser' not 'su'
+if [ -x /sbin/runuser ]
+then
+    SU=runuser
+else
+    SU=su
+fi
+
+PGENGINE=/usr/bin
+PGDATA=/var/lib/postgresql/data
+PGLOG=/var/lib/postgresql/pgstartup.log
+script_result=0
+
+initdb(){
+    if [ -f "$PGDATA/PG_VERSION" ]
+    then
+	echo -n "Data directory is not empty!"
+	echo -n " [FAILED] "
+	echo
+	script_result=1
+    else
+	echo -n "Initializing database: "
+	if [ ! -e "$PGDATA" -a ! -h "$PGDATA" ]
+	then
+		mkdir -p "$PGDATA" || exit 1
+		chown postgres:postgres "$PGDATA"
+		chmod go-rwx "$PGDATA"
+	fi
+	# Clean up SELinux tagging for PGDATA
+	[ -x /sbin/restorecon ] && /sbin/restorecon "$PGDATA"
+
+	# Make sure the startup-time log file is OK, too
+	if [ ! -e "$PGLOG" -a ! -h "$PGLOG" ]
+	then
+		touch "$PGLOG" || exit 1
+		chown postgres:postgres "$PGLOG"
+		chmod go-rwx "$PGLOG"
+		[ -x /sbin/restorecon ] && /sbin/restorecon "$PGLOG"
+	fi
+
+	# Initialize the database
+	$SU -l postgres -c "$PGENGINE/initdb --pgdata='$PGDATA' --auth='ident'" >> "$PGLOG" 2>&1 < /dev/null
+
+	# Create directory for postmaster log
+	mkdir "$PGDATA/pg_log"
+	chown postgres:postgres "$PGDATA/pg_log"
+	chmod go-rwx "$PGDATA/pg_log"
+
+	if [ -f "$PGDATA/PG_VERSION" ]
+	then
+	    echo -n " [ OK ] "
+	else
+	    echo -n " [FAILED] "
+	    script_result=1
+	fi
+	echo
+    fi
+}
+
+case "$1" in
+  initdb)
+	initdb
+	;;
+  *)
+	echo "Usage: $0 initdb"
+	exit 2
+esac
+
+exit $script_result

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.init
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.init
@@ -1,0 +1,193 @@
+#!/bin/sh
+#
+# postgresql	This is the init script for starting up the PostgreSQL
+#		server.
+#
+# chkconfig: - 64 36
+# description: PostgreSQL database server.
+# processname: postmaster
+# pidfile: /var/run/postmaster.PORT.pid
+
+# This script is slightly unusual in that the name of the daemon (postmaster)
+# is not the same as the name of the subsystem (postgresql)
+
+# PGVERSION is the full package version, e.g., 8.4.0
+# Note: the specfile inserts the correct value during package build
+PGVERSION=9.2.4
+# PGMAJORVERSION is major version, e.g., 10 (this should match PG_VERSION)
+PGMAJORVERSION=`echo "$PGVERSION" | sed 's/^\([0-9]*\).*$/\1/'`
+
+# Source function library.
+. /etc/init.d/functions
+
+# Find the name of the script
+NAME=`basename $0`
+if [ ${NAME:0:1} = "S" -o ${NAME:0:1} = "K" ]
+then
+	NAME=${NAME:3}
+fi
+
+# For SELinux we need to use 'runuser' not 'su'
+if [ -x /sbin/runuser ]
+then
+    SU=runuser
+else
+    SU=su
+fi
+
+
+# Set defaults for configuration variables
+PGENGINE=/usr/bin
+PGPORT=5432
+PGDATA=/var/lib/postgresql/data
+PGLOG=/var/lib/postgresql/pgstartup.log
+# Value to set as postmaster process's oom_adj
+PG_OOM_ADJ=-17
+
+# Override defaults from /etc/sysconfig/postgresql if file is present
+[ -f /etc/default/postgresql/${NAME} ] && . /etc/default/postgresql/${NAME}
+
+export PGDATA
+export PGPORT
+
+lockfile="/var/lock/subsys/${NAME}"
+pidfile="/var/run/postmaster.${PGPORT}.pid"
+
+script_result=0
+
+start(){
+	[ -x "$PGENGINE/postmaster" ] || exit 5
+
+	PSQL_START=$"Starting ${NAME} service: "
+
+	# Make sure startup-time log file is valid
+	if [ ! -e "$PGLOG" -a ! -h "$PGLOG" ]
+	then
+		touch "$PGLOG" || exit 4
+		chown postgres:postgres "$PGLOG"
+		chmod go-rwx "$PGLOG"
+		[ -x /sbin/restorecon ] && /sbin/restorecon "$PGLOG"
+	fi
+
+	# Check for the PGDATA structure
+	if [ -f "$PGDATA/PG_VERSION" ] && [ -d "$PGDATA/base" ]
+	then
+		# Check version of existing PGDATA
+		if [ x`cat "$PGDATA/PG_VERSION"` != x"$PGMAJORVERSION" ]
+		then
+			SYSDOCDIR="(Your System's documentation directory)"
+			if [ -d "/usr/doc/postgresql-$PGVERSION" ]
+			then
+				SYSDOCDIR=/usr/doc
+			fi
+			if [ -d "/usr/share/doc/postgresql-$PGVERSION" ]
+			then
+				SYSDOCDIR=/usr/share/doc
+			fi
+			if [ -d "/usr/doc/packages/postgresql-$PGVERSION" ]
+			then
+				SYSDOCDIR=/usr/doc/packages
+			fi
+			if [ -d "/usr/share/doc/packages/postgresql-$PGVERSION" ]
+			then
+				SYSDOCDIR=/usr/share/doc/packages
+			fi
+			echo
+			echo $"An old version of the database format was found."
+			echo $"You need to upgrade the data format before using PostgreSQL."
+			echo $"See $SYSDOCDIR/postgresql-$PGVERSION/README.rpm-dist for more information."
+			exit 1
+		fi
+	else
+		# No existing PGDATA! Warn the user to initdb it.
+		echo
+                echo "$PGDATA is missing. Use \"postgresql-setup initdb\" to initialize the cluster first."
+		echo -n " [FAILED] "
+		echo
+		exit 1
+	fi
+
+	echo -n "$PSQL_START"
+	test x"$PG_OOM_ADJ" != x && echo "$PG_OOM_ADJ" > /proc/self/oom_score_adj
+	$SU -l postgres -c "$PGENGINE/postmaster -p '$PGPORT' -D '$PGDATA' ${PGOPTS} &" >> "$PGLOG" 2>&1 < /dev/null
+	sleep 2
+	pid=`head -n 1 "$PGDATA/postmaster.pid" 2>/dev/null`
+	if [ "x$pid" != x ]
+	then
+		echo -n " [ OK ]"
+		touch "$lockfile"
+		echo $pid > "$pidfile"
+		echo
+	else
+		echo -n  " [FAILED]"
+		echo
+		script_result=1
+	fi
+}
+
+stop(){
+	echo -n $"Stopping ${NAME} service: "
+	if [ -e "$lockfile" ]
+	then
+	    $SU -l postgres -c "$PGENGINE/pg_ctl stop -D '$PGDATA' -s -m fast" > /dev/null 2>&1 < /dev/null
+	    ret=$?
+	    if [ $ret -eq 0 ]
+	    then
+		echo -n " [ OK ] "
+		rm -f "$pidfile"
+		rm -f "$lockfile"
+	    else
+		echo -n " [FAILED] "
+		script_result=1
+	    fi
+	else
+	    # not running; per LSB standards this is "ok"
+	    echo -n " [ OK ] "
+	fi
+	echo
+}
+
+restart(){
+    stop
+    start
+}
+
+condrestart(){
+    [ -e "$lockfile" ] && restart || :
+}
+
+reload(){
+    $SU -l postgres -c "$PGENGINE/pg_ctl reload -D '$PGDATA' -s" > /dev/null 2>&1 < /dev/null
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+	status postmaster
+	script_result=$?
+	;;
+  restart)
+	restart
+	;;
+  condrestart|try-restart)
+	condrestart
+	;;
+  reload)
+	reload
+	;;
+  force-reload)
+	restart
+	;;
+  *)
+	echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+	exit 2
+esac
+
+exit $script_result

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.pam
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.pam
@@ -1,0 +1,4 @@
+#%PAM-1.0
+auth            include         common-auth
+account         include         common-account
+password        include         common-password

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.service
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/files/postgresql.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=PostgreSQL database server
+After=network.target
+
+[Service]
+Type=forking
+User=postgres
+Group=postgres
+
+# Port number for server to listen on
+Environment=PGPORT=5432
+
+# Location of database directory
+Environment=PGDATA=/var/lib/postgresql/data
+
+# Disable OOM kill on the postmaster
+OOMScoreAdjust=-17
+
+ExecStart=@BINDIR@/pg_ctl start -D ${PGDATA} -s -o "-p ${PGPORT}" -w -t 300
+ExecStop=@BINDIR@/pg_ctl stop -D ${PGDATA} -s -m fast
+ExecReload=@BINDIR@/pg_ctl reload -D ${PGDATA} -s
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/postgresql.inc
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/postgresql.inc
@@ -1,0 +1,361 @@
+SUMMARY = "PostgreSQL is a powerful, open source relational database system."
+DESCRIPTION = "\
+    PostgreSQL is an advanced Object-Relational database management system \
+    (DBMS) that supports almost all SQL constructs (including \
+    transactions, subselects and user-defined types and functions). The \
+    postgresql package includes the client programs and libraries that \
+    you'll need to access a PostgreSQL DBMS server.  These PostgreSQL \
+    client programs are programs that directly manipulate the internal \
+    structure of PostgreSQL databases on a PostgreSQL server. These client \
+    programs can be located on the same machine with the PostgreSQL \
+    server, or may be on a remote machine which accesses a PostgreSQL \
+    server over a network connection. This package contains the docs \
+    in HTML for the whole package, as well as command-line utilities for \
+    managing PostgreSQL databases on a PostgreSQL server. \
+    \
+    If you want to manipulate a PostgreSQL database on a local or remote \
+    PostgreSQL server, you need this package. You also need to install \
+    this package if you're installing the postgresql-server package. \
+"
+HOMEPAGE = "http://www.postgresql.com"
+LICENSE = "BSD-0-Clause"
+DEPENDS = "libnsl2 zlib readline tzcode-native"
+
+ARM_INSTRUCTION_SET = "arm"
+
+SRC_URI = "http://ftp.postgresql.org/pub/source/v${PV}/${BP}.tar.bz2 \
+    file://postgresql.init \
+    file://postgresql-profile \
+    file://postgresql.pam \
+    file://postgresql-setup \
+    file://postgresql.service \
+"
+
+LEAD_SONAME = "libpq.so"
+
+# LDFLAGS for shared libraries
+export LDFLAGS_SL = "${LDFLAGS}"
+
+inherit autotools pkgconfig perlnative python3native useradd update-rc.d systemd gettext cpan-base
+
+CFLAGS += "-I${STAGING_INCDIR}/${PYTHON_DIR} -I${STAGING_INCDIR}/tcl8.6"
+
+SYSTEMD_SERVICE_${PN} = "postgresql.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"
+
+DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd-systemctl-native', '', d)}"
+pkg_postinst_${PN} () {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd sysvinit', 'true', 'false', d)}; then
+        if [ -n "$D" ]; then
+            OPTS="--root=$D"
+        fi
+        systemctl $OPTS mask postgresql-server.service
+    fi
+}
+
+enable_pam = "${@bb.utils.filter('DISTRO_FEATURES', 'pam', d)}"
+PACKAGECONFIG ??= "${enable_pam} openssl python uuid libxml tcl nls libxml perl"
+PACKAGECONFIG[pam] = "--with-pam,--without-pam,libpam,"
+PACKAGECONFIG[openssl] = "--with-openssl,--without-openssl,openssl,"
+PACKAGECONFIG[python] = "--with-python,--without-python,python3,python3"
+PACKAGECONFIG[uuid] = "--with-uuid=e2fs,--without-uuid,util-linux,"
+PACKAGECONFIG[tcl] = "--with-tcl --with-tclconfig=${STAGING_BINDIR_CROSS},--without-tcl,tcl tcl-native,"
+PACKAGECONFIG[nls] = "--enable-nls,--disable-nls,,"
+PACKAGECONFIG[libxml] = "--with-libxml,--without-libxml,libxml2,libxml2"
+PACKAGECONFIG[perl] = "--with-perl,--without-perl,perl,perl"
+
+EXTRA_OECONF += "--enable-thread-safety --disable-rpath \
+    --datadir=${datadir}/${BPN} \
+    --sysconfdir=${sysconfdir}/${BPN} \
+"
+EXTRA_OECONF_sh4 += "--disable-spinlocks"
+EXTRA_OECONF_aarch64 += "--disable-spinlocks"
+
+DEBUG_OPTIMIZATION_remove_mips = " -Og"
+DEBUG_OPTIMIZATION_append_mips = " -O"
+BUILD_OPTIMIZATION_remove_mips = " -Og"
+BUILD_OPTIMIZATION_append_mips = " -O"
+
+DEBUG_OPTIMIZATION_remove_mipsel = " -Og"
+DEBUG_OPTIMIZATION_append_mipsel = " -O"
+BUILD_OPTIMIZATION_remove_mipsel = " -Og"
+BUILD_OPTIMIZATION_append_mipsel = " -O"
+
+PACKAGES_DYNAMIC += "^${PN}-plperl \
+    ^${PN}-pltcl \
+    ^${PN}-plpython \
+"
+
+python populate_packages_prepend() {
+
+    def fill_more(name):
+        if name is None or name.strip() == "":
+            return
+
+        fpack=d.getVar('PACKAGES', False) or ""
+        fpack="${PN}-" + name + " " + fpack
+        d.setVar('PACKAGES', fpack)
+
+    conf=(d.getVar('PACKAGECONFIG') or "").split()
+    pack=d.getVar('PACKAGES', False) or ""
+    bb.debug(1, "PACKAGECONFIG=%s" % conf)
+    bb.debug(1, "PACKAGES1=%s" % pack )
+
+    if "perl" in conf :
+        fill_more("plperl")
+
+    if "tcl" in conf:
+        fill_more("pltcl")
+
+    if "python" in conf:
+        fill_more("plpython")
+
+    pack=d.getVar('PACKAGES') or ""
+    bb.debug(1, "PACKAGES2=%s" % pack)
+
+}
+
+# This will make native perl use target settings (for include dirs etc.)
+export PERLCONFIGTARGET = "${@is_target(d)}"
+export PERL_ARCHLIB = "${STAGING_LIBDIR}${PERL_OWN_DIR}/perl5/${@get_perl_version(d)}/${@get_perl_arch(d)}"
+
+do_configure() {
+    # do_configure
+    autotools_do_configure
+
+    # do_configure_append
+    # workaround perl package related bugs
+    sed -i -e "s:-L/usr/local/lib:-L=/usr/local/lib:g" \
+        ${B}/src/Makefile.global
+    LIBPNA="\${STAGING_LIBDIR_NATIVE}/perl-native"
+    LIBNA="\${STAGING_LIBDIR_NATIVE}"
+    BLIBNA="\${STAGING_BASE_LIBDIR_NATIVE}"
+    sed -i -e "/^perl_archlibexp/s:${LIBPNA}:${STAGING_LIBDIR}:g" \
+        ${B}/src/Makefile.global
+    sed -i -e "/^perl_privlibexp/s:${libdir}:${STAGING_LIBDIR}:g" \
+        ${B}/src/Makefile.global
+    # remove the rpath, replace with correct lib path
+    sed -i \
+        -e "/^perl_embed_ldflags/s:-Wl,-rpath,${LIBNA}::g" \
+        -e "/^perl_embed_ldflags/s:-Wl,-rpath,${BLIBNA}::g" \
+        -e "/^perl_embed_ldflags/s:-Wl,-rpath-link,${LIBNA}::g" \
+        -e "/^perl_embed_ldflags/s:-Wl,-rpath-link,${BLIBNA}::g" \
+        -e "/^perl_embed_ldflags/s:${LIBPNA}:${STAGING_LIBDIR}:g" \
+        -e "/^perl_embed_ldflags/s:${LIBNA}:${STAGING_LIBDIR}:g"  \
+        -e "/^perl_embed_ldflags/s:${BLIBNA}:${STAGING_BASELIBDIR}:g" \
+        -e "/^TCLSH/s:=.*:= ${bindir}/tclsh:g" \
+    ${B}/src/Makefile.global
+
+    if ${@bb.utils.contains('PACKAGECONFIG', 'perl', 'true', 'false', d)}; then
+        # workaround perl package's libperl.so problem
+        # we are using perlnative so this perl should have same version
+        perl_version=`perl -v 2>/dev/null | \
+            sed -n 's/This is perl.*v[a-z ]*\([0-9]\.[0-9][0-9.]*\).*$/\1/p'`
+        if [ ! -h "${STAGING_LIBDIR}/perl/$perl_version/CORE/libperl.so" -a \
+             ! -h "${STAGING_LIBDIR}/libperl.so" ]; then
+            ln -sf ../../../libperl.so.5 \
+                ${STAGING_LIBDIR}/perl/$perl_version/CORE/libperl.so
+        fi
+    fi
+}
+
+do_compile_append() {
+    oe_runmake -C contrib all
+}
+
+# server needs to configure user and group
+usernum = "28"
+groupnum = "28"
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM_${PN} = "-M -g postgres -o -r -d ${localstatedir}/lib/${BPN} \
+    -s /bin/sh -c 'PostgreSQL Server' -u ${usernum} postgres"
+GROUPADD_PARAM_${PN} = "-g ${groupnum} -o -r postgres"
+
+INITSCRIPT_PACKAGES = "${PN}"
+INITSCRIPT_NAME = "${BPN}-server"
+INITSCRIPT_PARAMS = "start 64 . stop 36 0 1 2 3 4 5 6 ."
+
+do_install_append() {
+    # install contrib
+    oe_runmake DESTDIR=${D} -C contrib install
+    # install tutorial
+    install -d -m 0755 ${D}${libdir}/${BPN}/tutorial
+    install ${B}/src/tutorial/* ${D}${libdir}/${BPN}/tutorial
+
+    # install COPYRIGHT README HISTORY
+    install -d -m 0755 ${D}${docdir}/${BPN}
+    for i in ${B}/COPYRIGHT ${B}/README ${B}/HISTORY ${B}/doc/KNOWN_BUGS ${B}/doc/MISSING_FEATURES ${B}/doc/README* ${B}/doc/bug.template; do
+        [ -f $i ] && install $i ${D}${docdir}/${BPN}
+    done
+
+    # install dirs and server init
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/${BPN}.init ${D}${sysconfdir}/init.d/${BPN}-server
+    sed -i -e "s/^PGVERSION=.*$/PGVERSION=${PV}/g" ${D}${sysconfdir}/init.d/${BPN}-server
+    install -m 0755 ${WORKDIR}/${BPN}-setup ${D}${bindir}/${BPN}-setup
+    install -d -m 700 ${D}${localstatedir}/lib/${BPN}/data
+    install -d -m 700 ${D}${localstatedir}/lib/${BPN}/backups
+    install -m 644 ${WORKDIR}/${BPN}-profile ${D}${localstatedir}/lib/${BPN}/.profile
+    chown -R postgres:postgres ${D}${localstatedir}/lib/${BPN}
+    # multiple server config directory
+    install -d -m 700 ${D}${sysconfdir}/default/${BPN}
+
+    if [ "${@d.getVar('enable_pam')}" = "pam" ]; then
+        install -d ${D}${sysconfdir}/pam.d
+        install -m 644 ${WORKDIR}/postgresql.pam ${D}${sysconfdir}/pam.d/postgresql
+    fi
+
+    # Install systemd unit files
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/postgresql.service ${D}${systemd_unitdir}/system
+    sed -i -e 's,@BINDIR@,${bindir},g' \
+        ${D}${systemd_unitdir}/system/postgresql.service
+}
+
+SSTATE_SCAN_FILES += "Makefile.global"
+SSTATE_SCAN_FILES_remove = "*_config"
+
+PACKAGES =+ "${PN}-client ${PN}-server-dev ${PN}-timezone \
+    libecpg-compat libecpg-compat-dev \
+    libecpg libecpg-dev libecpg-staticdev libecpg-doc \
+    libpq libpq-dev libpq-staticdev \
+    libpgtypes libpgtypes-staticdev libpgtypes-dev \
+    ${PN}-contrib \
+"
+
+RPROVIDES_${PN}-dbg += "libecpg-compat-dbg \
+                        libecpg-dbg \
+                        libpq-dbg \
+                        libpgtypes-dbg \
+                        ${PN}-contrib-dbg \
+                        ${PN}-pltcl-dbg \
+                        ${PN}-plpython-dbg \
+                        ${PN}-plperl-dbg \
+                       "
+
+FILES_${PN} += "${sysconfdir}/init.d/${BPN}-server \
+    ${localstatedir}/lib/${BPN}/data ${localstatedir}/lib/${BPN}/backups \
+    ${localstatedir}/lib/${BPN}/.profile ${sysconfdir}/default/${BPN} \
+    ${libdir}/${BPN}/dict_snowball.so ${libdir}/${BPN}/plpgsql.so \
+    ${libdir}/${BPN}/euc2004_sjis2004.so \
+    ${libdir}/${BPN}/libpqwalreceiver.so \
+    ${libdir}/${BPN}/*_and_*.so \
+    ${@'${sysconfdir}/pam.d/postgresql' \
+       if 'pam' == d.getVar('enable_pam') \
+       else ''} \
+"
+
+FILES_${PN}-client = "${bindir}/clusterdb \
+    ${bindir}/createdb \
+    ${bindir}/createuser \
+    ${bindir}/dropdb \
+    ${bindir}/dropuser \
+    ${bindir}/pg_dump \
+    ${bindir}/pg_dumpall \
+    ${bindir}/pg_restore \
+    ${bindir}/psql \
+    ${bindir}/reindexdb \
+    ${bindir}/vacuumdb \
+    ${bindir}/vacuumlo \
+    ${datadir}/${BPN}/psqlrc.sample \
+"
+FILES_${PN}-client-doc = "${mandir}/man1/clusterdb.* \
+    ${mandir}/man1/createdb.*   ${mandir}/man1/createlang.* \
+    ${mandir}/man1/createuser.* ${mandir}/man1/dropdb.* \
+    ${mandir}/man1/droplang.*   ${mandir}/man1/dropuser.* \
+    ${mandir}/man1/pg_dump.*    ${mandir}/man1/pg_dumpall.* \
+    ${mandir}/man1/pg_restore.* ${mandir}/man1/psql.* \
+    ${mandir}/man1/reindexdb.*  ${mandir}/man1/vacuumdb.* \
+    ${mandir}/man7/* \
+"
+FILES_${PN}-doc += "${docdir}/${BPN}/html ${libdir}/${BPN}/tutorial/ \
+    ${mandir}/man1/initdb.* ${mandir}/man1/pg_controldata.* \
+    ${mandir}/man1/pg_ctl.* ${mandir}/man1/pg_resetxlog.* \
+    ${mandir}/man1/postgres.* ${mandir}/man1/postmaster.* \
+"
+FILES_${PN}-timezone = "${datadir}/${BPN}/timezone \
+    ${datadir}/${BPN}/timezonesets \
+"
+RDEPENDS_${PN} += "${PN}-timezone"
+FILES_${PN}-server-dev = "${includedir}/${BPN}/server \
+                          ${libdir}/${BPN}/pgxs \
+"
+
+FILES_libecpg = "${libdir}/libecpg*${SOLIBS}"
+FILES_libecpg-dev = "${libdir}/libecpg*${SOLIBSDEV} \
+    ${libdir}/libpgtypes*${SOLIBSDEV} \
+    ${includedir}/ecpg*.h ${includedir}/${BPN}/ecpg*.h \
+    ${includedir}/pgtypes*.h ${includedir}/${BPN}/informix \
+    ${includedir}/sql3types.h ${includedir}/sqlca.h \
+"
+FILES_libecpg-doc = "${mandir}/man1/ecpg.*"
+FILES_libecpg-staticdev = "${libdir}/libecpg*.a"
+SECTION_libecpg-staticdev = "devel"
+RDEPENDS_libecpg-staticdev = "libecpg-dev (= ${EXTENDPKGV})"
+
+FILES_libpq = "${libdir}/libpq*${SOLIBS}"
+FILES_libpq-dev = "${libdir}/libpq*${SOLIBSDEV} \
+    ${includedir} \
+"
+FILES_libpq-staticdev = "${libdir}/libpq*.a ${libdir}/libpgport.a"
+SECTION_libpq-staticdev = "devel"
+RDEPENDS_libpq-staticdev = "libpq-dev (= ${EXTENDPKGV})"
+
+FILES_libecpg-compat = "${libdir}/libecpg_compat*${SOLIBS}"
+FILES_libecpg-compat-dev = "${libdir}/libecpg_compat*${SOLIBS}"
+FILES_libpgtypes = "${libdir}/libpgtypes*${SOLIBS}"
+FILES_libpgtypes-staticdev = "${libdir}/libpgtypes*.a"
+FILES_libpgtypes-dev = "${libdir}/libpgtypes*${SOLIBS} ${includedir}/pgtypes*.h"
+
+FILES_${PN}-contrib = " ${bindir}/oid2name ${bindir}/pg_standby \
+    ${bindir}/pgbench ${bindir}/vacuumlo \
+    ${S}/contrib/spi/*.example \
+    ${libdir}/${BPN}/_int.so ${libdir}/${BPN}/adminpack.so \
+    ${libdir}/${BPN}/autoinc.so ${libdir}/${BPN}/auto_explain.so \
+    ${libdir}/${BPN}/auth_delay.so ${libdir}/${BPN}/btree_gin.so \
+    ${libdir}/${BPN}/btree_gist.so ${libdir}/${BPN}/.so \
+    ${libdir}/${BPN}/chkpass.so ${libdir}/${BPN}/citext.so \
+    ${libdir}/${BPN}/cube.so ${libdir}/${BPN}/dblink.so \
+    ${libdir}/${BPN}/dict_int.so ${libdir}/${BPN}/dict_xsyn.so \
+    ${libdir}/${BPN}/dummy_seclabel.so ${libdir}/${BPN}/earthdistance.so \
+    ${libdir}/${BPN}/file_fdw.so ${libdir}/${BPN}/fuzzystrmatch.so \
+    ${libdir}/${BPN}/hstore.so ${libdir}/${BPN}/insert_username.so \
+    ${libdir}/${BPN}/isn.so ${libdir}/${BPN}/lo.so \
+    ${libdir}/${BPN}/ltree.so ${libdir}/${BPN}/moddatetime.so \
+    ${libdir}/${BPN}/pageinspect.so ${libdir}/${BPN}/pg_buffercache.so \
+    ${libdir}/${BPN}/pg_freespacemap.so ${libdir}/${BPN}/pg_trgm.so \
+    ${libdir}/${BPN}/pgcrypto.so ${libdir}/${BPN}/pgrowlocks.so \
+    ${libdir}/${BPN}/pgstattuple.so ${libdir}/${BPN}/pg_stat_statements.so \
+    ${libdir}/${BPN}/refint.so ${libdir}/${BPN}/seg.so \
+    ${libdir}/${BPN}/sslinfo.so \
+    ${libdir}/${BPN}/tablefunc.so \
+    ${libdir}/${BPN}/test_parser.so ${libdir}/${BPN}/timetravel.so \
+    ${libdir}/${BPN}/uuid-ossp.so \
+    ${libdir}/${BPN}/pgxml.so ${libdir}/${BPN}/passwordcheck.so \
+    ${libdir}/${BPN}/pg_upgrade_support.so ${libdir}/${BPN}/.so \
+    ${libdir}/${BPN}/unaccent.so \
+"
+DESCRIPTION_${PN}-contrib = "The postgresql-contrib package contains \
+    contributed packages that are included in the PostgreSQL distribution."
+
+FILES_${PN}-pltcl = "${libdir}/${BPN}/pltcl.so ${bindir}/pltcl_delmod \
+    ${binddir}/pltcl_listmod ${bindir}/pltcl_loadmod  \
+    ${datadir}/${BPN}/unknown.pltcl"
+SUMMARY_${PN}-pltcl = "The Tcl procedural language for PostgreSQL"
+DESCRIPTION_${PN}-pltcl = "PostgreSQL is an advanced Object-Relational \
+    database management system.  The postgresql-pltcl package contains the PL/Tcl \
+    procedural language for the backend."
+
+FILES_${PN}-plperl = "${libdir}/${BPN}/plperl.so"
+SUMMARY_${PN}-plperl = "The Perl procedural language for PostgreSQL"
+DESCRIPTION_${PN}-plperl = "PostgreSQL is an advanced Object-Relational \
+    database management system.  The postgresql-plperl package contains the \
+    PL/Perl procedural language for the backend."
+
+# In version 8, it will be plpython.so
+# In version 9, it might be plpython{2,3}.so depending on python2 or 3
+FILES_${PN}-plpython = "${libdir}/${BPN}/plpython*.so"
+SUMMARY_${PN}-plpython = "The Python procedural language for PostgreSQL"
+DESCRIPTION_${PN}-plpython = "PostgreSQL is an advanced Object-Relational \
+    database management system.  The postgresql-plpython package contains \
+    the PL/Python procedural language for the backend."

--- a/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/postgresql_12.5.bb
+++ b/meta-mentor-staging/openembedded-layer/recipes-dbs/postgresql/postgresql_12.5.bb
@@ -1,0 +1,11 @@
+require postgresql.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=fc4ce21960f0c561460d750bc270d11f"
+
+SRC_URI += "\
+   file://not-check-libperl.patch \
+   file://0001-Add-support-for-RISC-V.patch \
+   file://0001-Improve-reproducibility.patch \
+"
+
+SRC_URI[sha256sum] = "bd0d25341d9578b5473c9506300022de26370879581f5fddd243a886ce79ff95"


### PR DESCRIPTION
* Get the recipe from meta-oe dunfell branch.
* Updated version to 12.5 to get fix for CVE-2020-25694, CVE-2020-25695, CVE-2020-25696

Signed-off-by: Noor Ahsan <noor_ahsan@mentorg.com>