### PR TITLE
lttng-modules: fix: jbd2: use the correct print format(v5.10.163)

### DIFF
--- a/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules/0001-fix-jbd2-use-the-correct-print-format.patch
+++ b/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules/0001-fix-jbd2-use-the-correct-print-format.patch
@@ -1,0 +1,183 @@
+From 883f3024554bab21a1a22dac711368b905a4bd6b Mon Sep 17 00:00:00 2001
+From: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+Date: Thu, 2 Feb 2023 14:02:10 +0530
+Subject: [PATCH 1/2] fix: jbd2: use the correct print format
+
+See upstream commit :
+
+  commit d87a7b4c77a997d5388566dd511ca8e6b8e8a0a8
+  Author: Bixuan Cui <cuibixuan@linux.alibaba.com>
+  Date:   Tue Oct 11 19:33:44 2022 +0800
+
+    jbd2: use the correct print format
+
+    The print format error was found when using ftrace event:
+        <...>-1406 [000] .... 23599442.895823: jbd2_end_commit: dev 252,8 transaction -1866216965 sync 0 head -1866217368
+        <...>-1406 [000] .... 23599442.896299: jbd2_start_commit: dev 252,8 transaction -1866216964 sync 0
+
+    Use the correct print format for transaction, head and tid.
+
+Change-Id: Ic053f0e0c1e24ebc75bae51d07696aaa5e1c0094
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Error:
+|   131 | void trace_##_name(_proto);
+|       |      ^~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:43:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
+|    43 |  LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(map, name, map, PARAMS(proto), PARAMS(args))
+|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:85:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_MAP'
+|    85 |  LTTNG_TRACEPOINT_EVENT_MAP(name, name,    \
+|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../instrumentation/events/lttng-module/jbd2.h:183:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT'
+|   183 | LTTNG_TRACEPOINT_EVENT(jbd2_run_stats,
+|       | ^~~~~~~~~~~~~~~~~~~~~~
+| In file included from /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/trace/events/jbd2.h:9,
+|                  from /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/lttng-probe-jbd2.c:18:
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:248:21: note: previous definition of 'trace_jbd2_run_stats' was here
+|   248 |  static inline void trace_##name(proto)    \
+|       |                     ^~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:423:2: note: in expansion of macro '__DECLARE_TRACE'
+|   423 |  __DECLARE_TRACE(name, PARAMS(proto), PARAMS(args),  \
+|       |  ^~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:559:2: note: in expansion of macro 'DECLARE_TRACE'
+|   559 |  DECLARE_TRACE(name, PARAMS(proto), PARAMS(args))
+|       |  ^~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/trace/events/jbd2.h:248:1: note: in expansion of macro 'TRACE_EVENT'
+|   248 | TRACE_EVENT(jbd2_run_stats,
+
+Upstream-Status: Backport from
+https://github.com/lttng/lttng-modules/commit/b28830a0dcdf95ec3e6b390b4d032667deaad0c0
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ instrumentation/events/lttng-module/jbd2.h | 77 ++++++++++++++++++++++
+ 1 file changed, 77 insertions(+)
+
+diff --git a/instrumentation/events/lttng-module/jbd2.h b/instrumentation/events/lttng-module/jbd2.h
+index a760da2..806db09 100644
+--- a/instrumentation/events/lttng-module/jbd2.h
++++ b/instrumentation/events/lttng-module/jbd2.h
+@@ -27,6 +27,23 @@ LTTNG_TRACEPOINT_EVENT(jbd2_checkpoint,
+ 	)
+ )
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
++	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
++	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
++LTTNG_TRACEPOINT_EVENT_CLASS(jbd2_commit,
++
++	TP_PROTO(journal_t *journal, transaction_t *commit_transaction),
++
++	TP_ARGS(journal, commit_transaction),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev, journal->j_fs_dev->bd_dev)
++		ctf_integer(char, sync_commit, commit_transaction->t_synchronous_commit)
++		ctf_integer(tid_t, transaction, commit_transaction->t_tid)
++	)
++)
++#else
+ LTTNG_TRACEPOINT_EVENT_CLASS(jbd2_commit,
+ 
+ 	TP_PROTO(journal_t *journal, transaction_t *commit_transaction),
+@@ -39,6 +56,7 @@ LTTNG_TRACEPOINT_EVENT_CLASS(jbd2_commit,
+ 		ctf_integer(int, transaction, commit_transaction->t_tid)
+ 	)
+ )
++#endif
+ 
+ LTTNG_TRACEPOINT_EVENT_INSTANCE(jbd2_commit, jbd2_start_commit,
+ 
+@@ -77,6 +95,23 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(jbd2_commit, jbd2_drop_transaction,
+ )
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
++	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
++	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
++LTTNG_TRACEPOINT_EVENT(jbd2_end_commit,
++	TP_PROTO(journal_t *journal, transaction_t *commit_transaction),
++
++	TP_ARGS(journal, commit_transaction),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev, journal->j_fs_dev->bd_dev)
++		ctf_integer(char, sync_commit, commit_transaction->t_synchronous_commit)
++		ctf_integer(tid_t, transaction, commit_transaction->t_tid)
++		ctf_integer(tid_t, head, journal->j_tail_sequence)
++	)
++)
++#else
+ LTTNG_TRACEPOINT_EVENT(jbd2_end_commit,
+ 	TP_PROTO(journal_t *journal, transaction_t *commit_transaction),
+ 
+@@ -89,6 +124,7 @@ LTTNG_TRACEPOINT_EVENT(jbd2_end_commit,
+ 		ctf_integer(int, head, journal->j_tail_sequence)
+ 	)
+ )
++#endif
+ 
+ LTTNG_TRACEPOINT_EVENT(jbd2_submit_inode_data,
+ 	TP_PROTO(struct inode *inode),
+@@ -101,6 +137,46 @@ LTTNG_TRACEPOINT_EVENT(jbd2_submit_inode_data,
+ 	)
+ )
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
++	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
++	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
++LTTNG_TRACEPOINT_EVENT(jbd2_run_stats,
++	TP_PROTO(dev_t dev, tid_t tid,
++		 struct transaction_run_stats_s *stats),
++
++	TP_ARGS(dev, tid, stats),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev, dev)
++		ctf_integer(tid_t, tid, tid)
++		ctf_integer(unsigned long, wait, stats->rs_wait)
++		ctf_integer(unsigned long, running, stats->rs_running)
++		ctf_integer(unsigned long, locked, stats->rs_locked)
++		ctf_integer(unsigned long, flushing, stats->rs_flushing)
++		ctf_integer(unsigned long, logging, stats->rs_logging)
++		ctf_integer(__u32, handle_count, stats->rs_handle_count)
++		ctf_integer(__u32, blocks, stats->rs_blocks)
++		ctf_integer(__u32, blocks_logged, stats->rs_blocks_logged)
++	)
++)
++
++LTTNG_TRACEPOINT_EVENT(jbd2_checkpoint_stats,
++	TP_PROTO(dev_t dev, tid_t tid,
++		 struct transaction_chp_stats_s *stats),
++
++	TP_ARGS(dev, tid, stats),
++
++	TP_FIELDS(
++		ctf_integer(dev_t, dev, dev)
++		ctf_integer(tid_t, tid, tid)
++		ctf_integer(unsigned long, chp_time, stats->cs_chp_time)
++		ctf_integer(__u32, forced_to_close, stats->cs_forced_to_close)
++		ctf_integer(__u32, written, stats->cs_written)
++		ctf_integer(__u32, dropped, stats->cs_dropped)
++	)
++)
++#else
+ LTTNG_TRACEPOINT_EVENT(jbd2_run_stats,
+ 	TP_PROTO(dev_t dev, unsigned long tid,
+ 		 struct transaction_run_stats_s *stats),
+@@ -136,6 +212,7 @@ LTTNG_TRACEPOINT_EVENT(jbd2_checkpoint_stats,
+ 		ctf_integer(__u32, dropped, stats->cs_dropped)
+ 	)
+ )
++#endif
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0))
+ LTTNG_TRACEPOINT_EVENT(jbd2_update_log_tail,
+-- 
+2.17.1
+

--- a/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules/0002-fix-jbd2-use-the-correct-print-format-v5.10.163.patch
+++ b/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules/0002-fix-jbd2-use-the-correct-print-format-v5.10.163.patch
@@ -1,0 +1,89 @@
+From 028ea79ebe814c2633b8b84087e9df333701dffa Mon Sep 17 00:00:00 2001
+From: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+Date: Fri, 10 Feb 2023 14:03:21 +0530
+Subject: [PATCH 2/2] fix: jbd2: use the correct print format (v5.10.163)
+
+See upstream commit :
+
+  commit d87a7b4c77a997d5388566dd511ca8e6b8e8a0a8
+  Author: Bixuan Cui <cuibixuan@linux.alibaba.com>
+  Date:   Tue Oct 11 19:33:44 2022 +0800
+
+    jbd2: use the correct print format
+
+    The print format error was found when using ftrace event:
+        <...>-1406 [000] .... 23599442.895823: jbd2_end_commit: dev 252,8 transaction -1866216965 sync 0 head -1866217368
+        <...>-1406 [000] .... 23599442.896299: jbd2_start_commit: dev 252,8 transaction -1866216964 sync 0
+
+    Use the correct print format for transaction, head and tid.
+
+Change-Id: I7601f5cbb86495c2607be7b11e02724c90b3ebf9
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+
+Error:
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:131:6: error: conflicting types for 'trace_jbd2_run_stats'
+|   131 | void trace_##_name(_proto);
+|       |      ^~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:43:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
+|    43 |  LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(map, name, map, PARAMS(proto), PARAMS(args))
+|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:85:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_MAP'
+|    85 |  LTTNG_TRACEPOINT_EVENT_MAP(name, name,    \
+|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../instrumentation/events/lttng-module/jbd2.h:104:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT'
+|   104 | LTTNG_TRACEPOINT_EVENT(jbd2_run_stats,
+|       | ^~~~~~~~~~~~~~~~~~~~~~
+| In file included from /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/trace/events/jbd2.h:9,
+|                  from /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/lttng-probe-jbd2.c:18:
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:248:21: note: previous definition of 'trace_jbd2_run_stats' was here
+|   248 |  static inline void trace_##name(proto)    \
+|       |                     ^~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:423:2: note: in expansion of macro '__DECLARE_TRACE'
+|   423 |  __DECLARE_TRACE(name, PARAMS(proto), PARAMS(args),  \
+|       |  ^~~~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/linux/tracepoint.h:559:2: note: in expansion of macro 'DECLARE_TRACE'
+|   559 |  DECLARE_TRACE(name, PARAMS(proto), PARAMS(args))
+|       |  ^~~~~~~~~~~~~
+| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work-shared/zcu102-zynqmp-mel/kernel-source/include/trace/events/jbd2.h:248:1: note: in expansion of macro 'TRACE_EVENT'
+|   248 | TRACE_EVENT(jbd2_run_stats,
+
+Upstream-Status: Backport from
+https://github.com/lttng/lttng-modules/commit/dd7be14bd04c1de309ba267097b03a308da87dae
+
+Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>
+---
+ instrumentation/events/lttng-module/jbd2.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/instrumentation/events/lttng-module/jbd2.h b/instrumentation/events/lttng-module/jbd2.h
+index 806db09..d50475b 100644
+--- a/instrumentation/events/lttng-module/jbd2.h
++++ b/instrumentation/events/lttng-module/jbd2.h
+@@ -28,6 +28,7 @@ LTTNG_TRACEPOINT_EVENT(jbd2_checkpoint,
+ )
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,10,163, 6,0,0) \
+ 	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
+@@ -96,6 +97,7 @@ LTTNG_TRACEPOINT_EVENT_INSTANCE(jbd2_commit, jbd2_drop_transaction,
+ #endif
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,10,163, 6,0,0) \
+ 	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
+@@ -138,6 +140,7 @@ LTTNG_TRACEPOINT_EVENT(jbd2_submit_inode_data,
+ )
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) \
++	|| LTTNG_KERNEL_RANGE(5,10,163, 6,0,0) \
+ 	|| LTTNG_KERNEL_RANGE(5,15,87, 5,16,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,0,18, 6,1,0) \
+ 	|| LTTNG_KERNEL_RANGE(6,1,4, 6,2,0))
+-- 
+2.17.1
+

--- a/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules_%.bbappend
+++ b/meta-mel/mentor-bsp-xilinx-common/recipes-kernel/lttng/lttng-modules_%.bbappend
@@ -2,7 +2,7 @@
 # or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
 # as set forth in the Customer's applicable agreements with Siemens.
 # ---------------------------------------------------------------------------------------------------------------------
-# Unpublished work. Copyright 2022 Siemens
+# Unpublished work. Copyright 2023 Siemens
 # ---------------------------------------------------------------------------------------------------------------------
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
@@ -11,4 +11,6 @@ SRC_URI_append = "\
 		    file://0001-fix-random-tracepoints-removed-in-stable-kernels.patch \
 		    file://0001-fix-block-remove-the-request-queue-to-argument-request-based.patch \
 		    file://0002-fix-adjust-range-v5-10-137-in-block-probe.patch \
+		    file://0001-fix-jbd2-use-the-correct-print-format.patch \
+		    file://0002-fix-jbd2-use-the-correct-print-format-v5.10.163.patch \
 "


### PR DESCRIPTION
post kernel update from v5.10.162..v5.10.163, the commit - https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.10.y&id=c023597baecb0fe5c10708bdc3460b59ca8a8194 is causing lttng-modules compilation issue, for resolving it, the following commits are needed from UPSTREAM lttng-modules v2.12 branch - https://github.com/lttng/lttng-modules/commit/38b4e82d9f77265f80ea77f809eb354ff6c0f6e4 https://github.com/lttng/lttng-modules/commit/dd7be14bd04c1de309ba267097b03a308da87dae

Error:
|   131 | void trace_##_name(_proto);
|       |      ^~~~~~
| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:43:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
|    43 |  LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(map, name, map, PARAMS(proto), PARAMS(args))
|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../probes/lttng-tracepoint-event-impl.h:85:2: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_MAP'
|    85 |  LTTNG_TRACEPOINT_EVENT_MAP(name, name,    \
|       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~
| /home/snaaz/mel/fir/async_2/build_zcu/tmp/work/zcu102_zynqmp_mel-mel-linux/lttng-modules/2.12.2-r0/lttng-modules-2.12.2/probes/../instrumentation/events/lttng-module/jbd2.h:183:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT'
|   183 | LTTNG_TRACEPOINT_EVENT(jbd2_run_stats,
|       | ^~~~~~~~~~~~~~~~~~~~~~

JIRA-ID: SB-21433

Signed-off-by: Syeda Shagufta Naaz <SyedaShagufta_Naaz@mentor.com>