### PR TITLE
local.conf.sample: remove unneeded ptest-runner line

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -67,7 +67,6 @@ CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-r
 # Uncomment to enable runtime testing with ptest
 #USER_FEATURES += "ptest"
 #EXTRA_IMAGE_FEATURES += "ptest-pkgs"
-#CORE_IMAGE_EXTRA_INSTALL += "ptest-runner"
 
 # Example of how to add additional image types beyond the default. If the
 # machine doesn't define them, the default types are tar.bz2 and ext3.


### PR DESCRIPTION
The runner is already included via `RRECOMMENDS_${PN}-ptest`, so we don't need to explicitly include it.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
