### PR TITLE
mentor-staging/selinux: fix build error due to missing target config 

### DIFF
--- a/meta-mentor-staging/selinux/recipes-security/selinux/libselinux-python_3.0.bbappend
+++ b/meta-mentor-staging/selinux/recipes-security/selinux/libselinux-python_3.0.bbappend
@@ -1,0 +1,1 @@
+inherit python3targetconfig


### PR DESCRIPTION
This fixes the error below:

gcc: error: unrecognized command line option
‘-fmacro-prefix-map=/path/to/build/libselinux-python/3.0-r0=/usr/src/debug/libselinux-python/3.0-r0’

Without inheriting the config, supposedly a wrong compiler is used.

Backport from:
http://git.yoctoproject.org/cgit/cgit.cgi/meta-selinux/commit/recipes-security/selinux?h=dunfell&id=c9de7989464c7cd774e25d23496ed63ffc4ecdf6

Signed-off-by: ansar-rasool <ansar_rasool@mentor.com>