### PR TITLE
mel-initramfs-image: fix do_package warning for recipes that use init…

### DIFF
--- a/meta-mel/recipes-core/images/mel-initramfs-image.bb
+++ b/meta-mel/recipes-core/images/mel-initramfs-image.bb
@@ -22,3 +22,8 @@ BAD_RECOMMENDATIONS += "busybox-syslog"
 IMAGE_PREPROCESS_COMMAND_remove = "selinux_set_labels ;"
 
 COMPATIBLE_HOST_mel = "(arm|aarch64|i.86|x86_64).*-linux"
+
+# Take care of warnings due to dependency on noexec ${INITRAMFS_IMAGE}:do_image_complete's
+# do_packagedata() in our initramfs image for now. The fix needs to come from oe-core image
+# bbclass when available, after which this can be removed
+deltask do_packagedata


### PR DESCRIPTION
…ramfs

Packages like imx-boot package initramfs based kernel image when secure
boot is enabled which adds this kind of dependency to the recipe

d.appendVarFlag('do_compile', 'depends', ' ${INITRAMFS_IMAGE}:do_image_complete')

This causes a dependency on do_image_complete's do_packagedata() and
thus we get this warning. Delete do_packagedata as other do_package
relelated tasks for the image recipe will fix the error.

This is a temporary fix till we get the upstream fix in image.bbclass in
oe-core

http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=b608cf6120235754582edd3e73e34a9af0959b79

JIRA ID: SB-17562

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>