### PR TITLE
[sumo] staging: licenses: add license for HP

### DIFF
--- a/meta-mentor-staging/licenses/Hewlett-Packard
+++ b/meta-mentor-staging/licenses/Hewlett-Packard
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 1994
+ * Hewlett-Packard Company
+ *
+ * Permission to use, copy, modify, distribute and sell this software
+ * and its documentation for any purpose is hereby granted without fee,
+ * provided that the above copyright notice appear in all copies and
+ * that both that copyright notice and this permission notice appear
+ * in supporting documentation.  Hewlett-Packard Company makes no
+ * representations about the suitability of this software for any
+ * purpose.  It is provided "as is" without express or implied warranty.
+ *
+ */


### PR DESCRIPTION
This fixes

WARNING: ti-cgt-pru-native-2.3.2-r0 do_populate_lic: ti-cgt-pru-native: No generic license file exists for: Hewlett-Packard in any provider

and is a backport of

http://git.yoctoproject.org/cgit/cgit.cgi/meta-ti/commit/?id=97441a763e8568cf477a0e45ce1d86cb6b8e7e4a

JIRA: https://jira.alm.mentorg.com/browse/SB-17191
Signed-off-by: Awais Belal <awais_belal@mentor.com>