### PR TITLE
[dunfell] scripts: recipetool: fix SPDX license identifier

### DIFF
--- a/meta-mel/lib/recipetool/kernel.py
+++ b/meta-mel/lib/recipetool/kernel.py
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 
 # Recipe creation tool - kernel plugin
@@ -21,7 +21,7 @@
 #     $ recipetool kernel_add_dts meta-mylayer *.dts
 #
 #
-# Copyright 2021 Siemens
+# Copyright 2022 Siemens
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/scripts/capdebuginfo
+++ b/scripts/capdebuginfo
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 
 ###############################################################################
@@ -10,7 +10,7 @@
 #  Script to capture debug info from a MEL user's host
 #
 #
-# Copyright 2021 Siemens
+# Copyright 2022 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any

--- a/scripts/multi-machine
+++ b/scripts/multi-machine
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 #
-# Copyright 2021 Siemens 
+# Copyright 2022 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 #
-# Copyright 2021 Siemens
+# Copyright 2022 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any

--- a/scripts/setup-rh
+++ b/scripts/setup-rh
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 #
-# Copyright 2021 Siemens
+# Copyright 2022 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any

--- a/scripts/setup-ubuntu
+++ b/scripts/setup-ubuntu
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
 # ---------------------------------------------------------------------------------------------------------------------
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: GPL-2.0
 # ---------------------------------------------------------------------------------------------------------------------
 #
-# Copyright 2021 Siemens
+# Copyright 2022 Siemens
 #
 # This file is licensed under the terms of the GNU General Public License
 # version 2.  This program  is licensed "as is" without any warranty of any


### PR DESCRIPTION
These scripts are licensed under GPLv2 rather than MIT
so fix the SPDX license identifier accordingly.

Signed-off-by: Awais Belal <awais_belal@mentor.com>