### PR TITLE
[sumo] mel.conf: simplify license checking for QEMUDEPS

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -31,7 +31,7 @@ MEL_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 DISTRO_EXTRA_RDEPENDS += " ${MEL_DEFAULT_EXTRA_RDEPENDS}"
 DISTRO_EXTRA_RRECOMMENDS += " ${MEL_DEFAULT_EXTRA_RRECOMMENDS}"
 
-QEMUDEPS = "${@bb.utils.contains_any('INCOMPATIBLE_LICENSE', ['GPL-3.0', 'GPLv3', 'GPLv3.0'], '', 'packagegroup-core-device-devel',d)}"
+QEMUDEPS = "${@incompatible_license_contains('GPL-3.0', '', 'packagegroup-core-device-devel', d)}"
 DISTRO_EXTRA_RDEPENDS_append_qemuarm = " ${QEMUDEPS}"
 DISTRO_EXTRA_RDEPENDS_append_qemuarm64 = " ${QEMUDEPS}"
 DISTRO_EXTRA_RDEPENDS_append_qemumips = " ${QEMUDEPS}"


### PR DESCRIPTION
This simplifies the checking of GPLv3 incompatibility for
inclusion of tools in the QEMUDEPS.

Suggested-by: Christopher Larson <chris_larson@mentor.com>
Signed-off-by: Awais Belal <awais_belal@mentor.com>