### PR TITLE
mel: work around safe dir issue with METADATA_*

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -350,6 +350,12 @@ MACHINE_HWCODECS = ""
 
 # Work around missing vardep bug in bitbake
 sstate_stage_all[vardeps] += "sstate_stage_dirs"
+
+# Work around git safe directory issue with METADATA_*, by forcing early expansion
+# while in a build user context.
+require classes/metadata_scm.bbclass
+METADATA_BRANCH := "${@base_detect_branch(d)}"
+METADATA_REVISION := "${@base_detect_revision(d)}"
 ## }}}1
 ## SDK & Application Development Environment {{{1
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not


### PR DESCRIPTION
With recent versions of git, attempting to operate on a git repository owned by
one user as another user will fail. As our builds run under pseudo in some
contexts, this fails. This issue in tasks can be worked around with a git
wrapper script, and is worked around upstream, but that does not resolve the
issue with metadata_scm.bbclass, as it isn't run with the correct PATH. It's a
non-issue upstream as they already made this change to force immediate expansion
of these variables in the right context, so apply that here also.

JIRA: SB-19344

Signed-off-by: Christopher Larson <chris_larson@mentor.com>
