### PR TITLE
mel.conf: fix typo in fitImage

### DIFF
--- a/meta-mel/conf/distro/include/mel.conf
+++ b/meta-mel/conf/distro/include/mel.conf
@@ -441,7 +441,7 @@ include conf/distro/include/mel-mcf.conf
 
 # INITRAMFS
 INITRAMFS_IMAGE ?= "mel-initramfs-image"
-INITRAMFS_IMAGE_BUNDLE ?= "${@bb.utils.contains('KERNEL_IMAGETYPES', 'fitimage', '', '1', d)}"
+INITRAMFS_IMAGE_BUNDLE ?= "${@bb.utils.contains('KERNEL_IMAGETYPES', 'fitImage', '', '1', d)}"
 
 ## }}}1
 # vim: set fdm=marker fdl=0 :


### PR DESCRIPTION
INITRAMFS_IMAGE_BUNDLE needs to be empty when we are using fitImage. But due to the typo, it was being set to 1 which caused a check to fail in the updated oe-core.

JIRA-ID: SB-22900