### PR TITLE
mel: set https protocol for all github urls

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -50,12 +50,15 @@ gitsm://.*/.* http://downloads.yoctoproject.org/mirror/sources/ \n \
 hg://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
 osc://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
 p4://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n"
+svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
+git://github.com/.* git://github.com/PATH;protocol=https \n \
+"
 
 MIRRORS =+ "\
 ftp://.*/.*      http://downloads.yoctoproject.org/mirror/sources/ \n \
 http://.*/.*     http://downloads.yoctoproject.org/mirror/sources/ \n \
-https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
+https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
+"
 
 # The CONNECTIVITY_CHECK_URI's are used to test whether we can succesfully
 # fetch from the network (and warn you if not). To disable the test set


### PR DESCRIPTION
This is a workaround for https://github.blog/2021-09-01-improving-git-protocol-security-github/, to avoid needing to update bitbake to pick up the fix there.

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
