### PR TITLE
[HOLD] mel_utils.py: add source and homepage info for dump-licenses

### DIFF
--- a/meta-mel/lib/bblayers/mel_utils.py
+++ b/meta-mel/lib/bblayers/mel_utils.py
@@ -226,7 +226,13 @@ class MELUtilsPlugin(LayerPlugin):
                 pn = data.getVar('PN')
                 pv = data.getVar('PV')
                 lc = data.getVar('LICENSE')
-                f.write('%s,%s,%s\n' % (pn, pv, lc))
+                # For SRC_URI we need to drop the local sources i.e. file:// entries
+                # then for further filtering we pick up only the initial part of the archive/git src i.e. dropping out
+                # bitbake specifics like protocol, branch, name etc.
+                su = " ".join([x.split(';')[0] for x in data.getVar('SRC_URI').split() if not x.startswith('file://')])
+                hp = data.getVar('HOMEPAGE')
+
+                f.write('%s,%s,%s,%s,%s\n' % (pn, pv, lc, su, hp))
 
     def register_commands(self, sp):
         common = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
The dump-licenses command additionally processes SRC_URI and
HOMEPAGE for each of the packages. This is a requirement for
the Siemens SVM.
This change will have impact on the OSS jobs that generate
the diffs for OSS submissions as it utilizes the output of
dump-licenses already so modifications to that part should
be considered prior to merging this.

Signed-off-by: Awais Belal <awais_belal@mentor.com>