### PR TITLE
mel-selftest: add distro for use with oe-selftest

### DIFF
--- a/meta-mel/conf/distro/include/no_sanity_distros.inc
+++ b/meta-mel/conf/distro/include/no_sanity_distros.inc
@@ -1,0 +1,4 @@
+python no_sanity_distros () {
+    d.delVar('SANITY_TESTED_DISTROS')
+}
+addhandler no_sanity_distros

--- a/meta-mel/conf/distro/mel-selftest.conf
+++ b/meta-mel/conf/distro/mel-selftest.conf
@@ -1,0 +1,15 @@
+require conf/distro/mel.conf
+
+DISTRO .= "-selftest"
+DISTRO_NAME += "Selftest"
+DISTROOVERRIDES = "${DISTRO}:mel"
+
+PREFERRED_PROVIDER_virtual/kernel:mel-selftest = "linux-dummy"
+
+# Remove configuration items incompatible with oe-selftest
+INHERIT:remove = "buildhistory rm_work"
+PRSERV_HOST = ""
+
+# Selftest demands that this not even exist in the metadata, so setting to the
+# empty string is insufficient
+require conf/distro/include/no_sanity_distros.inc


### PR DESCRIPTION
It's useful to be able to run oe-selftest with mel as well as with
nodistro, but elements of our configuration are incompatible, so add
a convenience distro to remove those elements.