### PR TITLE
Revert "mel: work around safe dir issue with METADATA_*"

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -350,12 +350,6 @@ MACHINE_HWCODECS = ""
 
 # Work around missing vardep bug in bitbake
 sstate_stage_all[vardeps] += "sstate_stage_dirs"
-
-# Work around git safe directory issue with METADATA_*, by forcing early expansion
-# while in a build user context.
-require classes/metadata_scm.bbclass
-METADATA_BRANCH := "${@base_detect_branch(d)}"
-METADATA_REVISION := "${@base_detect_revision(d)}"
 ## }}}1
 ## SDK & Application Development Environment {{{1
 # As we remove the toolchain from the sdk, naming it 'toolchain' is not


### PR DESCRIPTION
This reverts commit 52d30501b2ab3ed10fc1476202d6e857ecafa928.

Fixed by oe-core update to 3.1.17 by commit
https://github.com/openembedded/openembedded-core/commit/0f6ae13d76129d96f788b7ede312cfc361ee2bda