### PR TITLE
go: Fix for net http permit requests invalid Host headers issue

### DIFF
--- a/meta-mentor-staging/recipes-devtools/go/files/0001-net-http-permit-request-with-invalid-Host-headers.patch
+++ b/meta-mentor-staging/recipes-devtools/go/files/0001-net-http-permit-request-with-invalid-Host-headers.patch
@@ -1,0 +1,110 @@
+From 04562b610b07d8bce4f036f345dc5ca71ab3b5b3 Mon Sep 17 00:00:00 2001
+From: Ashish Jain <ashish.jain2@siemens.com>
+Date: Tue, 5 Dec 2023 02:16:21 -0600
+Subject: [PATCH] net/http: permit request with invalid Host headers
+
+Historically, the Transport has silently truncated invalid
+Host headers at the first '/' or ' ' character. CL 506996 changed
+this behavior to reject invalid Host headers entirely.
+Unfortunately, Docker appears to rely on the previous behavior.
+
+When sending a HTTP/1 request with an invalid Host, send an empty
+Host header. This is safer than truncation: If you care about the
+Host, then you should get the one you set; if you don't care,
+then an empty Host should be fine.
+
+Continue to fully validate Host headers sent to a proxy,
+since proxies generally can't productively forward requests
+without a Host.
+
+For #60374
+Fixes #61431
+
+Change-Id: If170c7dd860aa20eb58fe32990fc93af832742b6
+Reviewed-on: https://go-review.googlesource.com/c/go/+/511155
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+Run-TryBot: Damien Neil <dneil@google.com>
+
+Upstream-Status: Backport from
+https://go-review.googlesource.com/c/go/+/511155/5/src/net/http/request.go
+
+JIRA ID: SB-22980
+
+Signed-off-by: Ashish Jain <ashish.jain2@siemens.com>
+---
+ src/net/http/request.go      | 23 ++++++++++++++++++++++-
+ src/net/http/request_test.go | 17 ++++++++++++-----
+ 2 files changed, 34 insertions(+), 6 deletions(-)
+
+diff --git a/src/net/http/request.go b/src/net/http/request.go
+index 93f4bf0..4906ca9 100644
+--- a/src/net/http/request.go
++++ b/src/net/http/request.go
+@@ -568,8 +568,29 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
+ 	if err != nil {
+ 		return err
+ 	}
++	// Validate that the Host header is a valid header in general,
++	// but don't validate the host itself. This is sufficient to avoid
++	// header or request smuggling via the Host field.
++	// The server can (and will, if it's a net/http server) reject
++	// the request if it doesn't consider the host valid.
+ 	if !httpguts.ValidHostHeader(host) {
+-		return errors.New("http: invalid Host header")
++		// Historically, we would truncate the Host header after '/' or ' '.
++		// Some users have relied on this truncation to convert a network
++		// address such as Unix domain socket path into a valid, ignored
++		// Host header (see https://go.dev/issue/61431).
++		//
++		// We don't preserve the truncation, because sending an altered
++		// header field opens a smuggling vector. Instead, zero out the
++		// Host header entirely if it isn't valid. (An empty Host is valid;
++		// see RFC 9112 Section 3.2.)
++		//
++		// Return an error if we're sending to a proxy, since the proxy
++		// probably can't do anything useful with an empty Host header.
++		if !usingProxy {
++			host = ""
++		} else {
++			return errors.New("http: invalid Host header")
++		}
+ 	}
+ 
+ 	// According to RFC 6874, an HTTP client, proxy, or other
+diff --git a/src/net/http/request_test.go b/src/net/http/request_test.go
+index 0d417ff..a52da84 100644
+--- a/src/net/http/request_test.go
++++ b/src/net/http/request_test.go
+@@ -668,16 +668,23 @@ func TestRequestWriteBufferedWriter(t *testing.T) {
+ 	}
+ }
+ 
+-func TestRequestBadHost(t *testing.T) {
++func TestRequestBadHostHeader(t *testing.T) {
+ 	got := []string{}
+ 	req, err := NewRequest("GET", "http://foo/after", nil)
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
+-	req.Host = "foo.com with spaces"
+-	req.URL.Host = "foo.com with spaces"
+-	if err := req.Write(logWrites{t, &got}); err == nil {
+-		t.Errorf("Writing request with invalid Host: succeded, want error")
++	req.Host = "foo.com\nnewline"
++	req.URL.Host = "foo.com\nnewline"
++	req.Write(logWrites{t, &got})
++	want := []string{
++		"GET /after HTTP/1.1\r\n",
++		"Host: \r\n",
++		"User-Agent: " + DefaultUserAgent + "\r\n",
++		"\r\n",
++	}
++	if !reflect.DeepEqual(got, want) {
++		t.Errorf("Writes = %q\n  Want = %q", got, want)
+ 	}
+ }
+ 
+-- 
+2.25.1
+

--- a/meta-mentor-staging/recipes-devtools/go/go-cross_1.14.bbappend
+++ b/meta-mentor-staging/recipes-devtools/go/go-cross_1.14.bbappend
@@ -1,0 +1,12 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2023 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+                   file://0001-net-http-permit-request-with-invalid-Host-headers.patch \
+"

--- a/meta-mentor-staging/recipes-devtools/go/go-native_1.14.bbappend
+++ b/meta-mentor-staging/recipes-devtools/go/go-native_1.14.bbappend
@@ -1,0 +1,12 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2023 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+                   file://0001-net-http-permit-request-with-invalid-Host-headers.patch \
+"

--- a/meta-mentor-staging/recipes-devtools/go/go-runtime_1.14.bbappend
+++ b/meta-mentor-staging/recipes-devtools/go/go-runtime_1.14.bbappend
@@ -1,0 +1,12 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2023 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+                   file://0001-net-http-permit-request-with-invalid-Host-headers.patch \
+"

--- a/meta-mentor-staging/recipes-devtools/go/go_1.14.bbappend
+++ b/meta-mentor-staging/recipes-devtools/go/go_1.14.bbappend
@@ -1,0 +1,12 @@
+# This material contains trade secrets or otherwise confidential information owned by Siemens Industry Software Inc.
+# or its affiliates (collectively, "Siemens"), or its licensors. Access to and use of this information is strictly limited
+# as set forth in the Customer's applicable agreements with Siemens.
+# ---------------------------------------------------------------------------------------------------------------------
+# Unpublished work. Copyright 2023 Siemens
+# ---------------------------------------------------------------------------------------------------------------------
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+                   file://0001-net-http-permit-request-with-invalid-Host-headers.patch \
+"


### PR DESCRIPTION
Faced issue while connecting to docker-container as got http: invalid host header so providing patch to fix this issue.

Issue occurs due to [CVE-2023](https://jira.alm.mentorg.com/browse/CVE-2023)-29406.patch in oe-core layer.

Ref: https://go-review.googlesource.com/c/go/+/511155/5/src/net/http/request.go

JIRA ID:  SB-22980

Signed-off-by: Ashish Jain <Ashish_Jain2@mentor.com>