### PR TITLE
mel_utils/dump-downloads/dump-licenses: support multi-config scenarios

### DIFF
--- a/meta-mel/lib/bblayers/mel_utils.py
+++ b/meta-mel/lib/bblayers/mel_utils.py
@@ -252,7 +252,21 @@ class MELUtilsPlugin(LayerPlugin):
         omode = 'a' if args.append else 'w'
         with open(filename, omode) as f:
             for recipe in fetch_recipes:
-                fn = depgraph['pn'][recipe]['filename']
+                try:
+                    fn = depgraph['pn'][recipe]['filename']
+                except KeyError:
+                    mc = self.tinfoil.config_data.getVar('BBMULTICONFIG')
+                    if not mc:
+                        raise Exception("Could not find key '%s' in depgraph and no multiconfigs defined" % recipe)
+                    for cfg in mc.split():
+                        try:
+                            nkey = f"mc:{cfg}:{recipe}"
+                            fn = depgraph['pn'][nkey]['filename']
+                        except KeyError:
+                            continue
+                if not fn:
+                    raise Exception("Could not find recipe for '%s' in depgraph" % recipe)
+
                 real_fn, cls, mc = bb.cache.virtualfn2realfn(fn)
                 appends = self.tinfoil.get_file_appends(fn)
                 data = self.tinfoil.parse_recipe_file(fn, appendlist=appends)


### PR DESCRIPTION
For a single configuration build the dependency graph does
not contain any configuration prefixes and the implementation
handled it correctly with this assumption. However, in case of
a multiconfig build the components (PNs/recipes) get prefixed
with mc:<config>:component which is something not taken care of
and hence the download dumping fails with a KeyError. The most
recent failure was seen with TI Jacinto7 platform builds which
failed with

Traceback (most recent call last):
  File "/var/jenkins/workspace/mel_fir_singo_main_incremental/buildtype/mel/label/mel-u18-64/machine/j7-evm-aitronx/repotop/bitbake/bin/bitbake-layers", line 95, in <module>
    ret = main()
  File "/var/jenkins/workspace/mel_fir_singo_main_incremental/buildtype/mel/label/mel-u18-64/machine/j7-evm-aitronx/repotop/bitbake/bin/bitbake-layers", line 88, in main
    return args.func(args)
  File "/var/jenkins/workspace/mel_fir_singo_main_incremental/buildtype/mel/label/mel-u18-64/machine/j7-evm-aitronx/repotop/meta-mentor/meta-mel/lib/bblayers/mel_utils.py", line 215, in do_dump_downloads
    for layer, item in items:
  File "/var/jenkins/workspace/mel_fir_singo_main_incremental/buildtype/mel/label/mel-u18-64/machine/j7-evm-aitronx/repotop/meta-mentor/meta-mel/lib/bblayers/mel_utils.py", line 185, in _gather_downloads
    fn = depgraph['pn'][recipe]['filename']
KeyError: 'ti-sci-fw'

in this case the depgraph entry for the ti-sci-fw was

'ti-sci-fw': {'pn': 'mc:k3r5:ti-sci-fw', 'filename': 'mc:k3r5:/var/awais/flex/singgo_aitronx_dev/meta-ti/recipes-bsp/ti-sci-fw/ti-sci-fw_git.bb', 'version': ':2021.01a-r1_psdkla_2'}

we now specifically check for each config in the multiconfig if the
basic depgraph search fails to cater for the scenario.

JIRA: https://jira.alm.mentorg.com/browse/SB-19283

Signed-off-by: Awais Belal <awais_belal@mentor.com>