### PR TITLE
mel.conf: Do PAM integration in Flex OS distro

### DIFF
--- a/meta-mel-support/recipes-core/images/mel-image.inc
+++ b/meta-mel-support/recipes-core/images/mel-image.inc
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------------------------------------------------
 
+inherit features_check
+
+REQUIRED_DISTRO_FEATURES = "pam"
+
 # We want a package manager in our base images
 IMAGE_FEATURES += "package-management"
 

--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -222,6 +222,11 @@ DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${MEL_DEF
 # We always want vfat support in our distro for external media
 DISTRO_FEATURES_append = " vfat"
 
+# Our images requre PAM to have user slice for user sessions in systemd cgroup
+# hierarchy. Without this we have login shell running directly under agetty,
+# causing it to ignore SIGHUP/SIGTERM and causing delays when we try to stop getty
+DISTRO_FEATURES_append = " pam"
+
 # Ensure fbset is in busybox configuration, and fbset-modes is included
 PACKAGECONFIG_append_pn-busybox = " fbset"
 


### PR DESCRIPTION
Our images requre PAM to have user slice for user sessions in systemd cgroup
hierarchy. Without this we have login shell running directly under agetty,
causing it to ignore SIGHUP/SIGTERM and causing delays when we try to stop getty

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>