### PR TITLE
archive-release: improve reproducibility

### DIFF
--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -21,7 +21,7 @@ ARCHIVE_RELEASE_VERSION = "${DISTRO_VERSION}.${BSP_VERSION}.${PATCH_VERSION}"
 PDK_LICENSE_VERSION_DATE = "20181206"
 
 # Version of the mel-scripts artifact, including setup-mel
-SCRIPTS_VERSION ?= "0"
+SCRIPTS_VERSION ?= "1"
 
 # Default values for BSP and PATCH version, to be redefined in other layers
 BSP_VERSION ?= "0"

--- a/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
+++ b/meta-mel/mel-support/recipes-core/meta/archive-release.bbappend
@@ -173,7 +173,7 @@ python do_archive_mel_layers () {
     mandir = os.path.join(outdir, 'manifests')
     bb.utils.mkdirhier(mandir)
     bb.utils.mkdirhier(os.path.join(mandir, 'extra'))
-    objdir = os.path.join(outdir, 'objects', 'pack')
+    objdir = os.path.join(outdir, 'git-bundles')
     bb.utils.mkdirhier(objdir)
     manifestfn = d.expand('%s/${MANIFEST_NAME}.manifest' % mandir)
     manifests = [manifestfn]
@@ -209,7 +209,8 @@ python do_archive_mel_layers () {
 
         l.setVar('S', subdir)
         source_date_epoch = oe.reproducible.get_source_date_epoch(l, parent or subdir)
-        pack_base, head = git_archive(subdir, objdir, parent, message, keep_paths, source_date_epoch)
+
+        head = git_archive(subdir, objdir, parent, message, keep_paths, source_date_epoch)
         if get_remotes:
             remotes = get_remotes(subdir, d) or {}
         else:
@@ -225,7 +226,10 @@ python do_archive_mel_layers () {
         else:
             fn = manifestfn
         manifestdata[fn].append('\t'.join([path, head] + ['%s=%s' % (k,v) for k,v in remotes.items()]) + '\n')
-        bb.process.run(['tar', '-cf', '%s.tar' % pack_base, 'objects/pack/%s.pack' % pack_base, 'objects/pack/%s.idx' % pack_base], cwd=outdir)
+        bb.process.run(['tar', '-cf', '%s.tar' % head, 'git-bundles/%s.bundle' % head], cwd=outdir)
+        os.unlink(os.path.join(objdir, '%s.bundle' % head))
+
+    os.rmdir(objdir)
 
     infofn = d.expand('%s/${MANIFEST_NAME}.info' % mandir)
     with open(infofn, 'w') as infofile:
@@ -242,7 +246,6 @@ python do_archive_mel_layers () {
         bb.process.run(['tar', '-cf', os.path.basename(fn) + '.tar'] + files, cwd=outdir)
 
     scripts = d.getVar('MEL_SCRIPTS_FILES').split()
-    bb.process.run(['rm', '-r', 'objects'], cwd=outdir)
     bb.process.run(['tar', '--transform=s,^,scripts/,', '--transform=s,^scripts/setup-mel,setup-mel,', '-cvf', d.expand('%s/${SCRIPTS_ARTIFACT_NAME}.tar' % outdir)] + scripts, cwd=d.getVar('WORKDIR'))
 }
 do_archive_mel_layers[dirs] = "${S}/do_archive_mel_layers ${S}"
@@ -318,11 +321,8 @@ def git_archive(subdir, outdir, parent=None, message=None, keep_paths=None, sour
         bb.process.run(['git', 'repack', '-a', '-d'], cwd=tmpdir)
         bb.process.run(['git', 'prune-packed'], cwd=tmpdir)
 
-        packdir = os.path.join(tmpdir, 'objects', 'pack')
-        packfiles = glob.glob(os.path.join(packdir, 'pack-*'))
-        base, ext = os.path.splitext(os.path.basename(packfiles[0]))
-        bb.process.run(['cp', '-f'] + packfiles + [outdir])
-        return base, head
+        bb.process.run(['git', 'bundle', 'create', os.path.join(outdir, '%s.bundle' % head), 'refs/packing'], cwd=tmpdir)
+        return head
 
 def checksummed_downloads(dl_by_layer_fn, dl_by_layer_dl_dir, dl_dir):
     with open(dl_by_layer_fn, 'r') as f:

--- a/scripts/release/mel-checkout
+++ b/scripts/release/mel-checkout
@@ -247,7 +247,12 @@ done | (
             fi
 
             cd "$checkout_path"
-            echo "$installdir/objects" >.git/objects/info/alternates
+            if [ -d "$installdir/objects" ]; then
+                echo "$installdir/objects" >.git/objects/info/alternates
+            fi
+            if [ -e "$installdir/git-bundles/$commit.bundle" ]; then
+                git bundle unbundle "$installdir/git-bundles/$commit.bundle" >/dev/null
+            fi
             echo "$commit" >.git/shallow
 
             echo "$remotes" | tr '\t' '\n' | while IFS== read -r name url; do
@@ -267,6 +272,9 @@ done | (
                     if [ "$other_checkout_path" = "$checkout_path" ]; then
                         branch="$(basename "${otherfn%.manifest}")"
                         if ! git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
+                            if [ -e "$installdir/git-bundles/$other_commit.bundle" ]; then
+                                git bundle unbundle "$installdir/git-bundles/$other_commit.bundle" >/dev/null
+                            fi
                             git update-ref "refs/heads/$branch" "$other_commit"
                         fi
                         echo "$other_commit" >>.git/shallow


### PR DESCRIPTION
Use SOURCE_DATE_EPOCH if needed to improve reproducibility of generated commits, and use bundles rather than pack files which give us consistent reproducible output and avoids file duplication between releases and updates.