### PR TITLE
kernel-uboot.bbclass: get rid of compression for arm64 kernel

### DIFF
--- a/meta-mel/classes/kernel-uboot.bbclass
+++ b/meta-mel/classes/kernel-uboot.bbclass
@@ -1,0 +1,26 @@
+uboot_prep_kimage() {
+	if [ -e arch/${ARCH}/boot/compressed/vmlinux ]; then
+		vmlinux_path="arch/${ARCH}/boot/compressed/vmlinux"
+		linux_suffix=""
+		linux_comp="none"
+	elif [ -e arch/${ARCH}/boot/vmlinuz.bin ]; then
+		rm -f linux.bin
+		cp -l arch/${ARCH}/boot/vmlinuz.bin linux.bin
+		vmlinux_path=""
+		linux_suffix=""
+		linux_comp="none"
+	else
+		vmlinux_path="vmlinux"
+		linux_suffix=""
+		linux_comp="none"
+	fi
+
+	[ -n "${vmlinux_path}" ] && ${OBJCOPY} -O binary -R .note -R .comment -S "${vmlinux_path}" linux.bin
+
+	if [ "${linux_comp}" != "none" ] ; then
+		gzip -9 linux.bin
+		mv -f "linux.bin${linux_suffix}" linux.bin
+	fi
+
+	echo "${linux_comp}"
+}


### PR DESCRIPTION
Maintain a local copy of kernel-uboot.bbclass which overrides the
behavior from the upstream class and removes kernel compression from
arm64 kernel image. This saves up to 1s from slow targets at bootup

JIRA ID: SB-17289

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>