### PR TITLE
setup-ubuntu: run locale-gen with sudo and bump SCRIPTS_VERSION

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -11,7 +11,7 @@ ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181206"
 
 # Version of the mel-scripts artifact, including setup-mel
-SCRIPTS_VERSION ?= "1"
+SCRIPTS_VERSION ?= "2"
 
 # Default values for BSP and PATCH version, to be redefined in other layers
 BSP_VERSION ?= "0"

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -65,6 +65,6 @@ if ! which virtualenv >/dev/null 2>&1; then
 fi
 
 echo "Generating the en_US.UTF-8 locale"
-locale-gen en_US.UTF-8
+sudo locale-gen en_US.UTF-8
 
 echo "Setup complete"


### PR DESCRIPTION
locale-gen creates temporary files in /etc and fails to
do so if not run with sudo.
Bumps the SCRIPTS_VERSION so the changes are picked up in the
next installer.

JIRA: https://jira.alm.mentorg.com/browse/SB-17257
Signed-off-by: Awais Belal <awais_belal@mentor.com>