### PR TITLE
mel: only support the tunings aligned with the external toolchain

### DIFF
--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -257,6 +257,11 @@ INHERIT += "resize-rootfs-gplv3"
 # Ensure that our DISTRO_CODENAME aligns with LAYERSERIES_CORENAMES
 INHERIT += "codename_is_corename"
 
+# Ensure we're building the toolchain in a supported configuration
+ERROR_QA:append = " disallowed-tuning"
+ALLOWED_TUNING = "armv5te armv7ahf-neon armv7a-neon armv7at armv8a i686 riscv64 x86-64"
+INHERIT += "required_toolchain_config"
+
 # Use our toolchain relocation scripts
 INHERIT += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-staging', 'toolchain_ship_relocate_sdk', '', d)}"
 TOOLCHAIN_SHAR_REL_TMPL = "${LAYERDIR_mentor-staging}/files/toolchain-shar-relocate.sh"

--- a/meta-mentor-common/classes/required_toolchain_config.bbclass
+++ b/meta-mentor-common/classes/required_toolchain_config.bbclass
@@ -1,0 +1,27 @@
+# Sanity test for allowed toolchain configurations
+#
+# Must be explicitly enabled both by configuring these variables and
+# adding 'disallowed-tuning' to your WARN_QA or ERROR_QA.
+ALLOWED_TUNING ?= "${DEFAULTTUNE}"
+DISALLOWED_TUNING ?= ""
+
+python required_tuning () {
+    def handle_error(error_class, error_msg, d):
+        if error_class in (d.getVar("ERROR_QA") or "").split():
+            bb.fatal("%s [%s]" % (error_msg, error_class))
+        elif error_class in (d.getVar("WARN_QA") or "").split():
+            bb.warn("%s [%s]" % (error_msg, error_class))
+        else:
+            bb.note("%s [%s]" % (error_msg, error_class))
+        return True
+
+    allowed = d.getVar('ALLOWED_TUNING')
+    disallowed = d.getVar('DISALLOWED_TUNING')
+    tuning = d.getVar('TUNE_PKGARCH')
+    if tuning in disallowed.split():
+        handle_error("disallowed-tuning", "TUNE_PKGARCH %s is disallowed by DISALLOWED_TUNING (%s)" % (tuning, disallowed), d)
+    elif allowed and tuning not in allowed:
+        handle_error("disallowed-tuning", "TUNE_PKGARCH %s is not allowed by ALLOWED_TUNING (%s)" % (tuning, allowed), d)
+}
+required_tuning[eventmask] = 'bb.event.SanityCheck'
+addhandler required_tuning


### PR DESCRIPTION
This aborts the MEL Flex build if the user is attempting to build a configuration which isn't one of the supported codebench toolchain configurations. This will keep internal toolchain builds aligned with external toolchain builds. It also means that attempts to build unsupported architectures like mips will fail at this time.