### PR TITLE
96boards-tools: update to latest revision

### DIFF
--- a/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
+++ b/meta-mel-support/recipes-bsp/96boards-tools/96boards-tools_0.12.bb
@@ -9,7 +9,7 @@ SECTION = "devel"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-SRCREV = "a999d655417bb19ce8a476ff8c811e957748b661"
+SRCREV = "52ad42bb74ba4b3fcece2483f0d496494d60715f"
 SRC_URI = "git://github.com/96boards/96boards-tools;branch=master;protocol=https\
            file://resize-helper.sh.in"
 


### PR DESCRIPTION
This has some improvements like exact size/blocks calculation and
non-interactive parted command

JIRA-ID: SB-19428

Signed-off-by: Ahsan Hussain <ahsan_hussain@mentor.com>