### PR TITLE
96boards-tools: remove unused sed from the recipe

### DIFF
--- a/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -17,11 +17,6 @@ S = "${WORKDIR}/git"
 
 inherit systemd allarch update-rc.d
 
-do_compile () {
-    # The parted version we're using doesn't want this argument
-    sed -i -e "/PARTED/s/ Yes / /" ${S}/resize-helper
-}
-
 do_install () {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0755 ${S}/*.rules ${D}${sysconfdir}/udev/rules.d/


### PR DESCRIPTION
This sed is from legacy implementation and no longer applies to the
current disk-resizer script in the 96boards-tools source

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>