### PR TITLE
mel: enable pam by default

### DIFF
--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -184,7 +184,7 @@ require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
 ## }}}1
 ## Distro Features & Recipe Configuration {{{1
-MEL_DEFAULT_DISTRO_FEATURES = "opengl multiarch"
+MEL_DEFAULT_DISTRO_FEATURES = "opengl multiarch pam"
 
 # This violates typical MACHINE/DISTRO boundaries, but is part of MEL's
 # supported features. If the vendor supports x11 and not wayland for its


### PR DESCRIPTION
The risk here is low, the disk space usage isn't terrible (adds 730KiB to our
development-image), the runtime impact is low, and the ptest failures go down by
enabling it.

JIRA: SB-15753

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
