### PR TITLE
mel: use common compatible tuning values for arm & aarch64

### DIFF
--- a/meta-mel/conf/distro/include/mel-arm-tuning.inc
+++ b/meta-mel/conf/distro/include/mel-arm-tuning.inc
@@ -1,0 +1,28 @@
+# Use common compatible tuning values.
+#
+# This avoids unnecessary toolchain component rebuilds and increases reuse and compatibility amongst
+# compatible machines.
+#
+# Imported from https://github.com/96boards/meta-rpb/blob/master/conf/distro/include/arm-defaults.inc
+# Imported from https://github.com/Angstrom-distribution/meta-angstrom/blob/master/conf/distro/include/arm-defaults.inc
+
+def get_generic_tune(d):
+    features = d.getVar('TUNE_FEATURES').split()
+    if 'aarch64' in features:
+        tune = 'armv8a'
+        if 'crc' in features:
+            tune += '-crc'
+        if 'crypto' in features:
+            tune += '-crypto'
+    # cortexa* tune files only list 'arm' in features instead of 'armv7*'
+    elif 'armv7a' in features or 'armv7ve' in features or ('arm' in features and 'neon' in features):
+        tune = 'armv7athf'
+        if 'bigendian' in features:
+            tune += 'b'
+        if 'neon' in features:
+            tune += '-neon'
+    else:
+        tune = None
+    return tune
+
+DEFAULTTUNE:mel := "${@get_generic_tune(d)}"

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -309,6 +309,9 @@ FEATURE_PACKAGES_samba-server    ?= "samba swat"
 DISTRO_EXTRA_RRECOMMENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'nss-myhostname', d)}"
 ## }}}1
 ## Workarounds & Overrides {{{1
+# Override arm tuning to reduce specificity and increase reuse.
+require conf/distro/include/mel-arm-tuning.inc
+
 # We aren't supporting meta-intel's RMC
 BBMASK += "/meta-intel/common/recipes-bsp/systemd-boot/"
 


### PR DESCRIPTION
This avoids unnecessary toolchain component rebuilds and increases reuse and
compatibility amongst compatible machines. Imported, then tweaked to also apply
to aarch64 and our DISTRO.

Imported from https://github.com/96boards/meta-rpb/blob/master/conf/distro/include/arm-defaults.inc
Imported from https://github.com/Angstrom-distribution/meta-angstrom/blob/master/conf/distro/include/arm-defaults.inc