### PR TITLE
ADE -> SDK

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -161,7 +161,7 @@ include conf/include/drop-toolchain-from-sdk.inc
 # We default to ipk:
 #PACKAGE_CLASSES ?= "package_ipk"
 
-# SDK/ADT target architecture
+# SDK target architecture
 #
 # Set to one of the mingw32 SDKMACHINEs to target Windows rather than Linux.
 # Warning: if you choose to add packages to TOOLCHAIN_HOST_TASK and target
@@ -173,31 +173,28 @@ include conf/include/drop-toolchain-from-sdk.inc
 # Uncomment to make populate_sdk write a tar file rather than a .sh installer
 #SDK_PACKAGING_FUNC = ""
 
-# By default, only include the target sysroot in the SDK/ADE, not host tools.
+# By default, only include the target sysroot in the SDK, not host tools.
 # Comment this line to change that. This packagegroup includes host tools like
-# autoconf, automake, etc. See the aforementioned warning about use of Windows
-# SDKMACHINE while setting TOOLCHAIN_HOST_TASK, if you're building a Windows
-# SDK/ADE.
+# autoconf, automake, etc.
 TOOLCHAIN_HOST_REMOVE ??= "nativesdk-packagegroup-sdk-host"
 TOOLCHAIN_HOST_TASK:remove = "${TOOLCHAIN_HOST_REMOVE}"
 
-# TOOLCHAIN_HOST_TASK is used to add host packages to the ADE/SDK, for
+# TOOLCHAIN_HOST_TASK is used to add host packages to the SDK, for
 # example, to add bash:
 #TOOLCHAIN_HOST_TASK_EXTRA += " nativesdk-bash"
 
-# TOOLCHAIN_TARGET_TASK is used to add target packages to the ADE/SDK, for
+# TOOLCHAIN_TARGET_TASK is used to add target packages to the SDK, for
 # example, to add libncurses:
 #TOOLCHAIN_TARGET_TASK_EXTRA += " ncurses-libncurses"
 
-# Uncomment to set a site name (shown in CodeBench) for the ADE
-# Default: ADE for ${ADE_IDENTIFIER}
-#ADE_SITENAME ?= "My Company's ADE for ${ADE_IDENTIFIER}"
+# Uncomment to set a title for the SDK
+# Default: SDK for ${SDK_IDENTIFIER}
+#SDK_TITLE ?= "My Company's SDK for ${SDK_IDENTIFIER}"
 
-# Uncomment to alter the identifier for the ADE. This mechanism is used to
-# support installation of multiple ADEs side-by-side. By default, every ADE
-# build gets its own identifier, so is self-contained already.
-# Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}
-#ADE_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${ADE_VERSION}.customized"
+# Uncomment to alter the identifier for the SDK. This mechanism is used to
+# isolate the SDK on disk, as well as the installers.
+# Default: ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}
+#SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}.customized"
 
 # The following is a list of additional classes to use when building which
 # enable extra features. Some available options which can be included in this variable

--- a/meta-mel-support/recipes-core/meta/codebench-makefile.bb
+++ b/meta-mel-support/recipes-core/meta/codebench-makefile.bb
@@ -1,0 +1,41 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2021 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+SUMMARY = "ADE Makefile Fragment for CodeBench"
+LICENSE = "MIT"
+INHIBIT_DEFAULT_DEPS = "1"
+
+S = "${WORKDIR}"
+
+ADE_PRE_BUILD_TARGET ?= ""
+ADE_POST_BUILD_TARGET ?= ""
+
+do_compile () {
+    cat <<END >environment-setup.mk
+PATH:=@SDKPATH@/sysroots/${SDK_SYS}${prefix_nativesdk}/bin:\$(PATH)
+-include @SDKPATH@/sysroots/${MULTIMACH_TARGET_SYS}/environment-setup.d/*.mk
+-include @SDKPATH@/sysroots/${SDK_SYS}/environment-setup.d/*.mk
+END
+
+    {
+        echo 'ADE_CUSTOM_MAKEFILE="sysroots/${MULTIMACH_TARGET_SYS}/environment-setup.mk"'
+        if [ -n "${ADE_PRE_BUILD_TARGET}" ]; then
+            echo 'PRE_BUILD_TARGET="${ADE_PRE_BUILD_TARGET}"'
+        fi
+        if [ -n "${ADE_POST_BUILD_TARGET}" ]; then
+            echo 'POST_BUILD_TARGET="${ADE_POST_BUILD_TARGET}"'
+        fi
+    } >${BPN}.sh
+}
+
+do_install () {
+    install -d ${D}/environment-setup.d
+    install -m 0644 environment-setup.mk ${D}/
+    install -m 0644 ${BPN}.sh ${D}/environment-setup.d/
+}
+
+FILES:${PN} += "/environment-setup.mk /environment-setup.d"

--- a/meta-mel-support/recipes-core/meta/nativesdk-relocate-makefile.bb
+++ b/meta-mel-support/recipes-core/meta/nativesdk-relocate-makefile.bb
@@ -1,0 +1,26 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2021 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+SUMMARY = "Relocate makefile fragments and environment-setup.d"
+LICENSE = "MIT"
+BASEDEPENDS = ""
+
+S = "${WORKDIR}"
+
+inherit nativesdk
+
+do_compile () {
+    echo '#!/bin/sh' >relocate.sh
+    echo 'for i in $1/sysroots/*/environment-setup.mk $1/sysroots/*/environment-setup.d/*.sh $1/sysroots/*/environment-setup.d/*.mk; do if [ -e "$i" ]; then sed -i -e "s,@SDKPATH@,$1,g" "$i"; fi; done' >>relocate.sh
+}
+
+do_install () {
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 relocate.sh ${D}${SDKPATHNATIVE}/post-relocate-setup.d/${BPN}.sh
+}
+
+FILES:${PN} += "${SDKPATHNATIVE}"

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -304,6 +304,10 @@ EXTERNAL_SETUP_SCRIPT_VARS += "REAL_MULTIMACH_TARGET_SYS"
 EXTERNAL_REAL_MULTIMACH_TARGET_SYS ??= "${REAL_MULTIMACH_TARGET_SYS}"
 CB_MBS_OPTIONS[general.yocto.sdk.value] = "${EXTERNAL_REAL_MULTIMACH_TARGET_SYS}"
 
+# Include metadata for CodeBench in the SDK
+SDKIMAGE_FEATURES:append = " codebench-metadata"
+IMAGE_CLASSES += "sdk_codebench_metadata"
+
 # This allows us to control what base target packages are installed for the
 # configured multilibs, by altering SDK_MULTILIB_VARIANTS to differ from
 # MULTILIB_VARIANTS. We also append meta-environment to obey

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -285,19 +285,19 @@ DEBUG_FLAGS:remove:pn-webkitgtk = "-g"
 SDK_DEPLOY:mel = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# Define a common identifier for a unique SDK, removing SDK_ARCH, switching from
-# TUNE_PKGARCH to MACHINE, and including image name and SDK version.
-SDK_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
-
-# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
-SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
-
 # Use distro rather than oecore
 SDK_NAME_PREFIX = "${DISTRO}"
 
 # Adjust installer name and default install path
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
 SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
+
+# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
+SDK_TITLE ?= "${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}"
+SDK_TITLE:task-populate-sdk-ext:mel = "${DISTRO_NAME} ${IMAGE_BASENAME} Extensible SDK for ${MACHINE}"
+
+# Define a common identifier for a unique SDK, to be set in CodeBench metadata
+SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -317,15 +317,11 @@ IMAGE_CLASSES += "image-sdk-multilib-variants"
 # Cull duplicate/invalid files for windows SDKMACHINEs
 IMAGE_CLASSES += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-staging', 'win_sdk_cull', '', d)}"
 
-# We need to ensure we can distribute downloads for SDK/ADE builds
+# We need to ensure we can distribute downloads for SDK builds
 IMAGE_CLASSES += "archive_sdk_downloads"
 
 # Create a 'latest' symlink for the SDK
 IMAGE_CLASSES += "sdk_latest_link"
-
-# If meta-mentor-private is available, pull in the populate-ade class
-ADE_IMAGE_CLASS = "${@bb.utils.contains('BBFILE_COLLECTIONS', 'mentor-private', 'populate_ade archive_ade_downloads', '', d)}"
-IMAGE_CLASSES += "${ADE_IMAGE_CLASS}"
 ## }}}1
 ## MEL Releases {{{1
 # Default image for our installers

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -11,7 +11,6 @@ MAINTAINER = "Siemens Digital Industries Software <embedded_support@mentor.com>"
 HOME_URL = "https://www.mentor.com/embedded-software/linux/mel-flex-os/"
 SUPPORT_URL = "https://support.sw.siemens.com/"
 BUG_REPORT_URL = "https://support.sw.siemens.com/"
-ADE_PROVIDER = "Siemens Digital Industries Software"
 TARGET_VENDOR = "-mel"
 SDK_VENDOR = "-melsdk"
 

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -285,10 +285,9 @@ DEBUG_FLAGS:remove:pn-webkitgtk = "-g"
 SDK_DEPLOY:mel = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# Define a common identifier for a unique SDK, switching from SDK_ARCH to
-# SDKMACHINE, from TUNE_PKGARCH to MACHINE, and including image name and the
-# version.
-SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
+# Define a common identifier for a unique SDK, removing SDK_ARCH, switching from
+# TUNE_PKGARCH to MACHINE, and including image name and SDK version.
+SDK_IDENTIFIER ?= "${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
 
 # Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
 SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
@@ -300,10 +299,10 @@ SDK_NAME_PREFIX = "${DISTRO}"
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
 SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
 
-# As we remove the toolchain from the sdk, naming it 'toolchain' is not #
+# As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include
 # SDK_VERSION in our SDK_NAME, so no need to duplicate it here.
-TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDK_NAME}"
+TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDKMACHINE}-${SDK_NAME}"
 
 # Restore the default to buildtools-tarball, as that recipe sets it with ?=
 TOOLCHAIN_OUTPUTNAME:pn-buildtools-tarball = "${SDK_ARCH}-buildtools-nativesdk-standalone-${DISTRO_VERSION}"

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -26,7 +26,7 @@ SCRIPTS_VERSION ?= "1"
 BSP_VERSION ?= "0"
 PATCH_VERSION ?= "0"
 
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
+SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('+snapshot-${DATE}','-snapshot')}"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -297,7 +297,7 @@ SDK_NAME_PREFIX = "${DISTRO}"
 
 # Adjust installer name and default install path
 SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
-SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}/sdk/${IMAGE_BASENAME}-${MACHINE}"
+SDKPATHINSTALL = "~/${DISTRO}/sdk/${SDK_VERSION}/${IMAGE_BASENAME}-${MACHINE}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -30,9 +30,6 @@ SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 
-SDK_NAME = "${DISTRO}-${TCLIBC}-${SDK_ARCH}-${IMAGE_BASENAME}-${TUNE_PKGARCH}"
-SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
-
 # This is a single libc DISTRO, so exclude it from tmpdir name
 TCLIBCAPPEND = ""
 
@@ -288,9 +285,25 @@ DEBUG_FLAGS:remove:pn-webkitgtk = "-g"
 SDK_DEPLOY:mel = "${DEPLOY_DIR_SDK}"
 DEPLOY_DIR_SDK ?= "${DEPLOY_DIR}/sdk"
 
-# As we remove the toolchain from the sdk, naming it 'toolchain' is not
-# accurate, and sdk better describes what it is anyway.
-TOOLCHAIN_OUTPUTNAME ?= "${SDK_NAME}-sdk-${SDK_VERSION}"
+# Define a common identifier for a unique SDK, switching from SDK_ARCH to
+# SDKMACHINE, from TUNE_PKGARCH to MACHINE, and including image name and the
+# version.
+SDK_IDENTIFIER ?= "${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}"
+
+# Set the SDK title. SDK_VERSION is left out, as it's explicitly shown in the installer
+SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
+
+# Use distro rather than oecore
+SDK_NAME_PREFIX = "${DISTRO}"
+
+# Use the SDK identifier
+SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
+SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
+
+# As we remove the toolchain from the sdk, naming it 'toolchain' is not #
+# accurate, and sdk better describes what it is anyway. We also include
+# SDK_VERSION in our SDK_NAME, so no need to duplicate it here.
+TOOLCHAIN_OUTPUTNAME ?= "sdk-${SDK_NAME}"
 
 # Restore the default to buildtools-tarball, as that recipe sets it with ?=
 TOOLCHAIN_OUTPUTNAME:pn-buildtools-tarball = "${SDK_ARCH}-buildtools-nativesdk-standalone-${DISTRO_VERSION}"

--- a/meta-mel/conf/distro/mel.conf
+++ b/meta-mel/conf/distro/mel.conf
@@ -295,9 +295,9 @@ SDK_TITLE ?= "SDK for ${IMAGE_BASENAME}-${MACHINE}"
 # Use distro rather than oecore
 SDK_NAME_PREFIX = "${DISTRO}"
 
-# Use the SDK identifier
-SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_IDENTIFIER}"
-SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}/${SDK_IDENTIFIER}"
+# Adjust installer name and default install path
+SDK_NAME = "${SDK_NAME_PREFIX}-${SDK_VERSION}-${IMAGE_BASENAME}-${MACHINE}"
+SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}/sdk/${IMAGE_BASENAME}-${MACHINE}"
 
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not
 # accurate, and sdk better describes what it is anyway. We also include

--- a/meta-mentor-common/classes/cb-mbs-options.bbclass
+++ b/meta-mentor-common/classes/cb-mbs-options.bbclass
@@ -1,0 +1,139 @@
+CB_MBS_OPTIONS ?= ""
+CB_MBS_OPTIONS_FEATURES_MAP ?= ""
+CB_MBS_OPTIONS_FLAGS_MAP ?= ""
+CB_MBS_OPTIONS_FLAGS_VALUE_MAP ?= ""
+
+CB_MBS_OPTIONS_CC_FLAGS_MAP ?= ""
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g] = "compiler*option.debugging.level=debugging.level.default"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g0] = "compiler*option.debugging.level=debugging.level.none"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g1] = "compiler*option.debugging.level=debugging.level.minimal"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-g3] = "compiler*option.debugging.level=debugging.level.max"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O0] = "compiler*option.optimization.level=optimization.level.none"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O1] = "compiler*option.optimization.level=optimization.level.optimize"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O2] = "compiler*option.optimization.level=optimization.level.more"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-O3] = "compiler*option.optimization.level=optimization.level.most"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-Os] = "compiler*option.optimization.level=optimization.level.size"
+CB_MBS_OPTIONS_CC_FLAGS_MAP[-Og] = "compiler*option.optimization.level=optimization.level.debug"
+
+CB_MBS_IGNORED_EXTRA_FLAGS ?= ""
+CB_MBS_IGNORED_EXTRA_FLAGS += "${@'-mcpu=* -march=* -mtune=*' if d.getVarFlag('CB_MBS_OPTIONS', 'general.cpu', expand=True) else ''}"
+CB_MBS_IGNORED_EXTRA_FLAGS += "${@'-mfpu=*' if d.getVarFlag('CB_MBS_OPTIONS', 'general.fpu', expand=True) else ''}"
+CB_MBS_IGNORED_EXTRA_FLAGS[doc] = "Arguments we don't want to include in the extra options, as they're already handled elsewhere."
+
+CB_MBS_IGNORED_FLAGS ?= ""
+CB_MBS_IGNORED_FLAGS[doc] = "General flag arguments we don't want to include."
+
+def cb_mbs_flag_vars(d):
+    import shlex
+    import subprocess
+    from fnmatch import fnmatchcase
+
+    l = d.createCopy()
+    l.finalize()
+    l.setVar('DEBUG_PREFIX_MAP', '')
+    l.setVar('STAGING_DIR_TARGET', '$SDKTARGETSYSROOT')
+
+    features = d.getVar('TUNE_FEATURES').split()
+    for feature, settings in (d.getVarFlags('CB_MBS_OPTIONS_FEATURES_MAP') or {}).items():
+        if feature.startswith('-'):
+            enabled = feature[1:] not in features
+        else:
+            enabled = feature in features
+        if enabled:
+            for setting in settings.split():
+                skey, svalue = setting.split('=', 1)
+                if setting and not d.getVarFlag('CB_MBS_OPTIONS', skey, False):
+                    d.setVarFlag('CB_MBS_OPTIONS', skey, svalue)
+
+    cflags = shlex.split(l.getVar('TARGET_CFLAGS', True))
+    cxxflags = shlex.split(l.getVar('TARGET_CXXFLAGS', True))
+    ldflags = shlex.split(l.getVar('TARGET_LDFLAGS', True))
+
+    ccargs = shlex.split(l.getVar('TARGET_CC_ARCH', True))
+    cflags.extend(ccargs)
+    cxxflags.extend(ccargs)
+    ldflags.extend(ccargs)
+
+    ignored = d.getVar('CB_MBS_IGNORED_FLAGS', True).split()
+    cflags = [a for a in cflags if not any(fnmatchcase(a, p) for p in ignored)]
+    cxxflags = [a for a in cxxflags if not any(fnmatchcase(a, p) for p in ignored)]
+    ldflags = [a for a in ldflags if not any(fnmatchcase(a, p) for p in ignored)]
+
+    check_cflags, check_cxxflags = list(cflags), list(cxxflags)
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_FLAGS_MAP') or {}).items():
+        for setting in settings.split():
+            skey, svalue = setting.split('=', 1)
+            if flag in check_cflags:
+                if flag in cflags:
+                    cflags.remove(flag)
+                if setting and not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                    d.setVarFlag('CB_MBS_OPTIONS', skey, svalue)
+
+            if flag in check_cxxflags:
+                if flag in cxxflags:
+                    cxxflags.remove(flag)
+                if setting and not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                    d.setVarFlag('CB_MBS_OPTIONS', skey, svalue)
+
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_FLAGS_VALUE_MAP') or {}).items():
+        for setting in settings.split():
+            skey, svalue = setting.split('=', 1)
+            for check_flag in check_cflags:
+                if check_flag.startswith(flag + '='):
+                    _, check_value = check_flag.split('=', 1)
+                    if check_flag in cflags:
+                        cflags.remove(check_flag)
+                    if setting and not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                        d.setVarFlag('CB_MBS_OPTIONS', skey, svalue + check_value)
+
+            for check_flag in check_cxxflags:
+                if check_flag.startswith(flag + '='):
+                    _, check_value = check_flag.split('=', 1)
+                    if check_flag in cxxflags:
+                        cxxflags.remove(check_flag)
+                    if setting and not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                        d.setVarFlag('CB_MBS_OPTIONS', skey, svalue + check_value)
+
+    for flag, settings in (d.getVarFlags('CB_MBS_OPTIONS_CC_FLAGS_MAP') or {}).items():
+        for setting in settings.split():
+            if flag in check_cflags:
+                if flag in cflags:
+                    cflags.remove(flag)
+                if setting:
+                    skey, svalue = setting.split('=', 1)
+                    skey = 'gnu.c.' + skey
+                    svalue = 'gnu.c.' + svalue
+                    if not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                        d.setVarFlag('CB_MBS_OPTIONS', skey, svalue)
+
+            if flag in check_cxxflags:
+                if flag in cxxflags:
+                    cxxflags.remove(flag)
+                if setting:
+                    skey, svalue = setting.split('=', 1)
+                    skey = 'gnu.cpp.' + skey
+                    svalue = 'gnu.cpp.compiler.' + svalue
+                    if not d.getVarFlag('CB_MBS_OPTIONS', skey, True):
+                        d.setVarFlag('CB_MBS_OPTIONS', skey, svalue)
+
+    ignored = d.getVar('CB_MBS_IGNORED_EXTRA_FLAGS', True).split()
+    cflags = [a for a in cflags if not any(fnmatchcase(a, p) for p in ignored)]
+    cxxflags = [a for a in cxxflags if not any(fnmatchcase(a, p) for p in ignored)]
+    ldflags = [a for a in ldflags if not any(fnmatchcase(a, p) for p in ignored)]
+
+    if cflags:
+        d.setVarFlag('CB_MBS_OPTIONS', 'gnu.c.compiler*option.misc.other', subprocess.list2cmdline(cflags))
+    if cxxflags:
+        d.setVarFlag('CB_MBS_OPTIONS', 'gnu.cpp.compiler*option.other.other', subprocess.list2cmdline(cxxflags))
+    if ldflags:
+        d.setVarFlag('CB_MBS_OPTIONS', 'gnu.c.link*option.ldflags', subprocess.list2cmdline(ldflags))
+        d.setVarFlag('CB_MBS_OPTIONS', 'gnu.cpp.link*option.flags', subprocess.list2cmdline(ldflags))
+
+    for option, value in d.getVarFlags('CB_MBS_OPTIONS').items():
+        value = d.expand(value)
+        if not value:
+            d.delVarFlag('CB_MBS_OPTIONS', option)
+        else:
+            # Force immediate expansion, so we use target overrides regardless
+            # of the context in which the flags are used
+            d.setVarFlag('CB_MBS_OPTIONS', option, value)

--- a/meta-mentor-common/classes/codebench-environment-setup-d-hack.bbclass
+++ b/meta-mentor-common/classes/codebench-environment-setup-d-hack.bbclass
@@ -1,0 +1,21 @@
+# Work around lack of support for environment-setup.d in CodeBench
+SDK_PACKAGING_COMMAND:prepend:sdk-codebench-metadata = "merge_environment_setup_d; add_no_sysroot_suffix;"
+
+merge_environment_setup_d() {
+    for setup_d in "${SDK_OUTPUT}${SDKPATH}/sysroots/"*/environment-setup.d; do
+        if [ -d "$setup_d" ]; then
+            for script in "${SDK_OUTPUT}${SDKPATH}/environment-setup-"*; do
+                find "$setup_d" -type f -print0 | xargs -0 cat >>"$script"
+            done
+            rm -rf "$setup_d"
+        fi
+    done
+}
+
+add_no_sysroot_suffix() {
+    # Codebench expects the --no-sysroot-suffix entries to be in the main
+    # variables, not the appended ones from external.sh
+    for script in "${SDK_OUTPUT}${SDKPATH}/environment-setup-"*; do
+        sed -i -e "/no-sysroot-suffix/d; /\(CC\|CXX\|CPP\|KCFLAGS\)/s/--sysroot=/--no-sysroot-suffix --sysroot=/g" "$script"
+    done
+}

--- a/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
@@ -1,7 +1,7 @@
 # Write additiional metadata for CodeBench to the SDK when codebench-metadata is
 # in SDKIMAGE_FEATURES.
 
-inherit sdk_extra_vars cb-mbs-options
+inherit sdk_extra_vars cb-mbs-options codebench-environment-setup-d-hack
 
 OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
 

--- a/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
@@ -1,0 +1,90 @@
+# Write additiional metadata for CodeBench to the SDK when codebench-metadata is
+# in SDKIMAGE_FEATURES.
+
+inherit sdk_extra_vars cb-mbs-options
+
+OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
+
+SOURCERY_VERSION ?= ""
+CODEBENCH_SDK_VARS += "\
+    MACHINE \
+    DISTRO \
+    DISTRO_NAME \
+    DISTRO_VERSION \
+    ADE_IDENTIFIER \
+    ADE_SITENAME \
+    ADE_VERSION \
+    gdb_serverpath=${bindir}/gdbserver \
+"
+CODEBENCH_SDK_VARS:append:tcmode-external-sourcery = "\
+    SOURCERY_VERSION \
+    TOOLCHAIN_VERSION=${@d.getVar('SOURCERY_VERSION').split('-', 1)[0]} \
+"
+EXTRA_SDK_VARS:append:sdk-codebench-metadata = " ${CODEBENCH_SDK_VARS}"
+SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench; write_codebench_metadata;"
+
+adjust_sdk_script_codebench () {
+    # Determine the script's location relative to itself rather than hardcoding it
+    script=${SDK_OUTPUT}/${SDKPATH}/environment-setup-${REAL_MULTIMACH_TARGET_SYS}
+    cat >"${script}.new" <<END
+if [ -n "\$BASH_SOURCE" ] || [ -n "\$ZSH_NAME" ]; then
+    if [ -n "\$BASH_SOURCE" ]; then
+        scriptdir="\$(cd "\$(dirname "\$BASH_SOURCE")" && pwd)"
+    elif [ -n "\$ZSH_NAME" ]; then
+        scriptdir="\$(cd "\$(dirname "\$0")" && pwd)"
+    fi
+else
+    if [ ! -d "${SDKPATH}" ]; then
+        echo >&2 "Warning: Unable to determine SDK install path from environment setup script location, using default of ${SDKPATH}."
+    fi
+    scriptdir="${SDKPATH}"
+fi
+END
+    sed -e "s#${SDKPATH}#\$scriptdir#g" "$script" >>"${script}.new"
+    mv "${script}.new" "${script}"
+
+    # Add variables from SDK_EXTRA_VARS
+    cat <<END >>"$script"
+${@sdk_extra_var_lines(d)}
+END
+}
+
+python write_codebench_metadata () {
+    localdata = bb.data.createCopy(d)
+
+    # make sure we only use the WORKDIR value from 'd', or it can change
+    localdata.setVar('WORKDIR', d.getVar('WORKDIR'))
+
+    # make sure we only use the SDKTARGETSYSROOT value from 'd'
+    localdata.setVar('SDKTARGETSYSROOT', d.getVar('SDKTARGETSYSROOT'))
+    localdata.setVar('libdir', d.getVar('target_libdir', False))
+
+    write_cb_mbs_options(localdata, localdata.expand('${SDK_OUTPUT}/${SDKPATH}/cb-mbs-options-${REAL_MULTIMACH_TARGET_SYS}'))
+
+    if not d.getVar("MLPREFIX"):
+        variants = d.getVar("MULTILIB_VARIANTS") or ""
+        for item in variants.split():
+            ld2 = localdata.createCopy()
+            # Load overrides from 'd' to avoid having to reset the value...
+            overrides = d.getVar("OVERRIDES", False) + ":virtclass-multilib-" + item
+            ld2.setVar("OVERRIDES", overrides)
+            ld2.setVar("MLPREFIX", item + "-")
+
+            write_cb_mbs_options(ld2, ld2.expand('${SDK_OUTPUT}/${SDKPATH}/cb-mbs-options-${REAL_MULTIMACH_TARGET_SYS}'))
+}
+write_codebench_metadata[vardepsexclude] += "OVERRIDES"
+
+def write_cb_mbs_options(d, optionsfile):
+    # We don't care about flags like debugging, optimization. TUNE_CCARGS is
+    # already covered.
+    l = d.createCopy()
+    l.setVar('TARGET_CFLAGS', '')
+    l.setVar('TARGET_CXXFLAGS', '')
+    l.setVar('TARGET_LDFLAGS', '')
+    options = get_cb_options(l)
+    bb.utils.mkdirhier(os.path.dirname(optionsfile))
+    with open(optionsfile, 'w') as f:
+        f.writelines('%s=%s\n' % (k, d.expand(v)) for k, v in sorted(options.items()))
+
+write_cb_mbs_options[vardeps] += "${@' '.join('CB_MBS_OPTIONS[%s]' % f for f in (d.getVarFlags('CB_MBS_OPTIONS') or []))}"
+

--- a/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
@@ -11,6 +11,9 @@ TOOLCHAIN_HOST_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFI
 TOOLCHAIN_TARGET_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'mel-support', 'codebench-makefile', '', d)}"
 
 SOURCERY_VERSION ?= ""
+SDK_IDENTIFIER ?= "${SDK_NAME}"
+ADE_IDENTIFIER ?= "${SDK_IDENTIFIER}"
+ADE_SITENAME ?= "${SDK_TITLE}"
 CODEBENCH_SDK_VARS += "\
     MACHINE \
     DISTRO \
@@ -18,7 +21,7 @@ CODEBENCH_SDK_VARS += "\
     DISTRO_VERSION \
     ADE_IDENTIFIER \
     ADE_SITENAME \
-    ADE_VERSION \
+    ADE_VERSION=${SDK_VERSION} \
     gdb_serverpath=${bindir}/gdbserver \
 "
 CODEBENCH_SDK_VARS:append:tcmode-external-sourcery = "\

--- a/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
+++ b/meta-mentor-common/classes/sdk_codebench_metadata.bbclass
@@ -5,6 +5,11 @@ inherit sdk_extra_vars cb-mbs-options codebench-environment-setup-d-hack
 
 OVERRIDES =. "${@bb.utils.contains('SDKIMAGE_FEATURES', 'codebench-metadata', 'sdk-codebench-metadata:', '', d)}"
 
+SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench; write_codebench_metadata;"
+
+TOOLCHAIN_HOST_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'mel-support', 'nativesdk-relocate-makefile', '', d)}"
+TOOLCHAIN_TARGET_TASK:append:sdk-codebench-metadata = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'mel-support', 'codebench-makefile', '', d)}"
+
 SOURCERY_VERSION ?= ""
 CODEBENCH_SDK_VARS += "\
     MACHINE \
@@ -21,7 +26,7 @@ CODEBENCH_SDK_VARS:append:tcmode-external-sourcery = "\
     TOOLCHAIN_VERSION=${@d.getVar('SOURCERY_VERSION').split('-', 1)[0]} \
 "
 EXTRA_SDK_VARS:append:sdk-codebench-metadata = " ${CODEBENCH_SDK_VARS}"
-SDK_POSTPROCESS_COMMAND:prepend:sdk-codebench-metadata = "adjust_sdk_script_codebench; write_codebench_metadata;"
+
 
 adjust_sdk_script_codebench () {
     # Determine the script's location relative to itself rather than hardcoding it

--- a/meta-mentor-common/classes/sdk_extra_vars.bbclass
+++ b/meta-mentor-common/classes/sdk_extra_vars.bbclass
@@ -1,0 +1,32 @@
+# In most cases, it's better to use environment-setup.d for this, but there
+# are cases where it's useful to add to the main env setup script.
+
+EXTRA_SDK_VARS ?= ""
+EXTRA_EXPORTED_SDK_VARS ?= ""
+EXTRA_SDK_LINES ?= ""
+
+def sdk_extra_var_lines(d):
+    lines = []
+    for var in d.getVar('EXTRA_SDK_VARS', True).split():
+        try:
+            var, shvar = var.split(':', 1)
+        except ValueError:
+            shvar = var
+        lines.append('%s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+    for var in d.getVar('EXTRA_EXPORTED_SDK_VARS', True).split():
+        try:
+            var, shvar = var.split(':', 1)
+        except ValueError:
+            shvar = var
+        lines.append('export %s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+    extra_lines = d.getVar('EXTRA_SDK_LINES', True).replace('\\n', '\n').split('\n')
+    lines.extend(extra_lines)
+    return '\n'.join(lines)
+
+toolchain_shared_env_script:append () {
+    cat <<END >>"$script"
+${@sdk_extra_var_lines(d)}
+END
+}

--- a/meta-mentor-common/classes/sdk_extra_vars.bbclass
+++ b/meta-mentor-common/classes/sdk_extra_vars.bbclass
@@ -9,17 +9,34 @@ def sdk_extra_var_lines(d):
     lines = []
     for var in d.getVar('EXTRA_SDK_VARS', True).split():
         try:
-            var, shvar = var.split(':', 1)
+            var, value = var.rsplit('=', 1)
+        except ValueError:
+            value = None
+
+        try:
+            var, shvar = var.rsplit(':', 1)
         except ValueError:
             shvar = var
-        lines.append('%s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+        if value is None:
+            value = d.getVar(var) or ""
+
+        lines.append('%s="%s"' % (shvar, value))
 
     for var in d.getVar('EXTRA_EXPORTED_SDK_VARS', True).split():
         try:
-            var, shvar = var.split(':', 1)
+            var, value = var.rsplit('=', 1)
+        except ValueError:
+            value = None
+
+        try:
+            var, shvar = var.rsplit(':', 1)
         except ValueError:
             shvar = var
-        lines.append('export %s="%s"' % (shvar, d.getVar(var, True) or ""))
+
+        if value is None:
+            value = d.getVar(var) or ""
+        lines.append('export %s="%s"' % (shvar, value))
 
     extra_lines = d.getVar('EXTRA_SDK_LINES', True).replace('\\n', '\n').split('\n')
     lines.extend(extra_lines)


### PR DESCRIPTION
- Use SDK naming
- Align with Yocto SDK
- Pull SDK enhancements and CodeBench metadata generation from other layers
- More pleasant title, aligned with upstream: `ADE for ${SDKMACHINE}-${IMAGE_BASENAME}-${MACHINE}-${SDK_VERSION}` -> `${DISTRO_NAME} ${IMAGE_BASENAME} SDK for ${MACHINE}`

JIRA: MELMR-1143