### PR TITLE
archive-release: improve reproducibility and usability for releases

### DIFF
--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -21,7 +21,7 @@ ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181206"
 
 # Version of the mel-scripts artifact, including setup-mel
-SCRIPTS_VERSION ?= "0"
+SCRIPTS_VERSION ?= "1"
 
 # Default values for BSP and PATCH version, to be redefined in other layers
 BSP_VERSION ?= "0"

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -237,9 +237,6 @@ def git_archive(subdir, outdir, message=None, keep_paths=None, remotes=None):
     import glob
     import tempfile
 
-    if message is None:
-        message = 'Release of %s' % os.path.basename(subdir)
-
     parent = None
     if os.path.exists(os.path.join(subdir, '.git')):
         parent = subdir
@@ -283,6 +280,9 @@ def git_archive(subdir, outdir, message=None, keep_paths=None, remotes=None):
             # Public git layer with no need to filter paths, skip commit
             head = parent_head
         else:
+            if message is None:
+                message = 'Release of %s' % os.path.basename(subdir)
+
             commitcmd = ['commit-tree', '-m', message]
             if parent:
                 bb.process.run(gitcmd + ['read-tree', parent_head])
@@ -319,8 +319,9 @@ def git_archive(subdir, outdir, message=None, keep_paths=None, remotes=None):
             }
             head = bb.process.run(gitcmd + commitcmd, env=env)[0].rstrip()
 
-        with open(os.path.join(tmpdir, 'shallow'), 'w') as f:
-            f.write(head + '\n')
+        if not remotes:
+            with open(os.path.join(tmpdir, 'shallow'), 'w') as f:
+                f.write(head + '\n')
 
         # We need a ref to ensure repack includes the new commit, as it
         # does not include dangling objects in the pack.

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -176,7 +176,7 @@ python do_archive_mel_layers () {
     bb.utils.mkdirhier(objdir)
     manifestfn = d.expand('%s/${MANIFEST_NAME}.manifest' % mandir)
     manifests = [manifestfn]
-    message = '%s release' % d.getVar('DISTRO')
+    message = '%s %s' % (d.getVar('DISTRO_NAME') or d.getVar('DISTRO'), d.getVar('DISTRO_VERSION'))
 
     manifestdata = collections.defaultdict(list)
     for subdir, path, keep_paths in sorted(to_archive):

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -247,7 +247,12 @@ done | (
             fi
 
             cd "$checkout_path"
-            echo "$installdir/objects" >.git/objects/info/alternates
+            if [ -d "$installdir/objects" ]; then
+                echo "$installdir/objects" >.git/objects/info/alternates
+            fi
+            if [ -e "$installdir/git-bundles/$commit.bundle" ]; then
+                git bundle unbundle "$installdir/git-bundles/$commit.bundle" >/dev/null
+            fi
             echo "$commit" >.git/shallow
 
             echo "$remotes" | tr '\t' '\n' | while IFS== read -r name url; do
@@ -267,6 +272,9 @@ done | (
                     if [ "$other_checkout_path" = "$checkout_path" ]; then
                         branch="$(basename "${otherfn%.manifest}")"
                         if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
+                            if [ -e "$installdir/git-bundles/$other_commit.bundle" ]; then
+                                git bundle unbundle "$installdir/git-bundles/$other_commit.bundle" >/dev/null
+                            fi
                             git update-ref "refs/heads/$branch" "$other_commit"
                         fi
                         echo "$other_commit" >>.git/shallow

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -253,7 +253,6 @@ done | (
             if [ -e "$installdir/git-bundles/$commit.bundle" ]; then
                 git bundle unbundle "$installdir/git-bundles/$commit.bundle" >/dev/null
             fi
-            echo "$commit" >.git/shallow
 
             echo "$remotes" | tr '\t' '\n' | while IFS== read -r name url; do
                 if [ -n "$name" ]; then
@@ -265,6 +264,9 @@ done | (
                 fi
             done
 
+            if [ -z "$remotes" ]; then
+                echo "$commit" >.git/shallow
+            fi
             # Create branches for all manifests, for reference
             manifestdir="$(dirname "$manifest")"
             for otherfn in "$manifestdir/"*.manifest; do
@@ -277,10 +279,13 @@ done | (
                             fi
                             git update-ref "refs/heads/$branch" "$other_commit"
                         fi
-                        echo "$other_commit" >>.git/shallow
+                        if [ -z "$remotes" ]; then
+                            echo "$other_commit" >>.git/shallow
+                        fi
                     fi
                 done <"$otherfn"
             done
+
             branch="$(basename "${manifest%.manifest}")"
             if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
                 git update-ref "refs/heads/$branch" "$commit"


### PR DESCRIPTION
- Avoid duplication of pack files between releases and updates
- Avoid creating new commits for public layers
- Ship history for public layers, don't make them shallow
- Improve the commit message when we do create commits

[![Screencast](https://asciinema.org/a/pcXiBFSPVeUzj5wTnXuJDFEal.png)](https://asciinema.org/a/pcXiBFSPVeUzj5wTnXuJDFEal)