### PR TITLE
packagegroup-base: Use nfs-utils-client instead of nfs-utils

### DIFF
--- a/meta-mel/recipes-core/packagegroups/packagegroup-base.bbappend
+++ b/meta-mel/recipes-core/packagegroups/packagegroup-base.bbappend
@@ -11,4 +11,4 @@ RRECOMMENDS_packagegroup-base-bluetooth_mel = "${VIRTUAL-RUNTIME_bluetooth-hw-su
 
 RDEPENDS_packagegroup-base-vfat_append_mel = " dosfstools"
 RDEPENDS_packagegroup-base-ipv6_append_mel = " dhcp-client"
-RDEPENDS_packagegroup-base-nfs_append_mel = " nfs-utils"
+RDEPENDS_packagegroup-base-nfs_append_mel = " nfs-utils-client"


### PR DESCRIPTION
Since we only require client capabilites we do not need to
install complete nfs-utils which comes with server capibilties
causing failures due to absend NFSD server configs as we do
not need them.

JIRA-ID: SB-18414

Signed-off-by: Muhammmad Hamza <muhammad_hamza@mentor.com>