### PR TITLE
mel_utils/dump-licenses: fix wrong su dump for pkgs having no SRC_URI

### DIFF
--- a/meta-mel/lib/bblayers/mel_utils.py
+++ b/meta-mel/lib/bblayers/mel_utils.py
@@ -250,6 +250,8 @@ class MELUtilsPlugin(LayerPlugin):
                 if not args.sourceinfo:
                     f.write('%s,%s,%s\n' % (pn, pv, lc))
                 else:
+                    # unset su, otherwise we get previous value if there is no current
+                    su = ''
                     for url in data.getVar('SRC_URI').split():
                         scheme, host, path, user, passwd, param = bb.fetch.decodeurl(url)
                         if scheme != 'file':


### PR DESCRIPTION
"bitbake-layers dump-licenses <recipe> --sourceinfo" dumps a wrong
value for packages having no SRC_URI i.e. "*-external" packages.
This fixes that.

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>