### PR TITLE
powertop_2.10: add patches to fix aclocal error

### DIFF
--- a/meta-mentor-staging/recipes-kernel/powertop/files/0001-configure.ac-ax_add_fortify_source.patch
+++ b/meta-mentor-staging/recipes-kernel/powertop/files/0001-configure.ac-ax_add_fortify_source.patch
@@ -1,0 +1,81 @@
+From 7ad2d54fc05fe48786bd30bfcca1c4f208ddb016 Mon Sep 17 00:00:00 2001
+From: Joe Konno <joe.konno@linux.intel.com>
+Date: Tue, 11 Feb 2020 14:15:42 -0800
+Subject: [PATCH 1/2] configure.ac: ax_add_fortify_source
+
+Use a maintained autoconf-archive macro to determine whether we need to
+add -D_FORTIFY_SOURCE=3D2, or if the underlying OS (or toolchain) has it
+baked in.
+
+Signed-off-by: Joe Konno <joe.konno@intel.com>
+
+Fixes:
+  aclocal: error: too many loops
+
+Upstream-Status: Backport from 2.12
+Signed-off-by: Tim Orling <timothy.t.orling@intel.com>
+
+Upstream-Status: Backporrt from
+https://github.com/openembedded/openembedded-core/commit/
+5a7e1e531d70eb41638c247b70791f2f3aea8793
+
+JIRA-ID: SB-17299
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ configure.ac                |  2 +-
+ m4/gcc_fortify_source_cc.m4 | 29 -----------------------------
+ 2 files changed, 1 insertion(+), 30 deletions(-)
+ delete mode 100644 m4/gcc_fortify_source_cc.m4
+
+diff --git a/configure.ac b/configure.ac
+index 0b33f8c..480d8c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -36,7 +36,7 @@ AC_PROG_LIBTOOL
+ AC_PROG_CC
+ AC_PROG_INSTALL
+ AM_PROG_CC_C_O
+-GCC_FORTIFY_SOURCE_CC
++AX_ADD_FORTIFY_SOURCE
+ AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+ 
+ # Checks for libraries.
+diff --git a/m4/gcc_fortify_source_cc.m4 b/m4/gcc_fortify_source_cc.m4
+deleted file mode 100644
+index 1206672..0000000
+--- a/m4/gcc_fortify_source_cc.m4
++++ /dev/null
+@@ -1,29 +0,0 @@
+-dnl GCC_FORTIFY_SOURCE_CC
+-dnl checks -D_FORTIFY_SOURCE with the C++ compiler, if it exists then
+-dnl updates CXXCPP
+-AC_DEFUN([GCC_FORTIFY_SOURCE_CC],[
+-  AC_LANG_ASSERT([C++])
+-  AS_IF([test "X$CXX" != "X"], [
+-    AC_MSG_CHECKING([for FORTIFY_SOURCE support])
+-    fs_old_cxxcpp="$CXXCPP"
+-    fs_old_cxxflags="$CXXFLAGS"
+-    CXXCPP="$CXXCPP -D_FORTIFY_SOURCE=2"
+-    CXXFLAGS="$CXXFLAGS -Werror"
+-    AC_COMPILE_IFELSE([
+-      AC_LANG_PROGRAM([[]], [[
+-        int main(void) {
+-        #if !(__GNUC_PREREQ (4, 1) )
+-        #error No FORTIFY_SOURCE support
+-        #endif
+-          return 0;
+-        }
+-      ]], [
+-        AC_MSG_RESULT([yes])
+-      ], [
+-        AC_MSG_RESULT([no])
+-        CXXCPP="$fs_old_cxxcpp"
+-      ])
+-    ])
+-    CXXFLAGS="$fs_old_cxxflags"
+-  ])
+-])
+-- 
+2.32.0
+

--- a/meta-mentor-staging/recipes-kernel/powertop/files/0002-configure-Use-AX_REQUIRE_DEFINED.patch
+++ b/meta-mentor-staging/recipes-kernel/powertop/files/0002-configure-Use-AX_REQUIRE_DEFINED.patch
@@ -1,0 +1,40 @@
+From e65490ac278e4578bed3af3ad2408307acf4d4c1 Mon Sep 17 00:00:00 2001
+From: David King <amigadave@amigadave.com>
+Date: Thu, 15 Apr 2021 11:45:13 +0100
+Subject: [PATCH 2/2] configure: Use AX_REQUIRE_DEFINED
+
+Require additional macros to be defined early, to avoid an aclocal
+"too many loops" error when copying macros.
+
+Upstream-Status: Backport from tip
+
+Signed-off-by: Tim Orling <ticotimo@gmail.com>
+
+Upstream-Status: Backporrt from
+https://github.com/openembedded/openembedded-core/commit/
+5a7e1e531d70eb41638c247b70791f2f3aea8793
+
+JIRA-ID: SB-17299
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ configure.ac | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 480d8c6..d571c68 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,9 @@ AM_GNU_GETTEXT([external])
+ AM_GNU_GETTEXT_VERSION([0.18.2])
+ 
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
++AX_REQUIRE_DEFINED([AX_ADD_FORTIFY_SOURCE])
++AX_REQUIRE_DEFINED([AX_CXX_COMPILE_STDCXX])
++AX_REQUIRE_DEFINED([AX_PTHREAD])
+ # Checks for programs.
+ AC_PROG_CPP
+ AC_PROG_CXX
+-- 
+2.32.0
+

--- a/meta-mentor-staging/recipes-kernel/powertop/powertop_2.10.bbappend
+++ b/meta-mentor-staging/recipes-kernel/powertop/powertop_2.10.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+DEPENDS += "autoconf-archive"
+
+SRC_URI_append = " \
+           file://0001-configure.ac-ax_add_fortify_source.patch \
+           file://0002-configure-Use-AX_REQUIRE_DEFINED.patch \
+"


### PR DESCRIPTION
Error:
aclocal: error: too many loops
aclocal: Please contact bug-automake@gnu.org.

JIRA-ID: SB-17299

Fix:
Backport https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/
?h=dunfell&id=d4b4bf172f260ee2d95088368c56de0e2155ffe2

Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>