### PR TITLE
staging/openembedded-layer/nodejs: upgrade to 8.16.1

### DIFF
--- a/meta-mentor-staging/openembedded-layer/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch
+++ b/meta-mentor-staging/openembedded-layer/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch
@@ -1,0 +1,29 @@
+From c2aff16cc196a61f4ab1cdae4a91c7926123c239 Mon Sep 17 00:00:00 2001
+From: Zuzana Svetlikova <zsvetlik@redhat.com>
+Date: Thu, 27 Apr 2017 14:25:42 +0200
+Subject: [PATCH] Disable running gyp on shared deps
+
+---
+ Makefile | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0a217bd893..e1229ad07f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -79,10 +79,9 @@ $(NODE_G_EXE): config.gypi out/Makefile
+ 	$(MAKE) -C out BUILDTYPE=Debug V=$(V)
+ 	if [ ! -r $@ -o ! -L $@ ]; then ln -fs out/Debug/$(NODE_EXE) $@; fi
+ 
+-out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
+-              deps/zlib/zlib.gyp deps/v8/gypfiles/toolchain.gypi \
+-              deps/v8/gypfiles/features.gypi deps/v8/src/v8.gyp node.gyp \
+-              config.gypi
++out/Makefile: common.gypi deps/http_parser/http_parser.gyp \
++              deps/v8/gypfiles/toolchain.gypi deps/v8/gypfiles/features.gypi \
++			  deps/v8/src/v8.gyp node.gyp config.gypi
+ 	$(PYTHON) tools/gyp_node.py -f make
+ 
+ config.gypi: configure
+-- 
+2.12.2

--- a/meta-mentor-staging/openembedded-layer/recipes-devtools/nodejs/nodejs_8.16.1.bb
+++ b/meta-mentor-staging/openembedded-layer/recipes-devtools/nodejs/nodejs_8.16.1.bb
@@ -1,0 +1,90 @@
+DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
+HOMEPAGE = "http://nodejs.org"
+LICENSE = "MIT & BSD & Artistic-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fde91d5c5bbd1e0389623e1ac018d9e8"
+
+DEPENDS = "openssl zlib"
+
+COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
+COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
+COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
+
+SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
+           file://0001-Disable-running-gyp-files-for-bundled-deps.patch \
+"
+SRC_URI[md5sum] = "e68a303f19512ff7c6285c2f01819971"
+SRC_URI[sha256sum] = "d8c190acdf2d967faf49c22df883d31a8d4e249d67852dae3c2d8a0f756b0512"
+
+S = "${WORKDIR}/node-v${PV}"
+
+# v8 errors out if you have set CCACHE
+CCACHE = ""
+
+def map_nodejs_arch(a, d):
+    import re
+
+    if   re.match('i.86$', a): return 'ia32'
+    elif re.match('x86_64$', a): return 'x64'
+    elif re.match('aarch64$', a): return 'arm64'
+    elif re.match('(powerpc64|ppc64le)$', a): return 'ppc64'
+    elif re.match('powerpc$', a): return 'ppc'
+    return a
+
+ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
+                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
+                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
+                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
+                    '--with-arm-fpu=vfp', d), d), d)}"
+GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
+ARCHFLAGS ?= ""
+
+# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
+do_configure () {
+    rm -rf ${S}/deps/openssl
+    export LD="${CXX}"
+    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
+    # $TARGET_ARCH settings don't match --dest-cpu settings
+   ./configure --prefix=${prefix} --without-intl --without-snapshot --shared-openssl --shared-zlib \
+               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
+               --dest-os=linux \
+               ${ARCHFLAGS}
+}
+
+do_compile () {
+    export LD="${CXX}"
+    oe_runmake BUILDTYPE=Release
+}
+
+do_install () {
+    oe_runmake install DESTDIR=${D}
+}
+
+do_install_append_class-native() {
+    # use node from PATH instead of absolute path to sysroot
+    # node-v0.10.25/tools/install.py is using:
+    # shebang = os.path.join(node_prefix, 'bin/node')
+    # update_shebang(link_path, shebang)
+    # and node_prefix can be very long path to bindir in native sysroot and
+    # when it exceeds 128 character shebang limit it's stripped to incorrect path
+    # and npm fails to execute like in this case with 133 characters show in log.do_install:
+    # updating shebang of /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/work/x86_64-linux/nodejs-native/0.10.15-r0/image/home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/npm to /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/node
+    # /usr/bin/npm is symlink to /usr/lib/node_modules/npm/bin/npm-cli.js
+    # use sed on npm-cli.js because otherwise symlink is replaced with normal file and
+    # npm-cli.js continues to use old shebang
+    sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+}
+
+do_install_append_class-target() {
+    sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+}
+
+PACKAGES =+ "${PN}-npm"
+FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm ${bindir}/npx"
+RDEPENDS_${PN}-npm = "bash python-shell python-datetime python-subprocess python-textutils \
+    python-compiler python-misc python-multiprocessing"
+
+PACKAGES =+ "${PN}-systemtap"
+FILES_${PN}-systemtap = "${datadir}/systemtap"
+
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This upgrades the nodejs package to 8.16.1 from 8.9.4 to
resolve a number of CVEs that were reported against the
older version. The backporting effort for the CVE fixes
on the older version out weighs the work that we are
expecting here so we simply upgrade the package.

Fixed CVEs:
CVE-2019-9511
CVE-2019-9512
CVE-2019-9513
CVE-2019-9514
CVE-2019-9515
CVE-2019-9516
CVE-2019-9517
CVE-2019-9518

JIRA: https://jira.alm.mentorg.com/browse/SB-16893
Signed-off-by: Awais Belal <awais_belal@mentor.com>