### PR TITLE
llvm: Fix Killed signal error on 8 core machine for llvm

### DIFF
--- a/meta-mel/recipes-devtools/llvm/llvm_%.bbappend
+++ b/meta-mel/recipes-devtools/llvm/llvm_%.bbappend
@@ -1,0 +1,2 @@
+# If build system has 8 or less CPU cores, build only 8 jobs in parallel
+PARALLEL_MAKE_mel = "-j ${@'8' if oe.utils.cpu_count() <= 8 else oe.utils.cpu_count() * 2}"


### PR DESCRIPTION
* llvm was consuming alot of resources due to which we were getting following
  g++: fatal error: Killed signal terminated program cc1plus
  Reduced PARALLEL_MAKE value to 8 when we are running on 9 cpu core machine.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>