### PR TITLE
Allow bblayers.conf to affect our bb-determine-layers script

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -142,6 +142,7 @@ def process_arguments(cmdline_args):
     parser.add_argument('-m', '--machine', help='add layer(s) providing the specified MACHINE')
     parser.add_argument('-d', '--distro', help='add layer(s) providing the specified DISTRO')
     parser.add_argument('-s', '--sdkmachine', help='add layer(s) providing the specified SDKMACHINE')
+    parser.add_argument('-c', '--config-file', help='load a bitbake config file prior to the layer.conf')
     parser.add_argument('-v', '--verbose', help='increase verbosity', action='store_true')
 
     scriptdir = os.path.dirname(__file__)
@@ -460,6 +461,8 @@ def determine_layers(cmdline_opts):
 
     data = bb.data.init()
     bb.parse.init_parser(data)
+    if args.config_file:
+        data = bb.parse.handle(args.config_file, data, include=True)
 
     all_layers = Layers()
     with status('Parsing layer configuration files'):

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -120,7 +120,6 @@ configure_builddir () {
     sed -i -e"s/^#*MACHINE *?*=.*/MACHINE ??= \"$MACHINE\"/" $BUILDDIR/conf/local.conf
     sed -n -i -e "s|##COREBASE##|$OEROOT|g" -e '/^BBLAYERS /{ :start; /\\$/{n; b start}; d; }; p' -e "/BBFILE_PRIORITY/d" $BUILDDIR/conf/bblayers.conf
 
-    echo 'BBLAYERS ?= "\' >> $BUILDDIR/conf/bblayers.conf
     layersfile="$tmpdir/layers"
 
     # Convert layer paths to layer names for bb-determine-layers
@@ -142,13 +141,15 @@ configure_builddir () {
         updatelayernames="$updatelayernames $layer"
     done
 
-    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" -m "$MACHINE" -d "$DISTRO" "$@" >$layersfile
+    $layerdir/scripts/bb-determine-layers -g "$layerpaths" -l "$CORELAYERS $extralayernames" -o "$EXTRAMELLAYERS $OPTIONALLAYERS" -e "$updatelayernames" -O "$layer_priority_overrides" -m "$MACHINE" -d "$DISTRO" -c "$BUILDDIR/conf/bblayers.conf" "$@" >$layersfile
     if [ $? -ne 0 ]; then
         echo >&2 "Error in execution of bb-determine-layers, aborting"
         return 1
     fi
+
+    echo 'BBLAYERS ?= "\' >>$BUILDDIR/conf/bblayers.conf
     sed -e "s#^$BUILDDIR/#\${TOPDIR}/#g;" -e 's,^,    ,; s,$, \\,' <$layersfile >>$BUILDDIR/conf/bblayers.conf
-    echo '"' >> $BUILDDIR/conf/bblayers.conf
+    echo '"' >>$BUILDDIR/conf/bblayers.conf
     configured_layers="$(PATH="$OEROOT/scripts:$BITBAKEDIR/bin:$PATH" $(dirname "$0")/bb-print-layer-data $(cat $layersfile) 2>/dev/null | cut -d: -f1 | xargs)"
 
     echo "$layer_priority_overrides" | tr " " "\n" | \


### PR DESCRIPTION
This aligns with the behavior of bitbake itself and allows for us to use this mechanism to pull in additional layers whenever a vendor BSP layer is included, so we can apply necessary integration changes.

JIRA: MELMR-1099

Example usage in our bblayers.conf.sample:
```bitbake
# BSP Integration Layers
LAYERRECOMMENDS_meta-polarfire-soc-yocto-bsp:append = " mentor-vendor-polarfire-soc"
```