### PR TITLE
[sumo] lttng-modules: fix compilation failure after kernel update

### DIFF
--- a/meta-mel/recipes-kernel/lttng/lttng-modules/0001-fix-random-tracepoints-removed-in-stable-kernels.patch
+++ b/meta-mel/recipes-kernel/lttng/lttng-modules/0001-fix-random-tracepoints-removed-in-stable-kernels.patch
@@ -1,0 +1,38 @@
+From 65a69e289dff15e432c2b7753a740ccbce6d9cd7 Mon Sep 17 00:00:00 2001
+From: Ansar Rasool <ansar_rasool@mentor.com>
+Date: Mon, 25 Jul 2022 09:17:20 +0500
+Subject: [PATCH] fix: 'random' tracepoints removed in stable kernels
+
+Upstream-status: backport from
+https://git.lttng.org/?p=lttng-modules.git;a=blobdiff;f=src/probes/Kbuild;h=2908cf75effdcf58dbb82df55eff6291ceff31b1;hp=31e0ee85757f9ea83f28e81d70ab004dd1909ae2;hb=ed1149ef88fb62c365ac66cf62c58ac6abd8d7e8;hpb=1901e0eb58795e850e8fdcb5e1c235e4397b470d
+
+Signed-off-by: Ansar Rasool <ansar_rasool@mentor.com>
+---
+ probes/Kbuild | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/probes/Kbuild b/probes/Kbuild
+index cc1c065..2290350 100644
+--- a/probes/Kbuild
++++ b/probes/Kbuild
+@@ -194,13 +194,10 @@ ifneq ($(CONFIG_FRAME_WARN),0)
+   CFLAGS_lttng-probe-printk.o += -Wframe-larger-than=2200
+ endif
+ 
+-obj-$(CONFIG_LTTNG) +=  $(shell \
+-    if [ $(VERSION) -ge 4 \
+-      -o \( $(VERSION) -eq 3 -a $(PATCHLEVEL) -ge 6 \) \
+-      -o \( $(VERSION) -eq 3 -a $(PATCHLEVEL) -eq 5 -a $(SUBLEVEL) -ge 2 \) \
+-      -o \( $(VERSION) -eq 3 -a $(PATCHLEVEL) -eq 4 -a $(SUBLEVEL) -ge 9 \) \
+-      -o \( $(VERSION) -eq 3 -a $(PATCHLEVEL) -eq 0 -a $(SUBLEVEL) -ge 41 \) ] ; then \
+-      echo "lttng-probe-random.o" ; fi;)
++random_dep = $(srctree)/include/trace/events/random.h
++ifneq ($(wildcard $(random_dep)),)
++  obj-$(CONFIG_LTTNG) += lttng-probe-random.o
++endif
+ 
+ obj-$(CONFIG_LTTNG) +=  $(shell \
+   if [ $(VERSION) -ge 4 \
+-- 
+2.7.4
+

--- a/meta-mel/recipes-kernel/lttng/lttng-modules_%.bbappend
+++ b/meta-mel/recipes-kernel/lttng/lttng-modules_%.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI_append = "  \
                     file://lttng-module-fix-writeback-Fix-sync.patch \
+                    file://0001-fix-random-tracepoints-removed-in-stable-kernels.patch \
 "


### PR DESCRIPTION
This fixes compilation error after latest LTS updates of
kernel where trace/events/random.h file is dropped in
kernel which is unused mostly. This file was being included
here in lttng-modules which causes compilation failure with LTS kernel. This
drops the inclusion of dropped file.

Reference upstream kernel commit:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-4.14.y&id=707c01fe19eb2128374d1a71b7b6d1c9ee2d379f

Signed-off-by: Ansar Rasool <ansar_rasool@mentor.com>