### PR TITLE
96boards-tools: fix a typo for sysvinit case

### DIFF
--- a/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -34,7 +34,7 @@ do_install () {
         install -d ${D}${sysconfdir}/init.d
         install -m 0755 ${WORKDIR}/resize-helper.sh.in ${D}${sysconfdir}/init.d/resize-helper.sh
         sed -i -e "s:@bindir@:${bindir}:; s:@sbindir@:${sbindir}:; s:@sysconfdir@:${sysconfdir}:" \
-            ${D}${sysconfdir}/init.d/resize-helper.sh}
+            ${D}${sysconfdir}/init.d/resize-helper.sh
     fi
 }
 


### PR DESCRIPTION
This is breaking the build when sysvinit is available in distro
features.

Jira ID: SB-18221

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>