### PR TITLE
bb-determine-layers: use common data for all parsed layer.conf files (dunfell)

### DIFF
--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -491,6 +491,8 @@ def determine_layers(cmdline_opts):
                     sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
                 else:
                     found.update(layers)
+            else:
+                sys.exit("Layer `{0}` was not found".format(name))
 
         s.set_layer_status(found)
         configured_layers |= found

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -182,6 +182,12 @@ class LayerError(Exception):
     pass
 
 
+class NamedLayerError(Exception):
+    def __init__(self, layer_name, *args):
+        super().__init__(*args)
+        self.name = layer_name
+
+
 class Layer(object):
     def __init__(self, path, confpath, name, version, priority, pattern, depends, recommends):
         self.path = os.path.realpath(path)
@@ -224,20 +230,23 @@ class Layer(object):
             l = Layer(layer_path, lconf, name, 0, 0, None, {})
             layers.append(l)
 
+        errors = []
         for name in bbfile_collections:
-            pattern = ldata.getVar('BBFILE_PATTERN_%s' % name, True)
-            priority = ldata.getVar('BBFILE_PRIORITY_%s' % name, True) or 0
-            depends = ldata.getVar('LAYERDEPENDS_%s' % name, True) or ''
-            version = ldata.getVar('LAYERVERSION_%s' % name, True)
-            depends = bb.utils.explode_dep_versions2(depends)
-            recommends = ldata.getVar('LAYERRECOMMENDS_%s' % name, True) or ''
-            recommends = bb.utils.explode_dep_versions2(recommends)
+            try:
+                pattern = ldata.getVar('BBFILE_PATTERN_%s' % name, True)
+                priority = ldata.getVar('BBFILE_PRIORITY_%s' % name, True) or 0
+                depends = ldata.getVar('LAYERDEPENDS_%s' % name, True) or ''
+                version = ldata.getVar('LAYERVERSION_%s' % name, True)
+                depends = bb.utils.explode_dep_versions2(depends)
+                recommends = ldata.getVar('LAYERRECOMMENDS_%s' % name, True) or ''
+                recommends = bb.utils.explode_dep_versions2(recommends)
+                l = Layer(layer_path, lconf, name, version, int(priority), pattern, depends, recommends)
+            except BaseException as exc:
+                errors.append(NamedLayerError(name, exc))
+            else:
+                layers.append(l)
 
-            l = Layer(layer_path, lconf, name, version, int(priority), pattern, depends, recommends)
-            layers.append(l)
-
-        if layers:
-            return layers
+        return layers, errors
 
 
 class Layers(collections.abc.MutableSet):
@@ -287,7 +296,10 @@ class Layers(collections.abc.MutableSet):
         if layerpath in self.by_path:
             return
 
-        self |= Layer.from_layerpath(layerpath, data)
+        layers, errors = Layer.from_layerpath(layerpath, data)
+        if layers:
+            self |= layers
+        return errors
 
     def discard(self, layer):
         self.layers.discard(layer)
@@ -478,7 +490,13 @@ def determine_layers(cmdline_opts):
     with StatusDisplay('Parsing layer configuration files', quiet=args.quiet):
         for layer_path in layer_paths:
             try:
-                all_layers.add_from_path(layer_path, data)
+                errors = all_layers.add_from_path(layer_path, data)
+                if errors and not args.quiet:
+                    for error in errors:
+                        if error.name in args.layers:
+                            sys.exit('Error parsing layer {} at {}: {}'.format(error.name, layer_path, error))
+                        else:
+                            sys.stderr.write('Warning: error parsing layer {} at {}\n'.format(error.name, layer_path))
             except LayerError as exc:
                 if not args.quiet:
                     sys.stderr.write('Warning: error parsing layer at {}\n'.format(layer_path))

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -208,23 +208,33 @@ class Layer(object):
         return hash(repr(self))
 
     @staticmethod
-    def from_layerpath(layer_path, data=None):
-        layers = []
-
+    def parse_layerpath(layer_path, data=None):
         if data is None:
             data = bb.data.init()
             bb.parse.init_parser(data)
 
         lconf = os.path.join(layer_path, 'conf', 'layer.conf')
-        ldata = data.createCopy()
-        ldata.setVar('LAYERDIR', layer_path)
+        data.setVar('LAYERDIR', layer_path)
+        initial_collections = set((data.getVar('BBFILE_COLLECTIONS', True) or '').split())
         try:
-            ldata = bb.parse.handle(lconf, ldata, include=True)
+            data = bb.parse.handle(lconf, data, include=True)
         except BaseException as exc:
             raise LayerError(exc)
+
+        ldata = data.createCopy()
+        ldata.expandVarref('LAYERDIR')
+        bbfile_collections = set((ldata.getVar('BBFILE_COLLECTIONS', True) or '').split())
+        return data, bbfile_collections - initial_collections
+
+    @staticmethod
+    def from_parsed(layer_path, layer_data, bbfile_collections):
+        layers = []
+        lconf = os.path.join(layer_path, 'conf', 'layer.conf')
+
+        ldata = layer_data.createCopy()
+        ldata.setVar('LAYERDIR', layer_path)
         ldata.expandVarref('LAYERDIR')
 
-        bbfile_collections = (ldata.getVar('BBFILE_COLLECTIONS', True) or '').split()
         if not bbfile_collections:
             name = os.path.basename(layer_path)
             l = Layer(layer_path, lconf, name, 0, 0, None, {})
@@ -247,6 +257,11 @@ class Layer(object):
                 layers.append(l)
 
         return layers, errors
+
+    @classmethod
+    def from_layerpath(cls, layer_path, layer_data=None):
+        data, collections = cls.parse_layerpath(layer_path, layer_data)
+        return cls.from_parsed(layer_path, layer_data, collections)
 
 
 class Layers(collections.abc.MutableSet):
@@ -487,19 +502,34 @@ def determine_layers(cmdline_opts):
     bb.parse.init_parser(data)
 
     all_layers = Layers()
+    collections = {}
     with StatusDisplay('Parsing layer configuration files', quiet=args.quiet):
         for layer_path in layer_paths:
             try:
-                errors = all_layers.add_from_path(layer_path, data)
-                if errors and not args.quiet:
-                    for error in errors:
-                        if error.name in args.layers:
-                            sys.exit('Error parsing layer {} at {}: {}'.format(error.name, layer_path, error))
-                        else:
-                            sys.stderr.write('Warning: error parsing layer {} at {}\n'.format(error.name, layer_path))
+                data, names = Layer.parse_layerpath(layer_path, data)
+                collections[layer_path] = names
             except LayerError as exc:
                 if not args.quiet:
                     sys.stderr.write('Warning: error parsing layer at {}\n'.format(layer_path))
+
+    with StatusDisplay('Processing layers', quiet=args.quiet):
+        for layer_path in layer_paths:
+            if layer_path not in collections:
+                continue
+
+            names = collections[layer_path]
+            try:
+                layers, errors = Layer.from_parsed(layer_path, data, names)
+                all_layers |= layers
+                if errors and not args.quiet:
+                    for error in errors:
+                        if error.name in args.layers:
+                            sys.exit('Error processing layer {} at {}: {}'.format(error.name, layer_path, error))
+                        else:
+                            sys.stderr.write('Warning: error processing layer {} at {}\n'.format(error.name, layer_path))
+            except LayerError as exc:
+                if not args.quiet:
+                    sys.stderr.write('Warning: error processing layer at {}\n'.format(layer_path))
 
     for layer in list(all_layers):
         if layer.name in args.excluded_layers:

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -57,16 +57,18 @@ def find(dir, dirfilter=None, **walkoptions):
 class StatusDisplay(object):
     """Show the user what we're doing, and whether we succeed"""
 
-    def __init__(self, message, output=None):
+    def __init__(self, message, output=None, quiet=False):
         self.message = message
         if output is None:
             output = sys.stderr
         self.output = output
+        self.quiet = quiet
         self.finished = False
 
     def __enter__(self):
-        self.output.write('{}..'.format(self.message))
-        self.output.flush()
+        if not self.quiet:
+            self.output.write('{}..'.format(self.message))
+            self.output.flush()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -75,21 +77,24 @@ class StatusDisplay(object):
 
         if not exc_type:
             self.set_status('done')
-        elif isinstance(exc_value, KeyboardInterrupt):
-            self.set_status('interrupted')
-        elif isinstance(exc_value, Terminate):
-            self.set_status('terminated')
         else:
-            self.set_status('failed')
+            if self.quiet:
+                self.quiet = False
+                self.__enter__()
+
+            if isinstance(exc_value, KeyboardInterrupt):
+                self.set_status('interrupted')
+            elif isinstance(exc_value, Terminate):
+                self.set_status('terminated')
+            else:
+                self.set_status('failed')
 
     def set_status(self, finishmessage):
         if self.finished:
             raise Exception("Status is already finished")
-        self.output.write('.' + finishmessage + '\n')
+        if not self.quiet:
+            self.output.write('.' + finishmessage + '\n')
         self.finished = True
-
-
-status = StatusDisplay
 
 
 class DictArgument(object):
@@ -146,6 +151,7 @@ def process_arguments(cmdline_args):
     parser.add_argument('-m', '--machine', help='add layer(s) providing the specified MACHINE')
     parser.add_argument('-d', '--distro', help='add layer(s) providing the specified DISTRO')
     parser.add_argument('-s', '--sdkmachine', help='add layer(s) providing the specified SDKMACHINE')
+    parser.add_argument('-q', '--quiet', help='quiet mode, show no status/progress information', action='store_true')
     parser.add_argument('-v', '--verbose', help='increase verbosity', action='store_true')
 
     scriptdir = os.path.dirname(__file__)
@@ -385,11 +391,14 @@ class DuplicateLayers(Exception):
 class LayerStatus(StatusDisplay):
     """Show status of work whose results are a set of layers."""
 
-    def __init__(self, message, verbose=False, output=None):
-        super(LayerStatus, self).__init__(message, output)
+    def __init__(self, message, verbose=False, output=None, quiet=False):
+        super(LayerStatus, self).__init__(message, output, quiet)
         self.verbose = verbose
 
     def set_layer_status(self, layers):
+        if self.quiet:
+            return
+
         layer_names = set(l.name for l in layers)
         if self.verbose:
             self.set_status('')
@@ -426,8 +435,8 @@ def get_layerpaths_bitbake(globs=None, paths=None):
 
 
 
-def get_layers_for(all_layers, value, varname, cfgpath, verbose=False):
-    with LayerStatus("Determining layers to include for {0} '{1}'".format(varname, value), verbose=verbose) as s:
+def get_layers_for(all_layers, value, varname, cfgpath, verbose=False, quiet=False):
+    with LayerStatus("Determining layers to include for {0} '{1}'".format(varname, value), verbose=verbose, quiet=quiet) as s:
         layers = all_layers.which('conf/{0}/{1}.conf'.format(cfgpath, value))
         if not layers:
             sys.exit("No layer found for {0} `{1}`".format(varname, value))
@@ -448,7 +457,7 @@ def determine_layers(cmdline_opts):
     args = process_arguments(cmdline_opts)
     args.layers.append('core')
 
-    with status('Locating layers and bitbake'):
+    with StatusDisplay('Locating layers and bitbake', quiet=args.quiet):
         layer_paths, bitbake_path = get_layerpaths_bitbake(args.globs, args.paths)
         if bitbake_path is not None:
             os.environ['PATH'] += ':' + bitbake_path
@@ -466,12 +475,13 @@ def determine_layers(cmdline_opts):
     bb.parse.init_parser(data)
 
     all_layers = Layers()
-    with status('Parsing layer configuration files'):
+    with StatusDisplay('Parsing layer configuration files', quiet=args.quiet):
         for layer_path in layer_paths:
             try:
                 all_layers.add_from_path(layer_path, data)
             except LayerError as exc:
-                sys.stderr.write('Warning: error parsing layer at {}\n'.format(layer_path))
+                if not args.quiet:
+                    sys.stderr.write('Warning: error parsing layer at {}\n'.format(layer_path))
 
     for layer in list(all_layers):
         if layer.name in args.excluded_layers:
@@ -482,7 +492,7 @@ def determine_layers(cmdline_opts):
                 layer.priority = priority_override
 
     configured_layers = Layers()
-    with LayerStatus('Checking for base layers', verbose=args.verbose) as s:
+    with LayerStatus('Checking for base layers', verbose=args.verbose, quiet=args.quiet) as s:
         found = set()
         for name in args.layers:
             if name in all_layers.by_name:
@@ -507,13 +517,14 @@ def determine_layers(cmdline_opts):
         configured_layers |= get_layers_for(all_layers, args.sdkmachine, 'SDKMACHINE', 'machine-sdk', args.verbose)
 
     if args.optional_layers:
-        with LayerStatus('Checking for optional layers', verbose=args.verbose) as s:
+        with LayerStatus('Checking for optional layers', verbose=args.verbose, quiet=args.quiet) as s:
             found_optional = set()
             for name in args.optional_layers:
                 if name in all_layers.by_name:
                     layers, missing_layers = all_layers.get_by_name_recursive(name)
                     if missing_layers:
-                        sys.stderr.write("Warning: optional layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
+                        if not args.quiet:
+                            sys.stderr.write("Warning: optional layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
                     else:
                         found_optional.update(layers)
 
@@ -522,7 +533,7 @@ def determine_layers(cmdline_opts):
             configured_layers |= found_optional
 
     if args.extra_layers:
-        with LayerStatus('Checking for extra layers', verbose=args.verbose) as s:
+        with LayerStatus('Checking for extra layers', verbose=args.verbose, quiet=args.quiet) as s:
             found_extra = set()
             for name in args.extra_layers:
                 if name in all_layers.by_name:

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -463,6 +463,20 @@ def determine_layers(cmdline_opts):
                 sys.exit("Dependent layers `{0}` not found for requested layer `{1}`".format(', '.join(missing_layers), name))
             configured_layers |= layers
 
+    if args.layers:
+        with LayerStatus('Checking for base layers', verbose=args.verbose) as s:
+            found = set()
+            for name in args.layers:
+                if name in all_layers.by_name:
+                    layers, missing_layers = all_layers.get_by_name_recursive(name)
+                    if missing_layers:
+                        sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
+                    else:
+                        found.update(layers)
+
+            s.set_layer_status(found)
+            configured_layers |= found
+
     if args.optional_layers:
         with LayerStatus('Checking for optional layers', verbose=args.verbose) as s:
             found_optional = set()

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -446,6 +446,7 @@ def get_layers_for(all_layers, value, varname, cfgpath, verbose=False):
 
 def determine_layers(cmdline_opts):
     args = process_arguments(cmdline_opts)
+    args.layers.append('core')
 
     with status('Locating layers and bitbake'):
         layer_paths, bitbake_path = get_layerpaths_bitbake(args.globs, args.paths)
@@ -481,19 +482,18 @@ def determine_layers(cmdline_opts):
                 layer.priority = priority_override
 
     configured_layers = Layers()
-    if args.layers:
-        with LayerStatus('Checking for base layers', verbose=args.verbose) as s:
-            found = set()
-            for name in args.layers:
-                if name in all_layers.by_name:
-                    layers, missing_layers = all_layers.get_by_name_recursive(name)
-                    if missing_layers:
-                        sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
-                    else:
-                        found.update(layers)
+    with LayerStatus('Checking for base layers', verbose=args.verbose) as s:
+        found = set()
+        for name in args.layers:
+            if name in all_layers.by_name:
+                layers, missing_layers = all_layers.get_by_name_recursive(name)
+                if missing_layers:
+                    sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
+                else:
+                    found.update(layers)
 
-            s.set_layer_status(found)
-            configured_layers |= found
+        s.set_layer_status(found)
+        configured_layers |= found
 
     if args.distro and args.distro != 'nodistro':
         configured_layers |= get_layers_for(all_layers, args.distro, 'DISTRO', 'distro', args.verbose)

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -177,19 +177,20 @@ class LayerError(Exception):
 
 
 class Layer(object):
-    def __init__(self, path, confpath, name, version, priority, pattern, depends):
+    def __init__(self, path, confpath, name, version, priority, pattern, depends, recommends):
         self.path = os.path.realpath(path)
         self.confpath = os.path.realpath(confpath)
         self.name = name
         self.version = version
         self.priority = priority
         self.depends = depends
+        self.recommends = recommends
         self.missingdeps = set()
         self.pattern = pattern
 
     def __repr__(self):
         return '{0.__class__.__name__}({0.path!r}, {0.confpath!r},' \
-               '{0.name!r}, {0.version!r}, {0.priority!r}, {0.pattern!r}, {0.depends!r})'.format(self)
+               '{0.name!r}, {0.version!r}, {0.priority!r}, {0.pattern!r}, {0.depends!r}, {0.recommends!r})'.format(self)
 
     def __hash__(self):
         return hash(repr(self))
@@ -223,8 +224,10 @@ class Layer(object):
             depends = ldata.getVar('LAYERDEPENDS_%s' % name, True) or ''
             version = ldata.getVar('LAYERVERSION_%s' % name, True)
             depends = bb.utils.explode_dep_versions2(depends)
+            recommends = ldata.getVar('LAYERRECOMMENDS_%s' % name, True) or ''
+            recommends = bb.utils.explode_dep_versions2(recommends)
 
-            l = Layer(layer_path, lconf, name, version, int(priority), pattern, depends)
+            l = Layer(layer_path, lconf, name, version, int(priority), pattern, depends, recommends)
             layers.append(l)
 
         if layers:
@@ -300,13 +303,16 @@ class Layers(collections.abc.MutableSet):
                 layers.append(layer)
         return layers
 
-    def get_by_name_recursive(self, name):
+    def get_by_name_recursive(self, name, include_recs=True, indirect_recs=False):
         """Get a layer by name and its dependencies, recursively.
 
         Returns a Layers() collection, and a list of missing dependencies."""
 
         missing = set()
         found_layers = Layers()
+
+        if not include_recs:
+            indirect_recs = False
 
         if name in self.duplicates:
             raise DuplicateLayers(name, self.duplicates[name])
@@ -319,7 +325,7 @@ class Layers(collections.abc.MutableSet):
             found_layers.add(layer)
             for dep, oplist in layer.depends.items():
                 try:
-                    dep_found, dep_missing = self.get_by_name_recursive(dep)
+                    dep_found, dep_missing = self.get_by_name_recursive(dep, indirect_recs, indirect_recs)
                 except KeyError:
                     missing.add(dep)
                     continue
@@ -339,6 +345,30 @@ class Layers(collections.abc.MutableSet):
                 if dep not in missing:
                     found_layers |= dep_found
                     missing |= dep_missing
+
+            if include_recs:
+                for rec, oplist in layer.recommends.items():
+                    found = True
+
+                    try:
+                        rec_found, _ = self.get_by_name_recursive(rec, indirect_recs, indirect_recs)
+                    except KeyError:
+                        continue
+
+                    for _rec in rec_found:
+                        for opstr in oplist:
+                            op, recver = opstr.split()
+                            if _rec.version:
+                                try:
+                                    res = bb.utils.vercmp_string_op(_rec.version, recver, op)
+                                except bb.utils.VersionStringException as vse:
+                                    found = False
+                                else:
+                                    if not res:
+                                        found = False
+
+                    if found and rec not in missing:
+                        found_layers |= rec_found
 
         return found_layers, missing
 

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -436,7 +436,9 @@ def get_layers_for(all_layers, value, varname, cfgpath, verbose=False):
         for name in set(l.name for l in layers):
             layers, missing_layers = all_layers.get_by_name_recursive(name)
             found_layers |= layers
-            if missing_layers:
+            if name in missing_layers:
+                sys.exit('Layer `{0}` was not found'.format(name))
+            elif missing_layers:
                 sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
         s.set_layer_status(found_layers)
         return found_layers

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -471,7 +471,7 @@ def determine_layers(cmdline_opts):
             try:
                 all_layers.add_from_path(layer_path, data)
             except LayerError as exc:
-                sys.exit(str(exc))
+                sys.stderr.write('Warning: error parsing layer at {}\n'.format(layer_path))
 
     for layer in list(all_layers):
         if layer.name in args.excluded_layers:

--- a/scripts/bb-determine-layers
+++ b/scripts/bb-determine-layers
@@ -395,6 +395,23 @@ def get_layerpaths_bitbake(globs=None, paths=None):
     return layer_paths, bitbake_path
 
 
+
+def get_layers_for(all_layers, value, varname, cfgpath, verbose=False):
+    with LayerStatus("Determining layers to include for {0} '{1}'".format(varname, value), verbose=verbose) as s:
+        layers = all_layers.which('conf/{0}/{1}.conf'.format(cfgpath, value))
+        if not layers:
+            sys.exit("No layer found for {0} `{1}`".format(varname, value))
+
+        found_layers = Layers()
+        for name in set(l.name for l in layers):
+            layers, missing_layers = all_layers.get_by_name_recursive(name)
+            found_layers |= layers
+            if missing_layers:
+                sys.exit("Layer `{0}` was found, but its dependencies are missing: `{1}`".format(name, ', '.join(missing_layers)))
+        s.set_layer_status(found_layers)
+        return found_layers
+
+
 def determine_layers(cmdline_opts):
     args = process_arguments(cmdline_opts)
 
@@ -431,38 +448,7 @@ def determine_layers(cmdline_opts):
             if priority_override is not None:
                 layer.priority = priority_override
 
-    def get_layers_for(value, varname, cfgpath):
-        with LayerStatus("Determining layers to include for {0} '{1}'".format(varname, value), verbose=args.verbose) as s:
-            layers = all_layers.which('conf/{0}/{1}.conf'.format(cfgpath, value))
-            if not layers:
-                sys.exit("No layer found for {0} `{1}`".format(varname, value))
-
-            s.set_layer_status(layers)
-            layer_names = set(l.name for l in layers)
-            return layer_names
-
-    configured_layer_names = set(args.layers)
-
-    if args.distro and args.distro != 'nodistro':
-        configured_layer_names |= get_layers_for(args.distro, 'DISTRO', 'distro')
-
-    if args.machine:
-        configured_layer_names |= get_layers_for(args.machine, 'MACHINE', 'machine')
-
-    if args.sdkmachine:
-        configured_layer_names |= get_layers_for(args.sdkmachine, 'SDKMACHINE', 'machine-sdk')
-
-    with status('Processing layer dependencies'):
-        configured_layers = Layers()
-        for name in configured_layer_names:
-            if name not in all_layers.by_name:
-                sys.exit("Layer '{0}' not found".format(name))
-
-            layers, missing_layers = all_layers.get_by_name_recursive(name)
-            if missing_layers:
-                sys.exit("Dependent layers `{0}` not found for requested layer `{1}`".format(', '.join(missing_layers), name))
-            configured_layers |= layers
-
+    configured_layers = Layers()
     if args.layers:
         with LayerStatus('Checking for base layers', verbose=args.verbose) as s:
             found = set()
@@ -476,6 +462,15 @@ def determine_layers(cmdline_opts):
 
             s.set_layer_status(found)
             configured_layers |= found
+
+    if args.distro and args.distro != 'nodistro':
+        configured_layers |= get_layers_for(all_layers, args.distro, 'DISTRO', 'distro', args.verbose)
+
+    if args.machine:
+        configured_layers |= get_layers_for(all_layers, args.machine, 'MACHINE', 'machine', args.verbose)
+
+    if args.sdkmachine:
+        configured_layers |= get_layers_for(all_layers, args.sdkmachine, 'SDKMACHINE', 'machine-sdk', args.verbose)
 
     if args.optional_layers:
         with LayerStatus('Checking for optional layers', verbose=args.verbose) as s:

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -377,10 +377,11 @@ tmpdir="$(mktemp -d -t "${0##*/}.XXXXX")" || exit 1
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 
 setup_builddir "$@" || {
+    ret=$?
     if [ "$existing_builddir" = 0 ]; then
         rm -rf "$BUILDDIR"
     fi
-    exit $?
+    exit "$ret"
 }
 if [ -e $BUILDDIR/conf/local.conf ]; then
     sed -i -e "s/^DISTRO.*/DISTRO = \'$DISTRO\'/" $BUILDDIR/conf/local.conf

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -230,7 +230,7 @@ setup_builddir () {
     process_arguments "$@" || return $?
     shift $(expr $OPTIND - 1)
 
-    OEROOT="$($layerdir/scripts/bb-determine-layers -g "$layerpaths" -l core 2>/dev/null)/.." || {
+    OEROOT="$($layerdir/scripts/bb-determine-layers -g "$layerpaths" -l core -q)/.." || {
         echo >&2 "Error: unable to locate core layer (oe-core) in $MELDIR, aborting"
         return 3
     }

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -124,7 +124,6 @@ configure_builddir () {
     sed -i -e"s/^#*MACHINE *?*=.*/MACHINE ??= \"$MACHINE\"/" $BUILDDIR/conf/local.conf
     sed -n -i -e "s|##COREBASE##|$OEROOT|g" -e '/^BBLAYERS /{ :start; /\\$/{n; b start}; d; }; p' -e "/BBFILE_PRIORITY/d" $BUILDDIR/conf/bblayers.conf
 
-    echo 'BBLAYERS ?= "\' >> $BUILDDIR/conf/bblayers.conf
     layersfile="$tmpdir/layers"
 
     # Convert layer paths to layer names for bb-determine-layers
@@ -151,6 +150,7 @@ configure_builddir () {
         echo >&2 "Error in execution of bb-determine-layers, aborting"
         return 1
     fi
+    echo 'BBLAYERS ?= "\' >> $BUILDDIR/conf/bblayers.conf
     sed -e "s#^$BUILDDIR/#\${TOPDIR}/#g;" -e 's,^,    ,; s,$, \\,' <$layersfile >>$BUILDDIR/conf/bblayers.conf
     echo '"' >> $BUILDDIR/conf/bblayers.conf
     configured_layers="$(PATH="$OEROOT/scripts:$BITBAKEDIR/bin:$PATH" $(dirname "$0")/bb-print-layer-data $(cat $layersfile) 2>/dev/null | cut -d: -f1 | xargs)"

--- a/scripts/setup-mel-builddir
+++ b/scripts/setup-mel-builddir
@@ -230,7 +230,7 @@ setup_builddir () {
     process_arguments "$@" || return $?
     shift $(expr $OPTIND - 1)
 
-    OEROOT="$($layerdir/scripts/bb-determine-layers -g "$layerpaths" -l core)/.." || {
+    OEROOT="$($layerdir/scripts/bb-determine-layers -g "$layerpaths" -l core 2>/dev/null)/.." || {
         echo >&2 "Error: unable to locate core layer (oe-core) in $MELDIR, aborting"
         return 3
     }


### PR DESCRIPTION
This allows for variable references amongst the layers, particularly from a layer to its dependencies.

JIRA: SB-19738

This is based upon https://github.com/MentorEmbedded/meta-mentor/pull/1491 and https://github.com/MentorEmbedded/meta-mentor/pull/1492, merge those first. This is the dunfell version of https://github.com/MentorEmbedded/meta-mentor/pull/1490.