### PR TITLE
[dunfell] bluez5: upgrade to 5.65 version

### DIFF
--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5.inc
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5.inc
@@ -1,0 +1,155 @@
+SUMMARY = "Linux Bluetooth Stack Userland V5"
+DESCRIPTION = "Linux Bluetooth stack V5 userland components.  These include a system configurations, daemons, tools and system libraries."
+HOMEPAGE = "http://www.bluez.org"
+SECTION = "libs"
+LICENSE = "GPLv2+ & LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
+                    file://COPYING.LIB;md5=fb504b67c50331fc78734fed90fb0e09 \
+                    file://src/main.c;beginline=1;endline=24;md5=0ad83ca0dc37ab08af448777c581e7ac"
+DEPENDS = "dbus glib-2.0"
+PROVIDES += "bluez-hcidump"
+RPROVIDES:${PN} += "bluez-hcidump"
+
+RCONFLICTS:${PN} = "bluez4"
+
+PACKAGECONFIG ??= "obex-profiles \
+    readline \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)} \
+    a2dp-profiles \
+    avrcp-profiles \
+    network-profiles \
+    hid-profiles \
+    hog-profiles \
+    tools \
+    deprecated \
+    udev \
+"
+PACKAGECONFIG[obex-profiles] = "--enable-obex,--disable-obex,libical"
+PACKAGECONFIG[readline] = "--enable-client,--disable-client,readline,"
+PACKAGECONFIG[testing] = "--enable-testing,--disable-testing"
+PACKAGECONFIG[midi] = "--enable-midi,--disable-midi,alsa-lib"
+PACKAGECONFIG[systemd] = "--enable-systemd,--disable-systemd"
+PACKAGECONFIG[cups] = "--enable-cups,--disable-cups,,cups"
+PACKAGECONFIG[nfc] = "--enable-nfc,--disable-nfc"
+PACKAGECONFIG[sap-profiles] = "--enable-sap,--disable-sap"
+PACKAGECONFIG[a2dp-profiles] = "--enable-a2dp,--disable-a2dp"
+PACKAGECONFIG[avrcp-profiles] = "--enable-avrcp,--disable-avrcp"
+PACKAGECONFIG[network-profiles] = "--enable-network,--disable-network"
+PACKAGECONFIG[hid-profiles] = "--enable-hid,--disable-hid"
+PACKAGECONFIG[hog-profiles] = "--enable-hog,--disable-hog"
+PACKAGECONFIG[health-profiles] = "--enable-health,--disable-health"
+PACKAGECONFIG[sixaxis] = "--enable-sixaxis,--disable-sixaxis"
+PACKAGECONFIG[tools] = "--enable-tools,--disable-tools"
+PACKAGECONFIG[threads] = "--enable-threads,--disable-threads"
+PACKAGECONFIG[deprecated] = "--enable-deprecated,--disable-deprecated"
+PACKAGECONFIG[mesh] = "--enable-mesh --enable-external-ell,--disable-mesh, json-c ell"
+PACKAGECONFIG[btpclient] = "--enable-btpclient --enable-external-ell,--disable-btpclient, ell"
+PACKAGECONFIG[udev] = "--enable-udev,--disable-udev,udev"
+PACKAGECONFIG[manpages] = "--enable-manpages,--disable-manpages,python3-docutils-native"
+
+SRC_URI = "${KERNELORG_MIRROR}/linux/bluetooth/bluez-${PV}.tar.xz \
+           file://init \
+           file://run-ptest \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '', 'file://0001-Allow-using-obexd-without-systemd-in-the-user-sessio.patch', d)} \
+           file://0001-tests-add-a-target-for-building-tests-without-runnin.patch \
+           file://0001-test-gatt-Fix-hung-issue.patch \
+           "
+S = "${WORKDIR}/bluez-${PV}"
+
+CVE_PRODUCT = "bluez"
+
+inherit autotools pkgconfig systemd update-rc.d ptest gobject-introspection-data
+
+EXTRA_OECONF = "\
+  --enable-test \
+  --enable-datafiles \
+  --enable-library \
+  --without-zsh-completion-dir \
+"
+
+# bluez5 builds a large number of useful utilities but does not
+# install them.  Specify which ones we want put into ${PN}-noinst-tools.
+NOINST_TOOLS_READLINE ??= ""
+NOINST_TOOLS_TESTING ??= ""
+NOINST_TOOLS_BT ??= ""
+NOINST_TOOLS = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'readline', '${NOINST_TOOLS_READLINE}', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'testing', '${NOINST_TOOLS_TESTING}', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'tools', '${NOINST_TOOLS_BT}', '', d)} \
+"
+
+do_install:append() {
+	install -d ${D}${INIT_D_DIR}
+	install -m 0755 ${WORKDIR}/init ${D}${INIT_D_DIR}/bluetooth
+
+	install -d ${D}${sysconfdir}/bluetooth/
+	if [ -f ${S}/profiles/network/network.conf ]; then
+		install -m 0644 ${S}/profiles/network/network.conf ${D}/${sysconfdir}/bluetooth/
+	fi
+	if [ -f ${S}/profiles/input/input.conf ]; then
+		install -m 0644 ${S}/profiles/input/input.conf ${D}/${sysconfdir}/bluetooth/
+	fi
+
+	if [ -f ${D}/${sysconfdir}/init.d/bluetooth ]; then
+		sed -i -e 's#@LIBEXECDIR@#${libexecdir}#g' ${D}/${sysconfdir}/init.d/bluetooth
+	fi
+
+	# Install desired tools that upstream leaves in build area
+	for f in ${NOINST_TOOLS} ; do
+		install -m 755 ${B}/$f ${D}/${bindir}
+	done
+
+	# Patch python tools to use Python 3; they should be source compatible, but
+	# still refer to Python 2 in the shebang
+	sed -i -e '1s,#!.*python.*,#!${bindir}/python3,' ${D}${libdir}/bluez/test/*
+}
+
+PACKAGES =+ "${PN}-testtools ${PN}-obex ${PN}-noinst-tools"
+
+FILES:${PN} += " \
+    ${libdir}/bluetooth/plugins/*.so \
+    ${systemd_unitdir}/ ${datadir}/dbus-1 \
+    ${libdir}/cups \
+"
+FILES:${PN}-dev += " \
+    ${libdir}/bluetooth/plugins/*.la \
+"
+
+FILES:${PN}-obex = "${libexecdir}/bluetooth/obexd \
+                    ${exec_prefix}/lib/systemd/user/obex.service \
+                    ${systemd_system_unitdir}/obex.service \
+                    ${sysconfdir}/systemd/system/multi-user.target.wants/obex.service \
+                    ${datadir}/dbus-1/services/org.bluez.obex.service \
+                    ${sysconfdir}/dbus-1/system.d/obexd.conf \
+                   "
+SYSTEMD_SERVICE:${PN}-obex = "obex.service"
+
+FILES:${PN}-testtools = "${libdir}/bluez/test/*"
+
+def get_noinst_tools_paths (d, bb, tools):
+    s = list()
+    bindir = d.getVar("bindir")
+    for bdp in tools.split():
+        f = os.path.basename(bdp)
+        s.append("%s/%s" % (bindir, f))
+    return "\n".join(s)
+
+FILES:${PN}-noinst-tools = "${@get_noinst_tools_paths(d, bb, d.getVar('NOINST_TOOLS'))}"
+
+RDEPENDS:${PN}-testtools += "python3-core python3-dbus"
+RDEPENDS:${PN}-testtools += "${@bb.utils.contains('GI_DATA_ENABLED', 'True', 'python3-pygobject', '', d)}"
+
+SYSTEMD_SERVICE:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'bluetooth.service', '', d)}"
+INITSCRIPT_PACKAGES = "${PN}"
+INITSCRIPT_NAME:${PN} = "bluetooth"
+
+do_compile_ptest() {
+	oe_runmake buildtests
+}
+
+do_install_ptest() {
+	cp -r ${B}/unit/ ${D}${PTEST_PATH}
+	rm -f ${D}${PTEST_PATH}/unit/*.o
+}
+
+RDEPENDS:${PN}-ptest:append:libc-glibc = " glibc-gconv-utf-16"

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-Allow-using-obexd-without-systemd-in-the-user-sessio.patch
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-Allow-using-obexd-without-systemd-in-the-user-sessio.patch
@@ -1,0 +1,56 @@
+From f74eb97c9fb3c0ee2895742e773ac6a3c41c999c Mon Sep 17 00:00:00 2001
+From: Giovanni Campagna <gcampagna-cNUdlRotFMnNLxjTenLetw@public.gmane.org>
+Date: Sat, 12 Oct 2013 17:45:25 +0200
+Subject: [PATCH] Allow using obexd without systemd in the user session
+
+Not all sessions run systemd --user (actually, the majority
+doesn't), so the dbus daemon must be able to spawn obexd
+directly, and to do so it needs the full path of the daemon.
+
+Upstream-Status: Denied
+
+Not accepted by upstream maintainer for being a distro specific
+configuration. See thread:
+
+http://thread.gmane.org/gmane.linux.bluez.kernel/38725/focus=38843
+
+Signed-off-by: Javier Viguera <javier.viguera@digi.com>
+
+---
+ Makefile.obexd                                                | 4 ++--
+ .../src/{org.bluez.obex.service => org.bluez.obex.service.in} | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+ rename obexd/src/{org.bluez.obex.service => org.bluez.obex.service.in} (76%)
+
+diff --git a/Makefile.obexd b/Makefile.obexd
+index de59d29..73004a3 100644
+--- a/Makefile.obexd
++++ b/Makefile.obexd
+@@ -1,12 +1,12 @@
+ if SYSTEMD
+ systemduserunitdir = $(SYSTEMD_USERUNITDIR)
+ systemduserunit_DATA = obexd/src/obex.service
++endif
+ 
+ dbussessionbusdir = $(DBUS_SESSIONBUSDIR)
+ dbussessionbus_DATA = obexd/src/org.bluez.obex.service
+-endif
+ 
+-EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service
++EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service.in
+ 
+ if OBEX
+ 
+diff --git a/obexd/src/org.bluez.obex.service b/obexd/src/org.bluez.obex.service.in
+similarity index 76%
+rename from obexd/src/org.bluez.obex.service
+rename to obexd/src/org.bluez.obex.service.in
+index a538088..9c815f2 100644
+--- a/obexd/src/org.bluez.obex.service
++++ b/obexd/src/org.bluez.obex.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+ Name=org.bluez.obex
+-Exec=/bin/false
++Exec=@libexecdir@/obexd
+ SystemdService=dbus-org.bluez.obex.service

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-test-gatt-Fix-hung-issue.patch
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-test-gatt-Fix-hung-issue.patch
@@ -1,0 +1,43 @@
+From 61e741654cc2eb167bca212a3bb2ba8f3ba280c1 Mon Sep 17 00:00:00 2001
+From: Mingli Yu <Mingli.Yu@windriver.com>
+Date: Fri, 24 Aug 2018 12:04:03 +0800
+Subject: [PATCH] test-gatt: Fix hung issue
+
+The below test hangs infinitely
+$ unit/test-gatt -p  /robustness/unkown-request -d
+/robustness/unkown-request - init
+/robustness/unkown-request - setup
+/robustness/unkown-request - setup complete
+/robustness/unkown-request - run
+  GATT: < 02 17 00                                         ...
+  bt_gatt_server:MTU exchange complete, with MTU: 23
+  GATT: > 03 00 02                                         ...
+  PDU: = 03 00 02                                         ...
+  GATT: < bf 00
+
+Actually, the /robustness/unkown-request test does
+no action.
+
+Upstream-Status: Submitted [https://marc.info/?l=linux-bluetooth&m=153508881804635&w=2]
+
+Signed-off-by: Mingli Yu <Mingli.Yu@windriver.com>
+---
+ unit/test-gatt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unit/test-gatt.c b/unit/test-gatt.c
+index c7e28f8..b57373b 100644
+--- a/unit/test-gatt.c
++++ b/unit/test-gatt.c
+@@ -4463,7 +4463,7 @@ int main(int argc, char *argv[])
+ 			test_server, service_db_1, NULL,
+ 			raw_pdu(0x03, 0x00, 0x02),
+ 			raw_pdu(0xbf, 0x00),
+-			raw_pdu(0x01, 0xbf, 0x00, 0x00, 0x06));
++			raw_pdu());
+ 
+ 	define_test_server("/robustness/unkown-command",
+ 			test_server, service_db_1, NULL,
+-- 
+2.7.4
+

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-tests-add-a-target-for-building-tests-without-runnin.patch
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/0001-tests-add-a-target-for-building-tests-without-runnin.patch
@@ -1,0 +1,28 @@
+From 4bdf0f96dcaa945fd29f26d56e5b36d8c23e4c8b Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 1 Apr 2016 17:07:34 +0300
+Subject: [PATCH] tests: add a target for building tests without running them
+
+Upstream-Status: Inappropriate [oe specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ Makefile.am | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 1a48a71..ba3b92f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -425,6 +425,9 @@ endif
+ TESTS = $(unit_tests)
+ AM_TESTS_ENVIRONMENT = MALLOC_CHECK_=3 MALLOC_PERTURB_=69
+ 
++# This allows building tests without running them
++buildtests: $(TESTS)
++
+ if DBUS_RUN_SESSION
+ AM_TESTS_ENVIRONMENT += dbus-run-session --
+ endif
+-- 
+2.8.0.rc3
+

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/init
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/init
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Source function library
+. /etc/init.d/functions
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+DESC=bluetooth
+
+DAEMON=@LIBEXECDIR@/bluetooth/bluetoothd
+
+# If you want to be ignore error of "org.freedesktop.hostname1",
+# please enable NOPLUGIN_OPTION.
+# NOPLUGIN_OPTION="--noplugin=hostname"
+NOPLUGIN_OPTION=""
+SSD_OPTIONS="--oknodo --quiet --exec $DAEMON -- $NOPLUGIN_OPTION"
+
+test -f $DAEMON || exit 0
+
+# FIXME: any of the sourced files may fail if/with syntax errors
+test -f /etc/default/bluetooth && . /etc/default/bluetooth
+test -f /etc/default/rcS && . /etc/default/rcS
+
+set -e
+
+case $1 in
+  start)
+	echo -n "Starting $DESC: "
+	if test "$BLUETOOTH_ENABLED" = 0; then
+		echo "disabled (see /etc/default/bluetooth)."
+		exit 0
+	fi
+	start-stop-daemon --start --background $SSD_OPTIONS
+	echo "${DAEMON##*/}."
+  ;;
+  stop)
+	echo -n "Stopping $DESC: "
+	if test "$BLUETOOTH_ENABLED" = 0; then
+		echo "disabled (see /etc/default/bluetooth)."
+		exit 0
+	fi
+	start-stop-daemon --stop $SSD_OPTIONS
+	echo "${DAEMON##*/}."
+  ;;
+  restart|force-reload)
+	$0 stop
+	sleep 1
+	$0 start
+  ;;
+  status)
+	status ${DAEMON} || exit $?
+   ;;
+   *)
+	N=/etc/init.d/bluetooth
+	echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0
+
+# vim:noet

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/run-ptest
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5/run-ptest
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+cd unit
+
+failed=0
+all=0
+
+for f in test-*; do
+    "./$f" -q
+    case "$?" in
+        0)
+            echo "PASS: $f"
+            all=$((all + 1))
+            ;;
+        77)
+            echo "SKIP: $f"
+            ;;
+        *)
+            echo "FAIL: $f"
+            failed=$((failed + 1))
+            all=$((all + 1))
+            ;;
+    esac
+done
+
+if [ "$failed" -eq 0 ] ; then
+  echo "All $all tests passed"
+else
+  echo "$failed of $all tests failed"
+fi
+

--- a/meta-mentor-staging/recipes-connectivity/bluez5/bluez5_5.65.bb
+++ b/meta-mentor-staging/recipes-connectivity/bluez5/bluez5_5.65.bb
@@ -1,0 +1,70 @@
+require bluez5.inc
+
+SRC_URI[sha256sum] = "2565a4d48354b576e6ad92e25b54ed66808296581c8abb80587051f9993d96d4"
+
+# These issues have kernel fixes rather than bluez fixes so exclude here
+CVE_CHECK_IGNORE += "CVE-2020-12352 CVE-2020-24490"
+
+# noinst programs in Makefile.tools that are conditional on READLINE
+# support
+NOINST_TOOLS_READLINE ?= " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'deprecated', 'attrib/gatttool', '', d)} \
+    tools/obex-client-tool \
+    tools/obex-server-tool \
+    tools/bluetooth-player \
+    tools/obexctl \
+    tools/btmgmt \
+"
+
+# noinst programs in Makefile.tools that are conditional on TESTING
+# support
+NOINST_TOOLS_TESTING ?= " \
+    emulator/btvirt \
+    emulator/b1ee \
+    emulator/hfp \
+    peripheral/btsensor \
+    tools/3dsp \
+    tools/mgmt-tester \
+    tools/gap-tester \
+    tools/l2cap-tester \
+    tools/sco-tester \
+    tools/smp-tester \
+    tools/hci-tester \
+    tools/rfcomm-tester \
+    tools/bnep-tester \
+    tools/userchan-tester \
+"
+
+# noinst programs in Makefile.tools that are conditional on TOOLS
+# support
+NOINST_TOOLS_BT ?= " \
+    tools/bdaddr \
+    tools/avinfo \
+    tools/avtest \
+    tools/scotest \
+    tools/amptest \
+    tools/hwdb \
+    tools/hcieventmask \
+    tools/hcisecfilter \
+    tools/btinfo \
+    tools/btsnoop \
+    tools/btproxy \
+    tools/btiotest \
+    tools/bneptest \
+    tools/mcaptest \
+    tools/cltest \
+    tools/oobtest \
+    tools/advtest \
+    tools/seq2bseq \
+    tools/nokfw \
+    tools/create-image \
+    tools/eddystone \
+    tools/ibeacon \
+    tools/btgatt-client \
+    tools/btgatt-server \
+    tools/test-runner \
+    tools/check-selftest \
+    tools/gatt-service \
+    profiles/iap/iapd \
+    ${@bb.utils.contains('PACKAGECONFIG', 'btpclient', 'tools/btpclient', '', d)} \
+"


### PR DESCRIPTION
Fix for CVE-2021-43400 has an impact before version 5.65 which causes bluetooth write failure. Upgrading to 5.65 version fixes this issue. This recipe is copied from kirkstone branch of oe-core layer.

JIRA: https://jira.alm.mentorg.com/browse/SIEJIR-6535