### PR TITLE
perf: add bash to RDEPENDS

### DIFF
--- a/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
+++ b/meta-mentor-staging/recipes-kernel/perf/perf.bbappend
@@ -4,3 +4,5 @@ inherit incompatible-recipe-check
 
 REMOVE_INCOMPATIBLE_MAN = "${@'man' if is_incompatible(d, ['libpipeline'], 'GPL-3.0') else ''}"
 RDEPENDS_${PN}-doc_remove = "${REMOVE_INCOMPATIBLE_MAN}"
+
+RDEPENDS_${PN}-tests += "bash"


### PR DESCRIPTION
Issue:
ERROR: perf-1.0-r9 do_package_qa: QA Issue: /usr/libexec/perf-core/tests/shell/test_uprobe_from_different_cu.sh contained in package perf-tests requires /bin/bash, but no providers found in RDEPENDS_perf-tests? [file-rdeps]

commit causing the issue - https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-4.14.y&id=4fca429889cb175ca5bd5eef0ea250b4770d5247

solution:
add bash to RDEPENDS variable for perf-tests