### PR TITLE
conf: distro.conf: WHITELIST coreutils

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -503,5 +503,6 @@ MACHINE_EXTRA_RRECOMMENDS_remove = "${@bb.utils.contains('USER_FEATURES', 'encry
 # Add initramfs image to the boot partition.
 IMAGE_BOOT_FILES_append = " ${@bb.utils.contains('USER_FEATURES', 'encrypted-fs', '${DM_INITRAMFS}', '', d)}"
 
+WHITELIST_GPL-3.0 += '${@bb.utils.contains("IMAGE_FEATURES", "security-selinux", "coreutils", "", d)}'
 ## }}}1
 # vim: set fdm=marker fdl=0 :


### PR DESCRIPTION
WHITELIST coreutils for selinux IMAGE_FEATURES when INCOMPATIBLE_LICENSE = "GPLv3" is set

It was leading to the following failure during boot: [FAILED] Failed to start SELinux init for /dev service loading. See 'systemctl status selinux-labeldev.service' for details. [FAILED] Failed to start SELinux init service loading. See 'systemctl status selinux-init.service' for details.

JIRA-ID: SB-22107