### PR TITLE
[sumo] mel.conf: check for GPLv3 variants for QEMUDEPS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -31,7 +31,7 @@ MEL_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 DISTRO_EXTRA_RDEPENDS += " ${MEL_DEFAULT_EXTRA_RDEPENDS}"
 DISTRO_EXTRA_RRECOMMENDS += " ${MEL_DEFAULT_EXTRA_RRECOMMENDS}"
 
-QEMUDEPS = "${@bb.utils.contains('INCOMPATIBLE_LICENSE', 'GPL-3.0', '', 'packagegroup-core-device-devel',d)}"
+QEMUDEPS = "${@bb.utils.contains_any('INCOMPATIBLE_LICENSE', ['GPL-3.0', 'GPLv3', 'GPLv3.0'], '', 'packagegroup-core-device-devel',d)}"
 DISTRO_EXTRA_RDEPENDS_append_qemuarm = " ${QEMUDEPS}"
 DISTRO_EXTRA_RDEPENDS_append_qemuarm64 = " ${QEMUDEPS}"
 DISTRO_EXTRA_RDEPENDS_append_qemumips = " ${QEMUDEPS}"


### PR DESCRIPTION
INCOMPATIBLE_LICENSE can have any variant of GPLv3 license
names i.e. GPL-3.0 or GPLv3.

Fixes: https://jira.alm.mentorg.com/browse/SB-17451
Signed-off-by: Awais Belal <awais_belal@mentor.com>