### PR TITLE
lttng-modules: fix adjust range v5.10.137 in block prob

### DIFF
--- a/meta-mel/recipes-kernel/lttng/lttng-modules/0001-fix-block-remove-the-request-queue-to-argument-request-based.patch
+++ b/meta-mel/recipes-kernel/lttng/lttng-modules/0001-fix-block-remove-the-request-queue-to-argument-request-based.patch
@@ -1,0 +1,240 @@
+From 132e2c970f7a1f2305bb33a6d0b8007195651b9b Mon Sep 17 00:00:00 2001
+From: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+Date: Fri, 4 Nov 2022 14:57:53 +0530
+Subject: [PATCH 1/2] From 173f7d83002d5e4b47f67c63ee0367011e80333c Mon Sep 17
+ 00:00:00 2001 From: Michael Jeanson <mjeanson@efficios.com> Date: Thu, 7 Jan
+ 2021 11:17:20 -0500 Subject: [PATCH] fix: block: remove the request_queue to
+ argument request  based tracepoints (v5.11)
+
+See upstream commit :
+
+  commit a54895fa057c67700270777f7661d8d3c7fda88a
+  Author: Christoph Hellwig <hch@lst.de>
+  Date:   Thu Dec 3 17:21:39 2020 +0100
+
+    block: remove the request_queue to argument request based tracepoints
+
+    The request_queue can trivially be derived from the request.
+
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+Change-Id: Ibe4a13f06ed57955fa3e0b77b87a44b7e6b57775
+
+This additional commit is required to fix lttng-modules issue post kernel update
+introduced by commit https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.10.y&id=1cb3032406423b25aa984854b4d78e0100d292dd
+
+Upstream-Status: Backport from
+https://github.com/lttng/lttng-modules/commit/173f7d83002d5e4b47f67c63ee0367011e80333c
+
+JIRA-ID: SB-20840
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ instrumentation/events/lttng-module/block.h | 141 +++++++++++++++++++-
+ 1 file changed, 139 insertions(+), 2 deletions(-)
+
+diff --git a/instrumentation/events/lttng-module/block.h b/instrumentation/events/lttng-module/block.h
+index 748a5c8..cd5e14c 100644
+--- a/instrumentation/events/lttng-module/block.h
++++ b/instrumentation/events/lttng-module/block.h
+@@ -266,6 +266,31 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq_with_error, block_rq_abort,
+ )
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++/**
++ * block_rq_requeue - place block IO request back on a queue
++ * @rq: block IO operation request
++ *
++ * The block operation request @rq is being placed back into queue
++ * @q.  For some reason the request was not completed and needs to be
++ * put back in the queue.
++ */
++LTTNG_TRACEPOINT_EVENT(block_rq_requeue,
++
++	TP_PROTO(struct request *rq),
++
++	TP_ARGS(rq),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev,
++			rq->rq_disk ? disk_devt(rq->rq_disk) : 0)
++		ctf_integer(sector_t, sector, blk_rq_trace_sector(rq))
++		ctf_integer(unsigned int, nr_sector, blk_rq_trace_nr_sectors(rq))
++		blk_rwbs_ctf_integer(unsigned int, rwbs,
++			lttng_req_op(rq), lttng_req_rw(rq), blk_rq_bytes(rq))
++	)
++)
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
+ /**
+  * block_rq_requeue - place block IO request back on a queue
+  * @q: queue holding operation
+@@ -275,7 +300,6 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq_with_error, block_rq_abort,
+  * @q.  For some reason the request was not completed and needs to be
+  * put back in the queue.
+  */
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
+ LTTNG_TRACEPOINT_EVENT(block_rq_requeue,
+ 
+ 	TP_PROTO(struct request_queue *q, struct request *rq),
+@@ -434,7 +458,26 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq_with_error, block_rq_complete,
+ 
+ #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)) */
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++LTTNG_TRACEPOINT_EVENT_CLASS(block_rq,
++
++	TP_PROTO(struct request *rq),
++
++	TP_ARGS(rq),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev,
++			rq->rq_disk ? disk_devt(rq->rq_disk) : 0)
++		ctf_integer(sector_t, sector, blk_rq_trace_sector(rq))
++		ctf_integer(unsigned int, nr_sector, blk_rq_trace_nr_sectors(rq))
++		ctf_integer(unsigned int, bytes, blk_rq_bytes(rq))
++		ctf_integer(pid_t, tid, current->pid)
++		blk_rwbs_ctf_integer(unsigned int, rwbs,
++			lttng_req_op(rq), lttng_req_rw(rq), blk_rq_bytes(rq))
++		ctf_array_text(char, comm, current->comm, TASK_COMM_LEN)
++	)
++)
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
+ LTTNG_TRACEPOINT_EVENT_CLASS(block_rq,
+ 
+ 	TP_PROTO(struct request_queue *q, struct request *rq),
+@@ -550,6 +593,23 @@ LTTNG_TRACEPOINT_EVENT_CLASS_CODE(block_rq,
+ )
+ #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)) */
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++/**
++ * block_rq_insert - insert block operation request into queue
++ * @rq: block IO operation request
++ *
++ * Called immediately before block operation request @rq is inserted
++ * into queue @q.  The fields in the operation request @rq struct can
++ * be examined to determine which device and sectors the pending
++ * operation would access.
++ */
++LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_insert,
++
++	TP_PROTO(struct request *rq),
++
++	TP_ARGS(rq)
++)
++#else
+ /**
+  * block_rq_insert - insert block operation request into queue
+  * @q: target queue
+@@ -566,7 +626,23 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_insert,
+ 
+ 	TP_ARGS(q, rq)
+ )
++#endif
++
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++/**
++ * block_rq_issue - issue pending block IO request operation to device driver
++ * @rq: block IO operation operation request
++ *
++ * Called when block operation request @rq from queue @q is sent to a
++ * device driver for processing.
++ */
++LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_issue,
+ 
++	TP_PROTO(struct request *rq),
++
++	TP_ARGS(rq)
++)
++#else
+ /**
+  * block_rq_issue - issue pending block IO request operation to device driver
+  * @q: queue holding operation
+@@ -581,6 +657,38 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_issue,
+ 
+ 	TP_ARGS(q, rq)
+ )
++#endif
++
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++/**
++ * block_rq_merge - merge request with another one in the elevator
++ * @rq: block IO operation operation request
++ *
++ * Called when block operation request @rq from queue @q is merged to another
++ * request queued in the elevator.
++ */
++LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_merge,
++
++	TP_PROTO(struct request *rq),
++
++	TP_ARGS(rq)
++)
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0))
++/**
++ * block_rq_merge - merge request with another one in the elevator
++ * @q: queue holding operation
++ * @rq: block IO operation operation request
++ *
++ * Called when block operation request @rq from queue @q is merged to another
++ * request queued in the elevator.
++ */
++LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_merge,
++
++	TP_PROTO(struct request_queue *q, struct request *rq),
++
++	TP_ARGS(q, rq)
++)
++#endif
+ 
+ /**
+  * block_bio_bounce - used bounce buffer when processing block operation
+@@ -1084,6 +1192,34 @@ LTTNG_TRACEPOINT_EVENT(block_bio_remap,
+ 	)
+ )
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++/**
++ * block_rq_remap - map request for a block operation request
++ * @rq: block IO operation request
++ * @dev: device for the operation
++ * @from: original sector for the operation
++ *
++ * The block operation request @rq in @q has been remapped.  The block
++ * operation request @rq holds the current information and @from hold
++ * the original sector.
++ */
++LTTNG_TRACEPOINT_EVENT(block_rq_remap,
++
++	TP_PROTO(struct request *rq, dev_t dev, sector_t from),
++
++	TP_ARGS(rq, dev, from),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev, disk_devt(rq->rq_disk))
++		ctf_integer(sector_t, sector, blk_rq_pos(rq))
++		ctf_integer(unsigned int, nr_sector, blk_rq_sectors(rq))
++		ctf_integer(dev_t, old_dev, dev)
++		ctf_integer(sector_t, old_sector, from)
++		blk_rwbs_ctf_integer(unsigned int, rwbs,
++			lttng_req_op(rq), lttng_req_rw(rq), blk_rq_bytes(rq))
++	)
++)
++#else
+ /**
+  * block_rq_remap - map request for a block operation request
+  * @q: queue holding the operation
+@@ -1112,6 +1248,7 @@ LTTNG_TRACEPOINT_EVENT(block_rq_remap,
+ 			lttng_req_op(rq), lttng_req_rw(rq), blk_rq_bytes(rq))
+ 	)
+ )
++#endif
+ 
+ #undef __print_rwbs_flags
+ #undef blk_fill_rwbs
+-- 
+2.25.1
+

--- a/meta-mel/recipes-kernel/lttng/lttng-modules/0002-fix-adjust-range-v5-10-137-in-block-probe.patch
+++ b/meta-mel/recipes-kernel/lttng/lttng-modules/0002-fix-adjust-range-v5-10-137-in-block-probe.patch
@@ -1,0 +1,101 @@
+From b9d61823016b069e7f2e3cac02d92c243fb26f5e Mon Sep 17 00:00:00 2001
+From: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+Date: Fri, 4 Nov 2022 15:02:50 +0530
+Subject: [PATCH 2/2] From 9f7df0f1867273244e62e14e68e20e03db4902ca Mon Sep 17
+ 00:00:00 2001 From: Michael Jeanson <mjeanson@efficios.com> Date: Mon, 22 Aug
+ 2022 14:16:27 -0400 Subject: [PATCH] fix: adjust range v5.10.137 in block
+ probe
+
+See upstream commit, backported in v5.10.137 :
+
+commit 1cb3032406423b25aa984854b4d78e0100d292dd
+Author: Christoph Hellwig <hch@lst.de>
+Date:   Thu Dec 3 17:21:39 2020 +0100
+
+    block: remove the request_queue to argument request based tracepoints
+
+    [ Upstream commit a54895fa057c67700270777f7661d8d3c7fda88a ]
+
+    The request_queue can trivially be derived from the request.
+
+Change-Id: I01f96a437641421faf993b4b031171c372bd0374
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Upstream-Status: Backport from
+https://git.lttng.org/?p=lttng-modules.git;a=patch;h=9f7df0f1867273244e62e14e68e20e03db4902ca
+
+JIRA-ID: SB-20840
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ instrumentation/events/lttng-module/block.h | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/instrumentation/events/lttng-module/block.h b/instrumentation/events/lttng-module/block.h
+index cd5e14c..0080af9 100644
+--- a/instrumentation/events/lttng-module/block.h
++++ b/instrumentation/events/lttng-module/block.h
+@@ -266,7 +266,8 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq_with_error, block_rq_abort,
+ )
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ /**
+  * block_rq_requeue - place block IO request back on a queue
+  * @rq: block IO operation request
+@@ -458,7 +459,8 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq_with_error, block_rq_complete,
+ 
+ #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)) */
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ LTTNG_TRACEPOINT_EVENT_CLASS(block_rq,
+ 
+ 	TP_PROTO(struct request *rq),
+@@ -593,7 +595,8 @@ LTTNG_TRACEPOINT_EVENT_CLASS_CODE(block_rq,
+ )
+ #endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)) */
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ /**
+  * block_rq_insert - insert block operation request into queue
+  * @rq: block IO operation request
+@@ -628,7 +631,8 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_insert,
+ )
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ /**
+  * block_rq_issue - issue pending block IO request operation to device driver
+  * @rq: block IO operation operation request
+@@ -659,7 +663,8 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(block_rq, block_rq_issue,
+ )
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ /**
+  * block_rq_merge - merge request with another one in the elevator
+  * @rq: block IO operation operation request
+@@ -1192,7 +1197,8 @@ LTTNG_TRACEPOINT_EVENT(block_bio_remap,
+ 	)
+ )
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) \
++        || LTTNG_KERNEL_RANGE(5,10,137, 5,11,0))
+ /**
+  * block_rq_remap - map request for a block operation request
+  * @rq: block IO operation request
+-- 
+2.25.1
+

--- a/meta-mel/recipes-kernel/lttng/lttng-modules_%.bbappend
+++ b/meta-mel/recipes-kernel/lttng/lttng-modules_%.bbappend
@@ -9,4 +9,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
  
 SRC_URI_append = "\
 		    file://0001-fix-random-tracepoints-removed-in-stable-kernels.patch \
+		    file://0001-fix-block-remove-the-request-queue-to-argument-request-based.patch \
+		    file://0002-fix-adjust-range-v5-10-137-in-block-probe.patch \
 "


### PR DESCRIPTION
Error:
| /home/syeda/mel/fir/up6/2async/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:131:6: error: conflicting types for 'trace_block_rq_requeue'
|   131 | void trace_##_name(_proto);
|       |      ^~~~~~
| /home/syeda/mel/fir/up6/2async/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:43:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
|    43 |  LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(map, name, map, PARAMS(proto), PARAMS(args))
|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| /home/syeda/mel/fir/up6/2async/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:85:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_MAP'
|    85 |  LTTNG_TRACEPOINT_EVENT_MAP(name, name,    \
|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~
| /home/syeda/mel/fir/up6/2async/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../instrumentation/events/lttng-module/block.h:279:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT'
|   279 | LTTNG_TRACEPOINT_EVENT(block_rq_requeue,
|       | ^~~~~~~~~~~~~~~~~~~~~~

Introduced by kernel update via commit - https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.10.y&id=1cb3032406423b25aa984854b4d78e0100d292dd

Fixed by backporting two commits:
1. An additional commit to support the actual commit as the patch code and source code didn't match - https://github.com/lttng/lttng-modules/commit/173f7d83002d5e4b47f67c63ee0367011e80333c

2. actual commit which fixes the issue - https://git.lttng.org/?p=lttng-modules.git;a=patch;h=9f7df0f1867273244e62e14e68e20e03db4902ca

JIRA-ID: SB-20840

Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>