### PR TITLE
mentor-staging/perl-rdepends.txt: remove spdx license header to fix build failure

### DIFF
--- a/meta-mentor-staging/recipes-devtools/perl/perl/perl-rdepends.txt
+++ b/meta-mentor-staging/recipes-devtools/perl/perl/perl-rdepends.txt
@@ -1,7 +1,3 @@
-# ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: Artistic-1.0 OR GPL-1.0-or-later
-# ---------------------------------------------------------------------------------------------------------------------
-
 RDEPENDS_perl-module-anydbm-file += "perl-module-strict"
 RDEPENDS_perl-module-anydbm-file += "perl-module-warnings"
 RDEPENDS_perl-module-app-cpan += "perl-module-config"


### PR DESCRIPTION
This removes SPDX header from perl-rdepends.txt file to fix
following build failure for perl package.

ERROR: perl-5.30.1-r0 do_package: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:split_perl_packages(d)
     0003:
File: '/data/ansar/fir_async2/oe-core/meta/recipes-devtools/perl/perl_5.30.1.bb', lineno: 335, function: split_perl_packages
     0331:            module = splitline[0] + '-native'
     0332:            depends = "perl-native"
     0333:        else:
     0334:            module = splitline[0].replace("RDEPENDS_perl", "RDEPENDS_${PN}")
 *** 0335:            depends = splitline[2].strip('"').replace("perl-module", "${PN}-module")
     0336:        d.appendVar(d.expand(module), " " + depends)
     0337:}
     0338:
     0339:python() {
Exception: IndexError: list index out of range

JIRA-ID: SB-17889

Signed-off-by: ansar-rasool <ansar_rasool@mentor.com>