### PR TITLE
staging/tcpdump: upgrade to 4.9.3

### DIFF
--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/add-ptest.patch
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/add-ptest.patch
@@ -1,0 +1,37 @@
+From 8c9c728757f89ebe6c4019114b83a63c63596f69 Mon Sep 17 00:00:00 2001
+From: "Hongjun.Yang" <hongjun.yang@windriver.com>
+Date: Wed, 2 Oct 2019 16:57:06 -0400
+Subject: [PATCH] Add ptest for tcpdump
+
+Upstream-Status: Pending
+
+Signed-off-by: Hongjun.Yang <hongjun.yang@windriver.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+
+---
+ Makefile.in | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 3b589184..7b10e38c 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -437,9 +437,17 @@ distclean:
+ 	    tests/failure-outputs.txt
+ 	rm -rf autom4te.cache tests/DIFF tests/NEW
+ 
+-check: tcpdump
++buildtest-TESTS: tcpdump
++
++runtest-PTEST:
+	(mkdir -p tests && SRCDIR=`cd ${srcdir}; pwd` && export SRCDIR && $$SRCDIR/tests/TESTrun.sh )
+ 
++install-ptest:
++	cp -r tests                     $(DESTDIR)
++	cp -r config.h                  $(DESTDIR)
++	install -m 0755 Makefile        $(DESTDIR)
++	ln -sf /usr/sbin/tcpdump        $(DESTDIR)/tcpdump
++
+ extags: $(TAGFILES)
+ 	ctags $(TAGFILES)
+ 

--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/avoid-absolute-path-when-searching-for-libdlpi.patch
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/avoid-absolute-path-when-searching-for-libdlpi.patch
@@ -1,0 +1,31 @@
+From 02085028cdaf075943c27ebc02bb6de0289ec1d3 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 2 Oct 2019 16:43:48 -0400
+Subject: [PATCH] avoid absolute path when searching for libdlpi
+
+Let the build environment control library search paths.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3401a7a3..6a52485a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -528,7 +528,7 @@ don't.])
+ fi
+ 
+ # libdlpi is needed for Solaris 11 and later.
+-AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi" LDFLAGS="-L/lib $LDFLAGS", ,-L/lib)
++AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi")
+ 
+ dnl
+ dnl Check for "pcap_list_datalinks()", "pcap_set_datalink()",
+-- 
+2.17.1
+

--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/fix-CVE-2020-8037.patch
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/fix-CVE-2020-8037.patch
@@ -1,0 +1,66 @@
+From 32027e199368dad9508965aae8cd8de5b6ab5231 Mon Sep 17 00:00:00 2001
+From: Guy Harris <guy@alum.mit.edu>
+Date: Sat, 18 Apr 2020 14:04:59 -0700
+Subject: [PATCH] PPP: When un-escaping, don't allocate a too-large buffer.
+
+The buffer should be big enough to hold the captured data, but it
+doesn't need to be big enough to hold the entire on-the-network packet,
+if we haven't captured all of it.
+
+(backported from commit e4add0b010ed6f2180dcb05a13026242ed935334)
+
+Upstream-Status: Backport
+---
+ print-ppp.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/print-ppp.c b/print-ppp.c
+index 891761728..33fb03412 100644
+--- a/print-ppp.c
++++ b/print-ppp.c
+@@ -1367,19 +1367,29 @@ print_bacp_config_options(netdissect_options *ndo,
+ 	return 0;
+ }
+ 
++/*
++ * Un-escape RFC 1662 PPP in HDLC-like framing, with octet escapes.
++ * The length argument is the on-the-wire length, not the captured
++ * length; we can only un-escape the captured part.
++ */
+ static void
+ ppp_hdlc(netdissect_options *ndo,
+          const u_char *p, int length)
+ {
++	u_int caplen = ndo->ndo_snapend - p;
+ 	u_char *b, *t, c;
+ 	const u_char *s;
+-	int i, proto;
++	u_int i;
++	int proto;
+ 	const void *se;
+ 
++	if (caplen == 0)
++		return;
++
+         if (length <= 0)
+                 return;
+ 
+-	b = (u_char *)malloc(length);
++	b = (u_char *)malloc(caplen);
+ 	if (b == NULL)
+ 		return;
+ 
+@@ -1388,10 +1398,10 @@ ppp_hdlc(netdissect_options *ndo,
+ 	 * Do this so that we dont overwrite the original packet
+ 	 * contents.
+ 	 */
+-	for (s = p, t = b, i = length; i > 0 && ND_TTEST(*s); i--) {
++	for (s = p, t = b, i = caplen; i != 0; i--) {
+ 		c = *s++;
+ 		if (c == 0x7d) {
+-			if (i <= 1 || !ND_TTEST(*s))
++			if (i <= 1)
+ 				break;
+ 			i--;
+ 			c = *s++ ^ 0x20;
+

--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/run-ptest
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/run-ptest
@@ -1,0 +1,5 @@
+#!/bin/sh
+make -k runtest-PTEST | sed -e '/: passed/ s/^/PASS: /g' \
+			-e '/: TEST FAILED.*/ s/^/FAIL: /g' \
+			-e 's/: passed//g' \
+			-e 's/: TEST FAILED.*//g'

--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/unnecessary-to-check-libpcap.patch
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump/unnecessary-to-check-libpcap.patch
@@ -1,0 +1,40 @@
+From dd023c133980fcc0cff5896e85377675e0571894 Mon Sep 17 00:00:00 2001
+From: Roy Li <rongqing.li@windriver.com>
+Date: Tue, 8 Jul 2014 13:20:47 +0800
+Subject: [PATCH] unnecessary to check libpcap
+
+since the check of libpcap did not consider the cross-compile, lead to the
+below error:
+	This autoconf log indicates errors, it looked at host include and/or
+	library paths while determining system capabilities.
+
+In fact, the libpcap has been added into the tcpdump's DEPENDS, not need to
+check if libpcap existed.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+---
+ configure.ac | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 56e2a624..3401a7a3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -404,7 +404,9 @@ dnl Some platforms may need -lnsl for getrpcbynumber.
+ AC_SEARCH_LIBS(getrpcbynumber, nsl,
+     AC_DEFINE(HAVE_GETRPCBYNUMBER, 1, [define if you have getrpcbynumber()]))
+ 
+-AC_LBL_LIBPCAP(V_PCAPDEP, V_INCLS)
++# Simplified (more cross compile friendly) check for libpcap. All we really
++# need is to sanity check that libpcap is available and add -lpcap to LIBS.
++AC_CHECK_LIB(pcap, pcap_compile, LIBS="$LIBS -lpcap")
+ 
+ #
+ # Check for these after AC_LBL_LIBPCAP, so we link with the appropriate
+-- 
+2.17.1
+

--- a/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump_4.9.3.bb
+++ b/meta-mentor-staging/networking-layer/recipes-support/tcpdump/tcpdump_4.9.3.bb
@@ -1,0 +1,52 @@
+SUMMARY = "A sophisticated network protocol analyzer"
+HOMEPAGE = "http://www.tcpdump.org/"
+SECTION = "net"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1d4b0366557951c84a94fabe3529f867"
+
+DEPENDS = "libpcap"
+
+RDEPENDS_${PN}-ptest += " make perl \
+	perl-module-file-basename \
+	perl-module-posix \
+	perl-module-carp"
+
+SRC_URI = " \
+    http://www.tcpdump.org/release/${BP}.tar.gz \
+    file://unnecessary-to-check-libpcap.patch \
+    file://avoid-absolute-path-when-searching-for-libdlpi.patch \
+    file://add-ptest.patch \
+    file://run-ptest \
+    file://fix-CVE-2020-8037.patch \
+"
+
+SRC_URI[md5sum] = "a4ead41d371f91aa0a2287f589958bae"
+SRC_URI[sha256sum] = "2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410"
+
+inherit autotools-brokensep ptest
+
+PACKAGECONFIG ?= "openssl"
+
+PACKAGECONFIG[libcap-ng] = "--with-cap-ng,--without-cap-ng,libcap-ng"
+PACKAGECONFIG[openssl] = "--with-crypto,--without-openssl --without-crypto,openssl"
+PACKAGECONFIG[smi] = "--with-smi,--without-smi,libsmi"
+# Note: CVE-2018-10103 (SMB - partially fixed, but SMB printing disabled)
+PACKAGECONFIG[smb] = "--enable-smb,--disable-smb"
+
+EXTRA_AUTORECONF += "-I m4"
+
+do_configure_prepend() {
+    mkdir -p ${S}/m4
+    if [ -f aclocal.m4 ]; then
+        mv aclocal.m4 ${S}/m4
+    fi
+}
+
+do_install_append() {
+    # make install installs an unneeded extra copy of the tcpdump binary
+    rm -f ${D}${sbindir}/tcpdump.${PV}
+}
+
+do_compile_ptest() {
+    oe_runmake buildtest-TESTS
+}


### PR DESCRIPTION
This upgrade the tcpdump package to version 4.9.3 in order to
fix several CVEs that are reported against version less than
4.9.3. The recipe along with patches has been picked up from
meta-networking zeus branch.
Additionally we fix a CVE that was reported by the cve-check
tool against package version 4.9.3.

JIRA: https://jira.alm.mentorg.com/browse/SB-16881
Signed-off-by: Awais Belal <awais_belal@mentor.com>