### PR TITLE
mel-checkout: fix prompt default when passing -a

### DIFF
--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -51,15 +51,12 @@ set_machine () {
 }
 
 prompt_choice () {
-    choice_non_interactive=0
-    while getopts n opt; do
-        case "$opt" in
-            n)
-                choice_non_interactive=1
-                ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    if [ "$1" = "-n" ]; then
+        choice_non_interactive=1
+        shift
+    else
+        choice_non_interactive=0
+    fi
 
     prompt_message="$1"
     prompt_default="${2:-}"


### PR DESCRIPTION
Due to an interaction between the argument processing for the main script and that of the prompt_choice function, `$2` was never seen (the shift removed it), and thus no default was set for the prompt.

JIRA: SB-17182

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
