### PR TITLE
Revert "mel: set https protocol for all github urls"

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -62,15 +62,12 @@ gitsm://.*/.* http://downloads.yoctoproject.org/mirror/sources/ \n \
 hg://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
 osc://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
 p4://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-git://github.com/.* git://github.com/PATH;protocol=https \n \
-"
+svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n"
 
 MIRRORS =+ "\
 ftp://.*/.*      http://downloads.yoctoproject.org/mirror/sources/ \n \
 http://.*/.*     http://downloads.yoctoproject.org/mirror/sources/ \n \
-https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-"
+https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
 
 # The CONNECTIVITY_CHECK_URI's are used to test whether we can succesfully
 # fetch from the network (and warn you if not). To disable the test set


### PR DESCRIPTION
This reverts commit 3063301fb263114a1c403c20abc560e92e2a5924.

This isn't needed, as the default MIRRORS already falls back to https.
