### PR TITLE
[fir_async2_next]: mel.conf: Unbundle initramfs from the kernel image

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -441,7 +441,7 @@ include conf/distro/include/mel-mcf.conf
 
 # INITRAMFS
 INITRAMFS_IMAGE ?= "mel-initramfs-image"
-INITRAMFS_IMAGE_BUNDLE ?= "1"
+INITRAMFS_IMAGE_BUNDLE ?= "${@bb.utils.contains('KERNEL_IMAGETYPES', 'fitimage', '', '1', d)}"
 
 ## }}}1
 # vim: set fdm=marker fdl=0 :


### PR DESCRIPTION
We now use FIT uImage for all our U-Boot based BSPs which incorporates
the separate initramfs section, so there is no need to bundle initramfs
with the kernel as well

JIRA ID: SB-17288

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>